### PR TITLE
Add K8s and cache fetch documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bazel build //designs/asap7/lfsr:lfsr_route
 
 ### RTL Regeneration (Bazel)
 
-By default, designs use pre-generated Verilog. To regenerate RTL from source repositories:
+By default, designs use pre-generated RTL checked into the repository. Some designs use Verilog converted from SystemVerilog via sv2v, while others (e.g., bp_processor) use SystemVerilog directly with the yosys-slang plugin. To regenerate RTL from source repositories:
 
 ```bash
 bazel build --define update_rtl=true //designs/asap7/lfsr:lfsr_final
@@ -83,6 +83,30 @@ Platform     Design                      Die Area  Core Area  Inst Area    Util%
 ================================================================================================================================================================
 asap7        lfsr                   81.7       47.0       21.8     46.4      205      0    13      56.91       0.00         5.78        0.381      0
 ```
+
+## Kubernetes (NRP Nautilus)
+
+Designs can be built at scale on the [NRP Nautilus](https://nationalresearchplatform.org/nautilus/) Kubernetes cluster. See [k8s/README.md](k8s/README.md) for full documentation on submitting jobs, monitoring, and managing builds.
+
+### Fetching Baseline Results
+
+HighTide generates baseline build results for all designs and stores them in a GCS remote cache. Users can fetch these baseline results locally without rebuilding:
+
+```bash
+# Fetch all cached designs
+./tools/fetch_cache.sh
+
+# Fetch all cached asap7 designs
+./tools/fetch_cache.sh asap7
+
+# Fetch a specific design
+./tools/fetch_cache.sh asap7 lfsr
+
+# Fetch only through a specific stage
+./tools/fetch_cache.sh --stage synth asap7
+```
+
+Each design reports whether it was fetched from the remote cache, found locally, or not cached. After fetching, view baseline results with `./tools/summary.sh`.
 
 ## Make Flow (legacy)
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,116 @@
+# Kubernetes Builds on NRP Nautilus
+
+HighTide uses the [National Research Platform (NRP) Nautilus](https://nationalresearchplatform.org/nautilus/) Kubernetes cluster to build designs at scale. Each design is submitted as a separate K8s Job, and build results are uploaded to a shared GCS remote cache.
+
+## Prerequisites
+
+- `kubectl` configured with access to the NRP Nautilus cluster
+- Namespace `vlsida` with the `gcs-bazel-cache` secret for cache uploads
+
+See the [NRP Nautilus documentation](https://docs.nrp-nautilus.io/) for cluster access and configuration.
+
+## Submitting Jobs
+
+Each invocation of `run.sh` creates one K8s Job per matching design. Jobs clone the HighTide repo, install Bazel, and run the full RTL-to-GDSII flow using bazel-orfs.
+
+```bash
+# Submit all designs, all platforms
+./k8s/run.sh
+
+# Submit all designs for a platform
+./k8s/run.sh asap7
+
+# Submit a single design
+./k8s/run.sh asap7 lfsr
+
+# Submit a design across all platforms
+./k8s/run.sh --design lfsr
+
+# Preview generated YAML without submitting
+./k8s/run.sh --dry-run asap7
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--branch BRANCH` | `main` | Git branch to build |
+| `--cpu NUM` | `8` | CPU request per job |
+| `--mem SIZE` | `64Gi` | Memory request per job (limit is 2x) |
+| `--dry-run` | | Print YAML without submitting |
+
+## Monitoring Jobs
+
+```bash
+# Show status of all HighTide jobs and pods
+./k8s/run.sh --status
+
+# Stream logs for a specific job
+kubectl logs -f job/hightide-asap7-lfsr -n vlsida
+```
+
+Job names follow the pattern `hightide-<platform>-<design>`, e.g., `hightide-asap7-lfsr`, `hightide-nangate45-bp-uno`.
+
+## Deleting Jobs
+
+Jobs can be deleted by platform, design, or both. Deletion uses Kubernetes label selectors on the `platform` and `design` labels attached to each job.
+
+```bash
+# Delete all HighTide jobs
+./k8s/run.sh --delete
+
+# Delete all jobs for a platform
+./k8s/run.sh --delete asap7
+
+# Delete a specific design on a platform
+./k8s/run.sh --delete asap7 lfsr
+
+# Delete a design across all platforms
+./k8s/run.sh --delete --design lfsr
+```
+
+## Remote Cache
+
+Jobs are configured with a GCS remote cache (`--remote_cache`). When the `gcs-bazel-cache` secret is present in the namespace, jobs upload build results after completion. This enables:
+
+1. **Faster rebuilds** — subsequent jobs for the same design hit the cache
+2. **Local fetching** — developers can pull baseline results without building locally
+
+### Fetching Baseline Results
+
+HighTide generates baseline build results for all designs. Users can fetch these locally using `tools/fetch_cache.sh`:
+
+```bash
+# Fetch all cached designs
+./tools/fetch_cache.sh
+
+# Fetch all cached designs for a platform
+./tools/fetch_cache.sh asap7
+
+# Fetch a specific design
+./tools/fetch_cache.sh asap7 lfsr
+
+# Fetch only through a specific stage (synth, floorplan, place, cts, route, final)
+./tools/fetch_cache.sh --stage synth asap7
+```
+
+The script uses `--local_cpu_resources=0` to prevent local builds — it only succeeds if results are available in the remote cache. Each design reports `OK (remote)`, `OK (local)`, or `NOT CACHED`.
+
+After fetching, view results with:
+
+```bash
+./tools/summary.sh
+```
+
+## Job Template
+
+The job template (`job-template.yaml`) defines the K8s Job spec. Each job:
+
+1. Clones the HighTide repo (init container using `alpine/git`)
+2. Installs dependencies (`curl`, `git`, `build-essential`, `python3`, `python3-yaml`, `python3-numpy`, `time`)
+3. Installs Bazelisk
+4. Runs `bazel build` with the remote cache flags
+
+The container uses `ubuntu:24.04` as a base image. ORFS tools are extracted from the Docker image by bazel-orfs at build time (via OCI layer extraction), matching the local build environment so that cache keys are compatible.
+
+Jobs have `backoffLimit: 1` (one retry on failure) and `ttlSecondsAfterFinished: 3600` (auto-cleanup after 1 hour).


### PR DESCRIPTION
## Summary
- Add Kubernetes section to README documenting k8s/run.sh for submitting, monitoring, and deleting jobs on NRP Nautilus
- Add detailed k8s/README.md with full K8s documentation
- Document tools/fetch_cache.sh for fetching baseline build results from the GCS remote cache
- Fix RTL regeneration documentation to mention SystemVerilog/yosys-slang and sv2v

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Confirm documented commands match current k8s/run.sh and tools/fetch_cache.sh behavior