### PR TITLE
Add K8s artifact upload/fetch/delete tools for debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ objects
 sv2v
 **/dev/liteeth_builds
 bazel-*
+artifacts/
 MODULE.bazel.lock
 .bazelrc.user
 google-cloud-sdk/

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -37,6 +37,7 @@ Each invocation of `run.sh` creates one K8s Job per matching design. Jobs clone 
 | `--branch BRANCH` | `main` | Git branch to build |
 | `--cpu NUM` | `8` | CPU request per job |
 | `--mem SIZE` | `64Gi` | Memory request per job (limit is 2x) |
+| `--upload-artifacts` | off | Upload `bazel-bin` artifacts to GCS for debug (see below) |
 | `--dry-run` | | Print YAML without submitting |
 
 ## Monitoring Jobs
@@ -101,6 +102,53 @@ After fetching, view results with:
 ```bash
 ./tools/summary.sh
 ```
+
+## Build Artifacts (Debug)
+
+For debugging individual builds, K8s jobs can upload their full `bazel-bin/<design>/` outputs (results, reports, logs) as a tarball to a separate GCS prefix. Use `--upload-artifacts` when submitting:
+
+```bash
+./k8s/run.sh --upload-artifacts asap7 lfsr
+```
+
+Tarballs are stored at `gs://hightide-bazel-cache/artifacts/designs/<platform>/<design>/build.tar.gz`.
+
+### Fetching Artifacts
+
+`tools/fetch_artifacts.sh` downloads and extracts artifacts to a local `artifacts/` directory. By default, the GCS tarball is **deleted** after a successful fetch (use `--keep` to preserve it).
+
+```bash
+# Fetch all available artifacts
+./tools/fetch_artifacts.sh
+
+# Fetch artifacts for a specific design
+./tools/fetch_artifacts.sh asap7 lfsr
+
+# Fetch and keep the tarball in GCS
+./tools/fetch_artifacts.sh --keep asap7 lfsr
+
+# Fetch to a custom directory
+./tools/fetch_artifacts.sh --output-dir debug asap7 lfsr
+```
+
+After fetching, the artifacts are at `artifacts/<platform>/<design>/` (containing `results/`, `reports/`, `logs/`).
+
+### Deleting Artifacts
+
+`tools/delete_artifacts.sh` removes artifact tarballs from GCS without fetching them. It prompts for confirmation by default (skip with `--yes`).
+
+```bash
+# Delete artifacts for a specific design
+./tools/delete_artifacts.sh asap7 lfsr
+
+# Delete all artifacts on a platform
+./tools/delete_artifacts.sh asap7
+
+# Delete all artifacts without confirmation
+./tools/delete_artifacts.sh --yes
+```
+
+Both fetch and delete tools require `gsutil` or `gcloud` to be installed and authenticated locally.
 
 ## Job Template
 

--- a/k8s/job-template.yaml
+++ b/k8s/job-template.yaml
@@ -54,6 +54,40 @@ spec:
           fi
 
           bazel build $CACHE_FLAGS __BAZEL_TARGET__
+
+          # Upload build artifacts to GCS for debug retrieval (when enabled)
+          if [ "__UPLOAD_ARTIFACTS__" = "true" ]; then
+            if [ -f /secrets/gcs/key.json ]; then
+              echo "Uploading build artifacts to GCS..."
+
+              # Install gcloud CLI for storage upload
+              curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts >/dev/null 2>&1
+              export PATH="$HOME/google-cloud-sdk/bin:$PATH"
+              gcloud auth activate-service-account --key-file=/secrets/gcs/key.json --quiet 2>&1
+
+              # Extract design path from bazel target //designs/<platform>/<design>:<name>
+              TARGET="__BAZEL_TARGET__"
+              DESIGN_PATH="${TARGET#//}"
+              DESIGN_PATH="${DESIGN_PATH%%:*}"
+
+              ARTIFACT_DIR="bazel-bin/${DESIGN_PATH}"
+              if [ -d "$ARTIFACT_DIR" ]; then
+                TARBALL="/tmp/__JOB_NAME__.tar.gz"
+                # Resolve symlinks since bazel-bin is a symlink to bazel-out
+                tar czhf "$TARBALL" \
+                    --exclude='*.runfiles' \
+                    --exclude='*.runfiles_manifest' \
+                    -C bazel-bin "${DESIGN_PATH}"
+                echo "Tarball size: $(du -h $TARBALL | cut -f1)"
+                gcloud storage cp "$TARBALL" "gs://hightide-bazel-cache/artifacts/${DESIGN_PATH}/build.tar.gz"
+                echo "Uploaded to gs://hightide-bazel-cache/artifacts/${DESIGN_PATH}/build.tar.gz"
+              else
+                echo "WARNING: artifact directory $ARTIFACT_DIR not found"
+              fi
+            else
+              echo "WARNING: artifact upload requested but GCS credentials not found"
+            fi
+          fi
         volumeMounts:
         - name: repo
           mountPath: /repo

--- a/k8s/run.sh
+++ b/k8s/run.sh
@@ -13,12 +13,13 @@
 #   ./k8s/run.sh --delete --design lfsr # delete lfsr across all platforms
 #
 # Options:
-#   --branch BRANCH   Git branch to build (default: current branch)
-#   --cpu NUM         CPU request per job (default: 8)
-#   --mem SIZE        Memory request per job (default: 32Gi)
-#   --dry-run         Print generated YAML without submitting
-#   --status          Show status of submitted jobs
-#   --delete          Delete jobs (filtered by platform/design args)
+#   --branch BRANCH    Git branch to build (default: current branch)
+#   --cpu NUM          CPU request per job (default: 8)
+#   --mem SIZE         Memory request per job (default: 64Gi)
+#   --upload-artifacts Upload build artifacts (bazel-bin) to GCS for debug
+#   --dry-run          Print generated YAML without submitting
+#   --status           Show status of submitted jobs
+#   --delete           Delete jobs (filtered by platform/design args)
 
 set -euo pipefail
 
@@ -35,6 +36,7 @@ MEM_REQUEST="64Gi"
 MEM_LIMIT="128Gi"
 DRY_RUN=false
 MODE="submit"
+UPLOAD_ARTIFACTS="false"
 FILTER_PLATFORM=""
 FILTER_DESIGN=""
 
@@ -44,6 +46,7 @@ while [[ $# -gt 0 ]]; do
         --branch)   BRANCH="$2"; shift 2 ;;
         --cpu)      CPU_REQUEST="$2"; CPU_LIMIT="$((${2} * 2))"; shift 2 ;;
         --mem)      MEM_REQUEST="$2"; MEM_LIMIT="${2%Gi}"; MEM_LIMIT="$((MEM_LIMIT * 2))Gi"; shift 2 ;;
+        --upload-artifacts) UPLOAD_ARTIFACTS=true; shift ;;
         --dry-run)  DRY_RUN=true; shift ;;
         --status)   MODE="status"; shift ;;
         --delete)   MODE="delete"; shift ;;
@@ -162,6 +165,7 @@ for entry in "${DESIGNS[@]}"; do
         -e "s|__JOB_NAME__|${job_name}|g" \
         -e "s|__BRANCH__|${BRANCH}|g" \
         -e "s|__BAZEL_TARGET__|${target}|g" \
+        -e "s|__UPLOAD_ARTIFACTS__|${UPLOAD_ARTIFACTS}|g" \
         -e "s|__CPU_REQUEST__|${CPU_REQUEST}|g" \
         -e "s|__CPU_LIMIT__|${CPU_LIMIT}|g" \
         -e "s|__MEM_REQUEST__|${MEM_REQUEST}|g" \

--- a/tools/delete_artifacts.sh
+++ b/tools/delete_artifacts.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Delete build artifacts uploaded by K8s jobs from GCS.
+# Removes tarballs at gs://hightide-bazel-cache/artifacts/<platform>/<design>/build.tar.gz
+#
+# Usage:
+#   ./tools/delete_artifacts.sh                      # all designs
+#   ./tools/delete_artifacts.sh asap7                # all asap7 designs
+#   ./tools/delete_artifacts.sh asap7 lfsr           # specific design
+#   ./tools/delete_artifacts.sh --design lfsr        # one design, all platforms
+#
+# Options:
+#   --yes  Skip confirmation prompt
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+GCS_BUCKET="gs://hightide-bazel-cache/artifacts"
+SKIP_CONFIRM=false
+FILTER_PLATFORM=""
+FILTER_DESIGN=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --yes)    SKIP_CONFIRM=true; shift ;;
+        --design) FILTER_DESIGN="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,/^$/s/^# //p' "$0"
+            exit 0
+            ;;
+        *)
+            if [[ -z "$FILTER_PLATFORM" ]]; then
+                FILTER_PLATFORM="$1"
+            elif [[ -z "$FILTER_DESIGN" ]]; then
+                FILTER_DESIGN="$1"
+            else
+                echo "ERROR: unexpected argument: $1" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Check for gsutil/gcloud
+if ! command -v gsutil >/dev/null 2>&1 && ! command -v gcloud >/dev/null 2>&1; then
+    echo "ERROR: gsutil or gcloud must be installed and authenticated" >&2
+    exit 1
+fi
+
+GS_CMD="gsutil"
+command -v gsutil >/dev/null 2>&1 || GS_CMD="gcloud storage"
+
+# Discover designs
+TARGETS=()
+for build_file in designs/*/BUILD.bazel \
+                  designs/*/*/BUILD.bazel \
+                  designs/*/*/*/BUILD.bazel; do
+    [[ -f "$build_file" ]] || continue
+    grep -q 'hightide_design(' "$build_file" || continue
+
+    dir=$(dirname "$build_file")
+    name=$(grep -A1 'hightide_design(' "$build_file" | grep -oP 'name\s*=\s*"\K[^"]+')
+    [[ -z "$name" ]] && continue
+
+    relpath="${dir#designs/}"
+    platform="${relpath%%/*}"
+    leaf="${relpath##*/}"
+
+    if [[ -n "$FILTER_PLATFORM" && "$platform" != "$FILTER_PLATFORM" ]]; then
+        continue
+    fi
+    if [[ -n "$FILTER_DESIGN" ]]; then
+        if [[ "$name" != "$FILTER_DESIGN" && "$leaf" != *"$FILTER_DESIGN"* && "$relpath" != *"$FILTER_DESIGN"* ]]; then
+            continue
+        fi
+    fi
+
+    TARGETS+=("$platform|$leaf|$relpath")
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+    echo "No designs matched the given filters."
+    exit 1
+fi
+
+echo "Will delete artifacts for ${#TARGETS[@]} design(s):"
+for entry in "${TARGETS[@]}"; do
+    IFS='|' read -r platform leaf relpath <<< "$entry"
+    echo "  $platform/$leaf"
+done
+echo ""
+
+if [[ "$SKIP_CONFIRM" != "true" ]]; then
+    read -p "Proceed? [y/N] " confirm
+    if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+PASS=0
+FAIL=0
+
+for entry in "${TARGETS[@]}"; do
+    IFS='|' read -r platform leaf relpath <<< "$entry"
+    printf "  %-12s %-30s " "$platform" "$leaf"
+
+    GCS_PATH="$GCS_BUCKET/designs/$relpath/build.tar.gz"
+    if $GS_CMD rm "$GCS_PATH" 2>/dev/null; then
+        echo "DELETED"
+        ((PASS++))
+    else
+        echo "NOT FOUND"
+        ((FAIL++))
+    fi
+done
+
+echo ""
+echo "Deleted: $PASS  Not found: $FAIL"

--- a/tools/fetch_artifacts.sh
+++ b/tools/fetch_artifacts.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Fetch build artifacts uploaded by K8s jobs from GCS.
+# Artifacts are uploaded to gs://hightide-bazel-cache/artifacts/<platform>/<design>/build.tar.gz
+# when jobs are submitted with `./k8s/run.sh --upload-artifacts ...`.
+#
+# Usage:
+#   ./tools/fetch_artifacts.sh                      # all designs
+#   ./tools/fetch_artifacts.sh asap7                # all asap7 designs
+#   ./tools/fetch_artifacts.sh asap7 lfsr           # specific design
+#   ./tools/fetch_artifacts.sh --design lfsr        # one design, all platforms
+#
+# Options:
+#   --output-dir DIR  Where to extract tarballs (default: artifacts/)
+#   --keep            Keep artifacts in GCS after fetching (default: delete)
+
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+GCS_BUCKET="gs://hightide-bazel-cache/artifacts"
+OUTPUT_DIR="artifacts"
+KEEP_REMOTE=false
+FILTER_PLATFORM=""
+FILTER_DESIGN=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        --keep)       KEEP_REMOTE=true; shift ;;
+        --design)     FILTER_DESIGN="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,/^$/s/^# //p' "$0"
+            exit 0
+            ;;
+        *)
+            if [[ -z "$FILTER_PLATFORM" ]]; then
+                FILTER_PLATFORM="$1"
+            elif [[ -z "$FILTER_DESIGN" ]]; then
+                FILTER_DESIGN="$1"
+            else
+                echo "ERROR: unexpected argument: $1" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Check for gsutil/gcloud
+if ! command -v gsutil >/dev/null 2>&1 && ! command -v gcloud >/dev/null 2>&1; then
+    echo "ERROR: gsutil or gcloud must be installed and authenticated" >&2
+    exit 1
+fi
+
+GS_CMD="gsutil"
+command -v gsutil >/dev/null 2>&1 || GS_CMD="gcloud storage"
+
+# Discover designs (same logic as fetch_cache.sh)
+TARGETS=()
+for build_file in designs/*/BUILD.bazel \
+                  designs/*/*/BUILD.bazel \
+                  designs/*/*/*/BUILD.bazel; do
+    [[ -f "$build_file" ]] || continue
+    grep -q 'hightide_design(' "$build_file" || continue
+
+    dir=$(dirname "$build_file")
+    name=$(grep -A1 'hightide_design(' "$build_file" | grep -oP 'name\s*=\s*"\K[^"]+')
+    [[ -z "$name" ]] && continue
+
+    relpath="${dir#designs/}"
+    platform="${relpath%%/*}"
+    leaf="${relpath##*/}"
+
+    if [[ -n "$FILTER_PLATFORM" && "$platform" != "$FILTER_PLATFORM" ]]; then
+        continue
+    fi
+    if [[ -n "$FILTER_DESIGN" ]]; then
+        if [[ "$name" != "$FILTER_DESIGN" && "$leaf" != *"$FILTER_DESIGN"* && "$relpath" != *"$FILTER_DESIGN"* ]]; then
+            continue
+        fi
+    fi
+
+    TARGETS+=("$platform|$leaf|$relpath")
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+    echo "No designs matched the given filters."
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+echo "Fetching artifacts to $OUTPUT_DIR/"
+echo ""
+
+PASS=0
+FAIL=0
+
+for entry in "${TARGETS[@]}"; do
+    IFS='|' read -r platform leaf relpath <<< "$entry"
+    printf "  %-12s %-30s " "$platform" "$leaf"
+
+    GCS_PATH="$GCS_BUCKET/designs/$relpath/build.tar.gz"
+    LOCAL_DIR="$OUTPUT_DIR/$relpath"
+    LOCAL_TAR="$LOCAL_DIR/build.tar.gz"
+
+    mkdir -p "$LOCAL_DIR"
+    # Strip "designs/<relpath>/" prefix from tarball (1 + number of slashes in relpath)
+    STRIP=$(($(echo "$relpath" | tr -cd / | wc -c) + 2))
+    if $GS_CMD cp "$GCS_PATH" "$LOCAL_TAR" 2>/dev/null; then
+        tar xzf "$LOCAL_TAR" -C "$LOCAL_DIR" --strip-components=$STRIP 2>/dev/null
+        if [[ "$KEEP_REMOTE" != "true" ]]; then
+            $GS_CMD rm "$GCS_PATH" 2>/dev/null && echo "OK (deleted remote)" || echo "OK"
+        else
+            echo "OK"
+        fi
+        ((PASS++))
+    else
+        echo "NOT FOUND"
+        ((FAIL++))
+    fi
+done
+
+echo ""
+echo "Fetched: $PASS  Not found: $FAIL"

--- a/tools/fetch_cache.sh
+++ b/tools/fetch_cache.sh
@@ -67,13 +67,14 @@ for build_file in designs/*/BUILD.bazel \
         continue
     fi
     if [[ -n "$FILTER_DESIGN" ]]; then
-        design_dir="${relpath#*/}"
-        if [[ "$name" != "$FILTER_DESIGN" && "$design_dir" != *"$FILTER_DESIGN"* ]]; then
+        leaf="${relpath##*/}"
+        if [[ "$name" != "$FILTER_DESIGN" && "$leaf" != *"$FILTER_DESIGN"* && "$relpath" != *"$FILTER_DESIGN"* ]]; then
             continue
         fi
     fi
 
-    TARGETS+=("$platform|$name|//designs/$relpath:${name}_${STAGE}")
+    leaf_name="${relpath##*/}"
+    TARGETS+=("$platform|$leaf_name|//designs/$relpath:${name}_${STAGE}")
 done
 
 if [[ ${#TARGETS[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Add \`--upload-artifacts\` flag to \`k8s/run.sh\` that tars \`bazel-bin/<design>/\` outputs and uploads to a separate \`gs://hightide-bazel-cache/artifacts/\` prefix using gcloud
- Add \`tools/fetch_artifacts.sh\` to download and extract artifact tarballs locally; deletes the GCS tarball by default after a successful fetch (\`--keep\` to preserve)
- Add \`tools/delete_artifacts.sh\` to remove artifact tarballs from GCS without fetching, with confirmation prompt (\`--yes\` to skip)
- Document the new debug workflow in \`k8s/README.md\`

## Test plan
- [x] Submit \`./k8s/run.sh --upload-artifacts asap7 lfsr\`, verify upload succeeds
- [x] Run \`./tools/fetch_artifacts.sh asap7 lfsr\`, verify extraction and remote deletion
- [x] Verify extracted files include results/reports/logs at the expected paths