### PR TITLE
Use gcloud storage rsync for K8s artifact upload/fetch/delete

### DIFF
--- a/k8s/job-template.yaml
+++ b/k8s/job-template.yaml
@@ -53,6 +53,12 @@ spec:
             echo "WARNING: GCS credentials not found, cache is read-only"
           fi
 
+          # When uploading artifacts, force download of all intermediate
+          # outputs (logs, reports, results) so we capture them on cache hits.
+          if [ "__UPLOAD_ARTIFACTS__" = "true" ]; then
+            CACHE_FLAGS="$CACHE_FLAGS --remote_download_outputs=all"
+          fi
+
           bazel build $CACHE_FLAGS __BAZEL_TARGET__
 
           # Upload build artifacts to GCS for debug retrieval (when enabled)
@@ -60,7 +66,7 @@ spec:
             if [ -f /secrets/gcs/key.json ]; then
               echo "Uploading build artifacts to GCS..."
 
-              # Install gcloud CLI for storage upload
+              # Install gcloud CLI for storage rsync
               curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts >/dev/null 2>&1
               export PATH="$HOME/google-cloud-sdk/bin:$PATH"
               gcloud auth activate-service-account --key-file=/secrets/gcs/key.json --quiet 2>&1
@@ -72,15 +78,12 @@ spec:
 
               ARTIFACT_DIR="bazel-bin/${DESIGN_PATH}"
               if [ -d "$ARTIFACT_DIR" ]; then
-                TARBALL="/tmp/__JOB_NAME__.tar.gz"
-                # Resolve symlinks since bazel-bin is a symlink to bazel-out
-                tar czhf "$TARBALL" \
-                    --exclude='*.runfiles' \
-                    --exclude='*.runfiles_manifest' \
-                    -C bazel-bin "${DESIGN_PATH}"
-                echo "Tarball size: $(du -h $TARBALL | cut -f1)"
-                gcloud storage cp "$TARBALL" "gs://hightide-bazel-cache/artifacts/${DESIGN_PATH}/build.tar.gz"
-                echo "Uploaded to gs://hightide-bazel-cache/artifacts/${DESIGN_PATH}/build.tar.gz"
+                # Sync the artifact directory to GCS, resolving symlinks
+                # (bazel-bin is a symlink tree to bazel-out)
+                REAL_DIR=$(readlink -f "$ARTIFACT_DIR")
+                gcloud storage rsync --recursive --delete-unmatched-destination-objects \
+                  "$REAL_DIR" "gs://hightide-bazel-cache/artifacts/${DESIGN_PATH}"
+                echo "Synced to gs://hightide-bazel-cache/artifacts/${DESIGN_PATH}/"
               else
                 echo "WARNING: artifact directory $ARTIFACT_DIR not found"
               fi

--- a/tools/delete_artifacts.sh
+++ b/tools/delete_artifacts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Delete build artifacts uploaded by K8s jobs from GCS.
-# Removes tarballs at gs://hightide-bazel-cache/artifacts/<platform>/<design>/build.tar.gz
+# Removes objects under gs://hightide-bazel-cache/artifacts/designs/<platform>/<design>/
 #
 # Usage:
 #   ./tools/delete_artifacts.sh                      # all designs
@@ -43,14 +43,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Check for gsutil/gcloud
-if ! command -v gsutil >/dev/null 2>&1 && ! command -v gcloud >/dev/null 2>&1; then
-    echo "ERROR: gsutil or gcloud must be installed and authenticated" >&2
+if ! command -v gcloud >/dev/null 2>&1; then
+    echo "ERROR: gcloud must be installed and authenticated" >&2
     exit 1
 fi
-
-GS_CMD="gsutil"
-command -v gsutil >/dev/null 2>&1 || GS_CMD="gcloud storage"
 
 # Discover designs
 TARGETS=()
@@ -107,8 +103,8 @@ for entry in "${TARGETS[@]}"; do
     IFS='|' read -r platform leaf relpath <<< "$entry"
     printf "  %-12s %-30s " "$platform" "$leaf"
 
-    GCS_PATH="$GCS_BUCKET/designs/$relpath/build.tar.gz"
-    if $GS_CMD rm "$GCS_PATH" 2>/dev/null; then
+    GCS_PATH="$GCS_BUCKET/designs/$relpath"
+    if gcloud storage rm --recursive "$GCS_PATH" >/dev/null 2>&1; then
         echo "DELETED"
         ((PASS++))
     else

--- a/tools/fetch_artifacts.sh
+++ b/tools/fetch_artifacts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Fetch build artifacts uploaded by K8s jobs from GCS.
-# Artifacts are uploaded to gs://hightide-bazel-cache/artifacts/<platform>/<design>/build.tar.gz
+# Artifacts are synced to gs://hightide-bazel-cache/artifacts/designs/<platform>/<design>/
 # when jobs are submitted with `./k8s/run.sh --upload-artifacts ...`.
 #
 # Usage:
@@ -10,7 +10,7 @@
 #   ./tools/fetch_artifacts.sh --design lfsr        # one design, all platforms
 #
 # Options:
-#   --output-dir DIR  Where to extract tarballs (default: artifacts/)
+#   --output-dir DIR  Where to sync artifacts (default: artifacts/)
 #   --keep            Keep artifacts in GCS after fetching (default: delete)
 
 set -uo pipefail
@@ -47,16 +47,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Check for gsutil/gcloud
-if ! command -v gsutil >/dev/null 2>&1 && ! command -v gcloud >/dev/null 2>&1; then
-    echo "ERROR: gsutil or gcloud must be installed and authenticated" >&2
+if ! command -v gcloud >/dev/null 2>&1; then
+    echo "ERROR: gcloud must be installed and authenticated" >&2
     exit 1
 fi
 
-GS_CMD="gsutil"
-command -v gsutil >/dev/null 2>&1 || GS_CMD="gcloud storage"
-
-# Discover designs (same logic as fetch_cache.sh)
+# Discover designs
 TARGETS=()
 for build_file in designs/*/BUILD.bazel \
                   designs/*/*/BUILD.bazel \
@@ -90,7 +86,7 @@ if [[ ${#TARGETS[@]} -eq 0 ]]; then
 fi
 
 mkdir -p "$OUTPUT_DIR"
-echo "Fetching artifacts to $OUTPUT_DIR/"
+echo "Syncing artifacts to $OUTPUT_DIR/"
 echo ""
 
 PASS=0
@@ -100,26 +96,30 @@ for entry in "${TARGETS[@]}"; do
     IFS='|' read -r platform leaf relpath <<< "$entry"
     printf "  %-12s %-30s " "$platform" "$leaf"
 
-    GCS_PATH="$GCS_BUCKET/designs/$relpath/build.tar.gz"
+    GCS_PATH="$GCS_BUCKET/designs/$relpath"
     LOCAL_DIR="$OUTPUT_DIR/$relpath"
-    LOCAL_TAR="$LOCAL_DIR/build.tar.gz"
+
+    # Check if remote path has any objects before attempting rsync
+    if ! gcloud storage ls "$GCS_PATH/**" >/dev/null 2>&1; then
+        echo "NOT FOUND"
+        ((FAIL++))
+        continue
+    fi
 
     mkdir -p "$LOCAL_DIR"
-    # Strip "designs/<relpath>/" prefix from tarball (1 + number of slashes in relpath)
-    STRIP=$(($(echo "$relpath" | tr -cd / | wc -c) + 2))
-    if $GS_CMD cp "$GCS_PATH" "$LOCAL_TAR" 2>/dev/null; then
-        tar xzf "$LOCAL_TAR" -C "$LOCAL_DIR" --strip-components=$STRIP 2>/dev/null
+    if gcloud storage rsync --recursive "$GCS_PATH" "$LOCAL_DIR" >/dev/null 2>&1; then
         if [[ "$KEEP_REMOTE" != "true" ]]; then
-            $GS_CMD rm "$GCS_PATH" 2>/dev/null && echo "OK (deleted remote)" || echo "OK"
+            gcloud storage rm --recursive "$GCS_PATH" >/dev/null 2>&1 \
+                && echo "OK (deleted remote)" || echo "OK"
         else
             echo "OK"
         fi
         ((PASS++))
     else
-        echo "NOT FOUND"
+        echo "FAILED"
         ((FAIL++))
     fi
 done
 
 echo ""
-echo "Fetched: $PASS  Not found: $FAIL"
+echo "Fetched: $PASS  Not found/failed: $FAIL"


### PR DESCRIPTION
## Summary
- Replace tar+\`gcloud storage cp\` with \`gcloud storage rsync\` for direct directory sync to/from GCS, eliminating the tarball step
- Add \`--remote_download_outputs=all\` to bazel build in K8s jobs when \`--upload-artifacts\` is enabled, so all intermediate stage outputs (logs, reports, results) are captured even on cache hits
- Update fetch_artifacts.sh and delete_artifacts.sh to use \`gcloud storage\` instead of \`gsutil\`

## Test plan
- [x] Submit \`./k8s/run.sh --upload-artifacts asap7 lfsr\`, verify rsync upload succeeds
- [x] Run \`./tools/fetch_artifacts.sh asap7 lfsr\`, verify all 76 files (including per-stage logs) are fetched