### PR TITLE
Use Nautilus PVC for artifact storage instead of GCS

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -105,17 +105,17 @@ After fetching, view results with:
 
 ## Build Artifacts (Debug)
 
-For debugging individual builds, K8s jobs can upload their full `bazel-bin/<design>/` outputs (results, reports, logs) as a tarball to a separate GCS prefix. Use `--upload-artifacts` when submitting:
+For debugging individual builds, K8s jobs can save their full `bazel-bin/<design>/` outputs (results, reports, logs) to persistent storage on Nautilus. Use `--upload-artifacts` when submitting:
 
 ```bash
 ./k8s/run.sh --upload-artifacts asap7 lfsr
 ```
 
-Tarballs are stored at `gs://hightide-bazel-cache/artifacts/designs/<platform>/<design>/build.tar.gz`.
+Artifacts are stored on the `hightide-artifacts` PVC (CephFS, ReadWriteMany) at `/artifacts/designs/<platform>/<design>/`. When `--upload-artifacts` is enabled, `--remote_download_outputs=all` is also set to ensure all intermediate stage outputs are fetched from the cache, not just the final stage.
 
 ### Fetching Artifacts
 
-`tools/fetch_artifacts.sh` downloads and extracts artifacts to a local `artifacts/` directory. By default, the GCS tarball is **deleted** after a successful fetch (use `--keep` to preserve it).
+`tools/fetch_artifacts.sh` copies artifacts from the PVC to a local `artifacts/` directory via a temporary pod. By default, artifacts are **deleted** from the PVC after a successful fetch (use `--keep` to preserve them).
 
 ```bash
 # Fetch all available artifacts
@@ -124,7 +124,7 @@ Tarballs are stored at `gs://hightide-bazel-cache/artifacts/designs/<platform>/<
 # Fetch artifacts for a specific design
 ./tools/fetch_artifacts.sh asap7 lfsr
 
-# Fetch and keep the tarball in GCS
+# Fetch and keep artifacts on the PVC
 ./tools/fetch_artifacts.sh --keep asap7 lfsr
 
 # Fetch to a custom directory
@@ -135,7 +135,7 @@ After fetching, the artifacts are at `artifacts/<platform>/<design>/` (containin
 
 ### Deleting Artifacts
 
-`tools/delete_artifacts.sh` removes artifact tarballs from GCS without fetching them. It prompts for confirmation by default (skip with `--yes`).
+`tools/delete_artifacts.sh` removes artifacts from the PVC without fetching them. It prompts for confirmation by default (skip with `--yes`).
 
 ```bash
 # Delete artifacts for a specific design
@@ -148,7 +148,7 @@ After fetching, the artifacts are at `artifacts/<platform>/<design>/` (containin
 ./tools/delete_artifacts.sh --yes
 ```
 
-Both fetch and delete tools require `gsutil` or `gcloud` to be installed and authenticated locally.
+Both fetch and delete tools require `kubectl` access to the Nautilus cluster.
 
 ## Job Template
 
@@ -158,7 +158,16 @@ The job template (`job-template.yaml`) defines the K8s Job spec. Each job:
 2. Installs dependencies (`curl`, `git`, `build-essential`, `python3`, `python3-yaml`, `python3-numpy`, `time`)
 3. Installs Bazelisk
 4. Runs `bazel build` with the remote cache flags
+5. Optionally copies artifacts to the `hightide-artifacts` PVC
 
 The container uses `ubuntu:24.04` as a base image. ORFS tools are extracted from the Docker image by bazel-orfs at build time (via OCI layer extraction), matching the local build environment so that cache keys are compatible.
 
 Jobs have `backoffLimit: 1` (one retry on failure) and `ttlSecondsAfterFinished: 3600` (auto-cleanup after 1 hour).
+
+### Volumes
+
+| Volume | Type | Purpose |
+|--------|------|---------|
+| `repo` | emptyDir | Cloned repo (ephemeral) |
+| `gcs-key` | Secret (`gcs-bazel-cache`, optional) | GCS credentials for remote cache |
+| `artifacts` | PVC (`hightide-artifacts`) | Persistent artifact storage for debug |

--- a/k8s/job-template.yaml
+++ b/k8s/job-template.yaml
@@ -61,34 +61,28 @@ spec:
 
           bazel build $CACHE_FLAGS __BAZEL_TARGET__
 
-          # Upload build artifacts to GCS for debug retrieval (when enabled)
+          # Copy build artifacts to persistent storage (when enabled)
           if [ "__UPLOAD_ARTIFACTS__" = "true" ]; then
-            if [ -f /secrets/gcs/key.json ]; then
-              echo "Uploading build artifacts to GCS..."
+            # Extract design path from bazel target //designs/<platform>/<design>:<name>
+            TARGET="__BAZEL_TARGET__"
+            DESIGN_PATH="${TARGET#//}"
+            DESIGN_PATH="${DESIGN_PATH%%:*}"
 
-              # Install gcloud CLI for storage rsync
-              curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts >/dev/null 2>&1
-              export PATH="$HOME/google-cloud-sdk/bin:$PATH"
-              gcloud auth activate-service-account --key-file=/secrets/gcs/key.json --quiet 2>&1
-
-              # Extract design path from bazel target //designs/<platform>/<design>:<name>
-              TARGET="__BAZEL_TARGET__"
-              DESIGN_PATH="${TARGET#//}"
-              DESIGN_PATH="${DESIGN_PATH%%:*}"
-
-              ARTIFACT_DIR="bazel-bin/${DESIGN_PATH}"
-              if [ -d "$ARTIFACT_DIR" ]; then
-                # Sync the artifact directory to GCS, resolving symlinks
-                # (bazel-bin is a symlink tree to bazel-out)
-                REAL_DIR=$(readlink -f "$ARTIFACT_DIR")
-                gcloud storage rsync --recursive --delete-unmatched-destination-objects \
-                  "$REAL_DIR" "gs://hightide-bazel-cache/artifacts/${DESIGN_PATH}"
-                echo "Synced to gs://hightide-bazel-cache/artifacts/${DESIGN_PATH}/"
-              else
-                echo "WARNING: artifact directory $ARTIFACT_DIR not found"
-              fi
+            ARTIFACT_DIR="bazel-bin/${DESIGN_PATH}"
+            if [ -d "$ARTIFACT_DIR" ]; then
+              DEST="/artifacts/${DESIGN_PATH}"
+              echo "Copying build artifacts to $DEST..."
+              rm -rf "$DEST"
+              mkdir -p "$DEST"
+              # Resolve symlinks (bazel-bin is a symlink tree to bazel-out)
+              cp -rL "$ARTIFACT_DIR"/* "$DEST/" 2>/dev/null || true
+              # Remove runfiles (not useful for debug)
+              find "$DEST" -name '*.runfiles' -type d -exec rm -rf {} + 2>/dev/null || true
+              find "$DEST" -name '*.runfiles_manifest' -delete 2>/dev/null || true
+              echo "Artifacts saved to $DEST/"
+              du -sh "$DEST"
             else
-              echo "WARNING: artifact upload requested but GCS credentials not found"
+              echo "WARNING: artifact directory $ARTIFACT_DIR not found"
             fi
           fi
         volumeMounts:
@@ -97,6 +91,8 @@ spec:
         - name: gcs-key
           mountPath: /secrets/gcs
           readOnly: true
+        - name: artifacts
+          mountPath: /artifacts
         resources:
           requests:
             memory: __MEM_REQUEST__
@@ -111,4 +107,7 @@ spec:
         secret:
           secretName: gcs-bazel-cache
           optional: true
+      - name: artifacts
+        persistentVolumeClaim:
+          claimName: hightide-artifacts
       restartPolicy: Never

--- a/tools/delete_artifacts.sh
+++ b/tools/delete_artifacts.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# Delete build artifacts uploaded by K8s jobs from GCS.
-# Removes objects under gs://hightide-bazel-cache/artifacts/designs/<platform>/<design>/
+# Delete build artifacts from the hightide-artifacts PVC on Nautilus NRP.
 #
 # Usage:
 #   ./tools/delete_artifacts.sh                      # all designs
@@ -16,7 +15,8 @@ set -uo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
 
-GCS_BUCKET="gs://hightide-bazel-cache/artifacts"
+NAMESPACE="vlsida"
+PVC_NAME="hightide-artifacts"
 SKIP_CONFIRM=false
 FILTER_PLATFORM=""
 FILTER_DESIGN=""
@@ -42,11 +42,6 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-
-if ! command -v gcloud >/dev/null 2>&1; then
-    echo "ERROR: gcloud must be installed and authenticated" >&2
-    exit 1
-fi
 
 # Discover designs
 TARGETS=()
@@ -96,6 +91,41 @@ if [[ "$SKIP_CONFIRM" != "true" ]]; then
     fi
 fi
 
+# Start a temporary pod to access the PVC
+POD_NAME="hightide-delete-$$"
+echo "Starting temporary pod to access PVC..."
+kubectl run "$POD_NAME" -n "$NAMESPACE" \
+    --image=alpine \
+    --restart=Never \
+    --overrides='{
+      "spec": {
+        "containers": [{
+          "name": "delete",
+          "image": "alpine",
+          "command": ["sleep", "3600"],
+          "volumeMounts": [{
+            "name": "artifacts",
+            "mountPath": "/artifacts"
+          }]
+        }],
+        "volumes": [{
+          "name": "artifacts",
+          "persistentVolumeClaim": {
+            "claimName": "'"$PVC_NAME"'"
+          }
+        }]
+      }
+    }' >/dev/null 2>&1
+
+echo "Waiting for pod..."
+kubectl wait --for=condition=Ready pod/"$POD_NAME" -n "$NAMESPACE" --timeout=60s >/dev/null 2>&1
+
+cleanup() {
+    echo "Cleaning up temporary pod..."
+    kubectl delete pod "$POD_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+}
+trap cleanup EXIT
+
 PASS=0
 FAIL=0
 
@@ -103,8 +133,8 @@ for entry in "${TARGETS[@]}"; do
     IFS='|' read -r platform leaf relpath <<< "$entry"
     printf "  %-12s %-30s " "$platform" "$leaf"
 
-    GCS_PATH="$GCS_BUCKET/designs/$relpath"
-    if gcloud storage rm --recursive "$GCS_PATH" >/dev/null 2>&1; then
+    REMOTE_DIR="/artifacts/designs/$relpath"
+    if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- rm -rf "$REMOTE_DIR" 2>/dev/null; then
         echo "DELETED"
         ((PASS++))
     else

--- a/tools/fetch_artifacts.sh
+++ b/tools/fetch_artifacts.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# Fetch build artifacts uploaded by K8s jobs from GCS.
-# Artifacts are synced to gs://hightide-bazel-cache/artifacts/designs/<platform>/<design>/
-# when jobs are submitted with `./k8s/run.sh --upload-artifacts ...`.
+# Fetch build artifacts from the hightide-artifacts PVC on Nautilus NRP.
+# Artifacts are saved by K8s jobs when submitted with `./k8s/run.sh --upload-artifacts`.
 #
 # Usage:
 #   ./tools/fetch_artifacts.sh                      # all designs
@@ -10,15 +9,16 @@
 #   ./tools/fetch_artifacts.sh --design lfsr        # one design, all platforms
 #
 # Options:
-#   --output-dir DIR  Where to sync artifacts (default: artifacts/)
-#   --keep            Keep artifacts in GCS after fetching (default: delete)
+#   --output-dir DIR  Where to copy artifacts (default: artifacts/)
+#   --keep            Keep artifacts on the PVC after fetching (default: delete)
 
 set -uo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
 
-GCS_BUCKET="gs://hightide-bazel-cache/artifacts"
+NAMESPACE="vlsida"
+PVC_NAME="hightide-artifacts"
 OUTPUT_DIR="artifacts"
 KEEP_REMOTE=false
 FILTER_PLATFORM=""
@@ -46,11 +46,6 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-
-if ! command -v gcloud >/dev/null 2>&1; then
-    echo "ERROR: gcloud must be installed and authenticated" >&2
-    exit 1
-fi
 
 # Discover designs
 TARGETS=()
@@ -85,8 +80,44 @@ if [[ ${#TARGETS[@]} -eq 0 ]]; then
     exit 1
 fi
 
+# Start a temporary pod to access the PVC
+POD_NAME="hightide-fetch-$$"
+echo "Starting temporary pod to access PVC..."
+kubectl run "$POD_NAME" -n "$NAMESPACE" \
+    --image=alpine \
+    --restart=Never \
+    --overrides='{
+      "spec": {
+        "containers": [{
+          "name": "fetch",
+          "image": "alpine",
+          "command": ["sleep", "3600"],
+          "volumeMounts": [{
+            "name": "artifacts",
+            "mountPath": "/artifacts"
+          }]
+        }],
+        "volumes": [{
+          "name": "artifacts",
+          "persistentVolumeClaim": {
+            "claimName": "'"$PVC_NAME"'"
+          }
+        }]
+      }
+    }' >/dev/null 2>&1
+
+# Wait for the pod to be ready
+echo "Waiting for pod..."
+kubectl wait --for=condition=Ready pod/"$POD_NAME" -n "$NAMESPACE" --timeout=60s >/dev/null 2>&1
+
+cleanup() {
+    echo "Cleaning up temporary pod..."
+    kubectl delete pod "$POD_NAME" -n "$NAMESPACE" --ignore-not-found=true >/dev/null 2>&1
+}
+trap cleanup EXIT
+
 mkdir -p "$OUTPUT_DIR"
-echo "Syncing artifacts to $OUTPUT_DIR/"
+echo "Fetching artifacts to $OUTPUT_DIR/"
 echo ""
 
 PASS=0
@@ -96,21 +127,23 @@ for entry in "${TARGETS[@]}"; do
     IFS='|' read -r platform leaf relpath <<< "$entry"
     printf "  %-12s %-30s " "$platform" "$leaf"
 
-    GCS_PATH="$GCS_BUCKET/designs/$relpath"
-    LOCAL_DIR="$OUTPUT_DIR/$relpath"
+    REMOTE_DIR="/artifacts/designs/$relpath"
 
-    # Check if remote path has any objects before attempting rsync
-    if ! gcloud storage ls "$GCS_PATH/**" >/dev/null 2>&1; then
+    # Check if remote directory exists
+    if ! kubectl exec "$POD_NAME" -n "$NAMESPACE" -- ls "$REMOTE_DIR" >/dev/null 2>&1; then
         echo "NOT FOUND"
         ((FAIL++))
         continue
     fi
 
+    LOCAL_DIR="$OUTPUT_DIR/$relpath"
     mkdir -p "$LOCAL_DIR"
-    if gcloud storage rsync --recursive "$GCS_PATH" "$LOCAL_DIR" >/dev/null 2>&1; then
+
+    # Copy artifacts from PVC via kubectl cp
+    if kubectl cp "$NAMESPACE/$POD_NAME:$REMOTE_DIR" "$LOCAL_DIR" >/dev/null 2>&1; then
         if [[ "$KEEP_REMOTE" != "true" ]]; then
-            gcloud storage rm --recursive "$GCS_PATH" >/dev/null 2>&1 \
-                && echo "OK (deleted remote)" || echo "OK"
+            kubectl exec "$POD_NAME" -n "$NAMESPACE" -- rm -rf "$REMOTE_DIR" 2>/dev/null
+            echo "OK (deleted remote)"
         else
             echo "OK"
         fi


### PR DESCRIPTION
## Summary
- Replace `gcloud storage rsync` with CephFS PVC (`hightide-artifacts`) for build artifact storage
- Artifacts are written directly to the PVC during K8s jobs via `cp -rL` and fetched locally via `kubectl cp` from a temporary pod
- No gcloud CLI needed in containers or locally — only `kubectl`
- Update `k8s/README.md` to document PVC-based artifact workflow

## Test plan
- [x] Created `hightide-artifacts` PVC (50Gi, rook-cephfs, ReadWriteMany)
- [x] Submit `./k8s/run.sh --upload-artifacts asap7 lfsr`, verify 75 files saved to PVC (14M)
- [x] Run `./tools/fetch_artifacts.sh asap7 lfsr`, verify local extraction and PVC cleanup