### PR TITLE
Add bp_processor designs with new bazel-orfs OCI extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ objects
 sv2v
 **/dev/liteeth_builds
 bazel-*
+!patches/bazel-*
 artifacts/
 MODULE.bazel.lock
 .bazelrc.user

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,15 +12,15 @@ python.toolchain(python_version = "3.13", is_default = True)
 git_override(
     module_name = "bazel-orfs",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
-    commit = "845f580208912233af32f5188564cdbf20a58971",
+    commit = "da4ffdf2752f377c6e66aa942fae3e24a36ad99a",
 )
 
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
 
 # Docker image must match the bazel-orfs commit and the ORFS submodule.
 orfs.default(
-    image = "docker.io/openroad/orfs:26Q1-656-g97416b2e4",
-    sha256 = "9c90633d62e08f0b3772d4fdfc06b14e4f33273ae1511d1c41d3c48560adb9a5",
+    image = "docker.io/openroad/orfs:26Q2-32-gca75a11e2",
+    sha256 = "a50429aaed8cbaf2103b46196507f7c9445c95066d00a91953bd47c27dad6f31",
 )
 
 use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -65,18 +65,17 @@ git_override(
 
 # --- yosys + plugins (slang) extracted from the ORFS Docker image ---
 # The BCR yosys package doesn't ship the slang plugin that bp_processor
-# needs. We re-run the same OCI extraction docker_pkg rule with a
-# custom BUILD file that exposes yosys, yosys-abc, and yosys_share
-# (including plugins/slang.so) from the image. Bazel's repository
-# cache dedupes the layer downloads with @docker_orfs_image.
+# needs. We re-run bazel-orfs's docker_pkg rule with a custom BUILD
+# file exposing yosys, yosys-abc, and yosys_share (including
+# plugins/slang.so) from the image, then route orfs.default() at the
+# extracted binaries. Bazel's content-addressed repository cache
+# dedupes the layer downloads with @docker_orfs_image.
 #
-# TEMPORARY: upstream bazel-orfs (ideas/toolchains.md on main) is
-# retiring @docker_orfs / image extraction in favor of a prebuilt
-# bazel-orfs-yosys toolchain submodule that bundles slang. When that
-# ships, drop docker_yosys.BUILD.bazel and the docker_pkg call below,
-# and replace the yosys/yosys_abc/yosys_share overrides in
-# orfs.default() with the new toolchain extension. See
-# https://github.com/The-OpenROAD-Project/bazel-orfs/blob/main/ideas/toolchains.md
+# This is the intended downstream extensibility pattern — bazel-orfs
+# supports pointing at user-supplied docker-extracted binaries as a
+# first-class use case. The retirement of @docker_orfs described in
+# bazel-orfs/ideas/toolchains.md applies to bazel-orfs's own internal
+# default path, not to the orfs.default(yosys=...) override below.
 bazel_dep(name = "yosys", version = "0.62")
 single_version_override(
     module_name = "yosys",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,6 +69,14 @@ git_override(
 # custom BUILD file that exposes yosys, yosys-abc, and yosys_share
 # (including plugins/slang.so) from the image. Bazel's repository
 # cache dedupes the layer downloads with @docker_orfs_image.
+#
+# TEMPORARY: upstream bazel-orfs (ideas/toolchains.md on main) is
+# retiring @docker_orfs / image extraction in favor of a prebuilt
+# bazel-orfs-yosys toolchain submodule that bundles slang. When that
+# ships, drop docker_yosys.BUILD.bazel and the docker_pkg call below,
+# and replace the yosys/yosys_abc/yosys_share overrides in
+# orfs.default() with the new toolchain extension. See
+# https://github.com/The-OpenROAD-Project/bazel-orfs/blob/main/ideas/toolchains.md
 bazel_dep(name = "yosys", version = "0.62")
 single_version_override(
     module_name = "yosys",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,26 +1,92 @@
+"""HighTide2 module — uses bazel-orfs with OpenROAD extracted from the
+ORFS Docker image (zero-source OpenROAD build).
+
+Mirrors the bazel-orfs test/docker/MODULE.bazel pattern.
+"""
+
 module(
     name = "hightide2",
     version = "0.0.1",
 )
 
-bazel_dep(name = "rules_python", version = "1.8.5")
+# --- bazel-orfs ---
+BAZEL_ORFS_COMMIT = "da4ffdf2752f377c6e66aa942fae3e24a36ad99a"
+
+BAZEL_ORFS_REMOTE = "https://github.com/The-OpenROAD-Project/bazel-orfs.git"
+
 bazel_dep(name = "bazel-orfs")
-
-python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-python.toolchain(python_version = "3.13", is_default = True)
-
 git_override(
     module_name = "bazel-orfs",
-    remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
-    commit = "da4ffdf2752f377c6e66aa942fae3e24a36ad99a",
+    commit = BAZEL_ORFS_COMMIT,
+    remote = BAZEL_ORFS_REMOTE,
 )
 
+# bazel-orfs-verilog lives in the verilog/ subdir of the bazel-orfs repo.
+bazel_dep(name = "bazel-orfs-verilog")
+git_override(
+    module_name = "bazel-orfs-verilog",
+    commit = BAZEL_ORFS_COMMIT,
+    remote = BAZEL_ORFS_REMOTE,
+    strip_prefix = "verilog",
+)
+
+# --- Stub overrides for modules we don't build from source ---
+# The OpenROAD binary comes from the Docker image via
+# @bazel-orfs//:openroad-latest, so @openroad and @qt-bazel only need
+# to exist for module-graph resolution. We point them at the stub
+# subdirs inside bazel-orfs itself.
+bazel_dep(name = "openroad")
+git_override(
+    module_name = "openroad",
+    commit = BAZEL_ORFS_COMMIT,
+    remote = BAZEL_ORFS_REMOTE,
+    strip_prefix = "test/docker/stub/openroad",
+)
+
+bazel_dep(name = "qt-bazel")
+git_override(
+    module_name = "qt-bazel",
+    commit = BAZEL_ORFS_COMMIT,
+    remote = BAZEL_ORFS_REMOTE,
+    strip_prefix = "test/docker/stub/qt-bazel",
+)
+
+# --- ORFS flow scripts (Makefile, TCL, PDKs) ---
+bazel_dep(name = "orfs")
+git_override(
+    module_name = "orfs",
+    commit = "d8c6b0cbd54d3a2d6e78671e80b7b479c10af6f6",
+    patch_strip = 1,
+    patches = [
+        "//patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
+    ],
+    remote = "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git",
+)
+
+# --- yosys (built from source via BCR) ---
+bazel_dep(name = "yosys", version = "0.62")
+single_version_override(
+    module_name = "yosys",
+    patch_strip = 1,
+    patches = [
+        "//patches:yosys-visibility.patch",
+    ],
+)
+
+# --- Python 3.13 toolchain ---
+bazel_dep(name = "rules_python", version = "1.8.5")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    is_default = True,
+    python_version = "3.13",
+)
+
+# --- ORFS extension: use Docker image OpenROAD binary ---
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
-
-# Docker image must match the bazel-orfs commit and the ORFS submodule.
 orfs.default(
-    image = "docker.io/openroad/orfs:26Q2-32-gca75a11e2",
-    sha256 = "a50429aaed8cbaf2103b46196507f7c9445c95066d00a91953bd47c27dad6f31",
+    openroad = "@bazel-orfs//:openroad-latest",
+    opensta = "@bazel-orfs//:opensta-latest",
 )
-
 use_repo(orfs, "docker_orfs")
+use_repo(orfs, "docker_orfs_image")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -63,7 +63,12 @@ git_override(
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git",
 )
 
-# --- yosys (built from source via BCR) ---
+# --- yosys + plugins (slang) extracted from the ORFS Docker image ---
+# The BCR yosys package doesn't ship the slang plugin that bp_processor
+# needs. We re-run the same OCI extraction docker_pkg rule with a
+# custom BUILD file that exposes yosys, yosys-abc, and yosys_share
+# (including plugins/slang.so) from the image. Bazel's repository
+# cache dedupes the layer downloads with @docker_orfs_image.
 bazel_dep(name = "yosys", version = "0.62")
 single_version_override(
     module_name = "yosys",
@@ -71,6 +76,20 @@ single_version_override(
     patches = [
         "//patches:yosys-visibility.patch",
     ],
+)
+
+docker_pkg = use_repo_rule("@bazel-orfs//:docker.bzl", "docker_pkg")
+
+docker_pkg(
+    name = "docker_orfs_yosys",
+    build_file = "//:docker_yosys.BUILD.bazel",
+    image = "docker.io/openroad/orfs:26Q2-32-gca75a11e2",
+    # Delete BUILD files under OpenROAD-flow-scripts so they don't
+    # create subpackages that break the yosys_share glob.
+    patch_cmds = [
+        "find OpenROAD-flow-scripts -name BUILD -delete -o -name BUILD.bazel -delete",
+    ],
+    sha256 = "a50429aaed8cbaf2103b46196507f7c9445c95066d00a91953bd47c27dad6f31",
 )
 
 # --- Python 3.13 toolchain ---
@@ -82,11 +101,14 @@ python.toolchain(
     python_version = "3.13",
 )
 
-# --- ORFS extension: use Docker image OpenROAD binary ---
+# --- ORFS extension: use Docker image OpenROAD + yosys binaries ---
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
 orfs.default(
     openroad = "@bazel-orfs//:openroad-latest",
     opensta = "@bazel-orfs//:opensta-latest",
+    yosys = "@docker_orfs_yosys//:yosys",
+    yosys_abc = "@docker_orfs_yosys//:yosys-abc",
+    yosys_share = "@docker_orfs_yosys//:yosys_share",
 )
 use_repo(orfs, "docker_orfs")
 use_repo(orfs, "docker_orfs_image")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,13 @@ bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
     commit = BAZEL_ORFS_COMMIT,
+    patch_strip = 1,
+    # Point private _tcl/_opengl/_qt_plugins attr defaults at
+    # @docker_orfs_image so OpenROAD can find its Qt offscreen
+    # plugin at the save_images.tcl finish stage (GUI-0076/0077).
+    patches = [
+        "//patches:bazel-orfs-docker-orfs-image-runtime-deps.patch",
+    ],
     remote = BAZEL_ORFS_REMOTE,
 )
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -4,9 +4,9 @@ load("@bazel-orfs//:openroad.bzl", "orfs_flow")
 
 # PDK label mapping per platform
 PDKS = {
-    "asap7": "@docker_orfs//:asap7",
-    "nangate45": "@docker_orfs//:nangate45",
-    "sky130hd": "@docker_orfs//:sky130hd",
+    "asap7": "@orfs//flow:asap7",
+    "nangate45": "@orfs//flow:nangate45",
+    "sky130hd": "@orfs//flow:sky130hd",
 }
 
 def hightide_design(name, platform, verilog_files, top = None, arguments = {}, sources = {}, **kwargs):

--- a/designs/asap7/bp_processor/bp_quad/BUILD.bazel
+++ b/designs/asap7/bp_processor/bp_quad/BUILD.bazel
@@ -7,7 +7,7 @@ _ARGS.update({
     "VERILOG_TOP_PARAMS": "bp_params_p 11",
     "CORE_UTILIZATION": "35",
     "PLACE_PINS_ARGS": "-min_distance 30 -min_distance_in_tracks",
-    "MACRO_PLACE_HALO": "20 20",
+    "MACRO_PLACE_HALO": "6 6",
     "MACRO_BLOCKAGE_HALO": "0.5",
     "PLACE_DENSITY_LB_ADDON": "0.10",
 })

--- a/designs/asap7/bp_processor/bp_quad/BUILD.bazel
+++ b/designs/asap7/bp_processor/bp_quad/BUILD.bazel
@@ -5,8 +5,8 @@ _ARGS = dict(BP_COMMON_ARGS)
 
 _ARGS.update({
     "VERILOG_TOP_PARAMS": "bp_params_p 11",
-    "DIE_AREA": "0 0 1600 1600",
-    "CORE_AREA": "10 10 1590 1590",
+    "DIE_AREA": "0 0 2000 2000",
+    "CORE_AREA": "10 10 1990 1990",
     "PLACE_PINS_ARGS": "-min_distance 30 -min_distance_in_tracks",
     "MACRO_PLACE_HALO": "6 6",
     "MACRO_BLOCKAGE_HALO": "0.5",

--- a/designs/asap7/bp_processor/bp_quad/BUILD.bazel
+++ b/designs/asap7/bp_processor/bp_quad/BUILD.bazel
@@ -5,10 +5,9 @@ _ARGS = dict(BP_COMMON_ARGS)
 
 _ARGS.update({
     "VERILOG_TOP_PARAMS": "bp_params_p 11",
-    "DIE_AREA": "0 0 2000 2000",
-    "CORE_AREA": "10 10 1990 1990",
+    "CORE_UTILIZATION": "35",
     "PLACE_PINS_ARGS": "-min_distance 30 -min_distance_in_tracks",
-    "MACRO_PLACE_HALO": "6 6",
+    "MACRO_PLACE_HALO": "20 20",
     "MACRO_BLOCKAGE_HALO": "0.5",
     "PLACE_DENSITY_LB_ADDON": "0.10",
 })

--- a/designs/asap7/bp_processor/bp_quad/BUILD.bazel
+++ b/designs/asap7/bp_processor/bp_quad/BUILD.bazel
@@ -5,8 +5,8 @@ _ARGS = dict(BP_COMMON_ARGS)
 
 _ARGS.update({
     "VERILOG_TOP_PARAMS": "bp_params_p 11",
-    "DIE_AREA": "0 0 1200 1200",
-    "CORE_AREA": "10 10 1190 1190",
+    "DIE_AREA": "0 0 1600 1600",
+    "CORE_AREA": "10 10 1590 1590",
     "PLACE_PINS_ARGS": "-min_distance 30 -min_distance_in_tracks",
     "MACRO_PLACE_HALO": "6 6",
     "MACRO_BLOCKAGE_HALO": "0.5",

--- a/designs/src/bp_processor/BUILD.bazel
+++ b/designs/src/bp_processor/BUILD.bazel
@@ -12,17 +12,14 @@ _EXCLUDED_SUFFIXES = [
     "bsg_mem_1rw_sync_mask_write_bit_synth.sv",
 ]
 
-def _filter_srcs(srcs):
-    return [f for f in srcs if not any(f.endswith(e) for e in _EXCLUDED_SUFFIXES)]
-
 filegroup(
     name = "rtl_release",
-    srcs = _filter_srcs(_REL_SRCS) + ["stubs.v"],
+    srcs = [f for f in _REL_SRCS if not any([f.endswith(e) for e in _EXCLUDED_SUFFIXES])] + ["stubs.v"],
 )
 
 filegroup(
     name = "rtl_dev",
-    srcs = _filter_srcs(_DEV_SRCS) + ["stubs.v"],
+    srcs = [f for f in _DEV_SRCS if not any([f.endswith(e) for e in _EXCLUDED_SUFFIXES])] + ["stubs.v"],
 )
 
 alias(

--- a/designs/src/bp_processor/release/repo/external/basejump_stl/bsg_misc/bsg_defines.sv
+++ b/designs/src/bp_processor/release/repo/external/basejump_stl/bsg_misc/bsg_defines.sv
@@ -1,0 +1,219 @@
+`ifndef BSG_DEFINES_V
+`define BSG_DEFINES_V
+
+`define BSG_MAX(x,y) (((x)>(y)) ? (x) : (y))
+`define BSG_MIN(x,y) (((x)<(y)) ? (x) : (y))
+
+`define BSG_SIGN_EXTEND(sig, width) \
+  ({{`BSG_MAX(width-$bits(sig),0){sig[$bits(sig)-1]}}, sig[0+:`BSG_MIN(width, $bits(sig))]})
+`define BSG_ZERO_EXTEND(sig, width) \
+  ({{`BSG_MAX(width-$bits(sig),0){1'b0}}, sig[0+:`BSG_MIN(width, $bits(sig))]})
+
+// place this macro at the end of a verilog module file if that module has invalid parameters
+// that must be specified by the user. this will prevent that module from becoming a top-level
+// module per the discussion here: https://github.com/SymbiFlow/sv-tests/issues/1160 and the
+// SystemVerilog Standard
+
+//    "Top-level modules are modules that are included in the SystemVerilog
+//    source text, but do not appear in any module instantiation statement, as
+//    described in 23.3.2. This applies even if the module instantiation appears
+//    in a generate block that is not itself instantiated (see 27.3). A design
+//    shall contain at least one top-level module. A top-level module is
+//    implicitly instantiated once, and its instance name is the same as the
+//    module name. Such an instance is called a top-level instance."
+//  
+
+`define BSG_ABSTRACT_MODULE(fn) \
+    /*verilator lint_off DECLFILENAME*/ \
+    /*verilator lint_off PINMISSING*/ \
+    module fn``__abstract(); if (0) begin : abstract fn not_used(); end endmodule \
+    /*verilator lint_on PINMISSING*/ \
+    /*verilator lint_on DECLFILENAME*/
+
+// macro for defining invalid parameter; with the abstract module declaration
+// it should be sufficient to omit the "inv" but we include this for tool portability
+// if later we find that all tools are compatible, we can remove the use of this from BaseJump STL
+
+`ifdef XCELIUM // Bare default parameters are incompatible as of 20.09.012
+               // = "inv" causes type inference mismatch as of 20.09.012
+`define BSG_INV_PARAM(param) param = -1
+`elsif YOSYS // Bare default parameters are incompatible as of 0.9
+`define BSG_INV_PARAM(param) param = "inv"
+`else // VIVADO, DC, VERILATOR, GENUS, SURELOG
+`define BSG_INV_PARAM(param) param
+`endif
+
+
+// maps 1 --> 1 instead of to 0
+`define BSG_SAFE_CLOG2(x) ( (((x)==1) || ((x)==0))? 1 : $clog2((x)))
+`define BSG_IS_POW2(x) ( (1 << $clog2(x)) == (x))
+`define BSG_WIDTH(x) ($clog2({1'b0, x}+1))
+`define BSG_SAFE_MINUS(x, y) (((x)<(y))) ? 0 : ((x)-(y))
+
+// these "SAFE" shift functions handle a common problem that shifts default to 32 bits wide even
+// though the result may be more bits than that.
+
+// these macros ensure that a left shift is done with sufficient bits of precision not to lose data
+// extra is used if you want some extra bits of margin
+`define BSG_SAFE_SHIFT_LEFT_BY_CONST(a,b_const,extra) (( ($bits(a) + (b_const) + extra )'(a)) << (b_const))
+
+// b_max is the maximum value that b_variable can take on
+`define BSG_SAFE_SHIFT_LEFT_CONST_BY_VARIABLE(a_const,b_variable,b_max,extra) (( ($clog2( (a_const)+1)+(b_max)+(extra)) ' (a_const)) << (b_variable) )
+
+      
+// calculate ceil(x/y) 
+`define BSG_CDIV(x,y) (((x)+(y)-1)/(y))
+
+`ifdef SYNTHESIS
+`define BSG_UNDEFINED_IN_SIM(val) (val)
+`else
+`define BSG_UNDEFINED_IN_SIM(val) ('X)
+`endif
+
+`ifdef VERILATOR
+`define BSG_HIDE_FROM_VERILATOR(val)
+`define BSG_VERILATOR_ONLY(val) val
+`else
+`define BSG_HIDE_FROM_VERILATOR(val) val
+`define BSG_VERILATOR_ONLY(val)
+`endif
+
+`ifdef SYNTHESIS
+`define BSG_DISCONNECTED_IN_SIM(val) (val)
+`elsif VERILATOR
+`define BSG_DISCONNECTED_IN_SIM(val) (val)
+`else
+`define BSG_DISCONNECTED_IN_SIM(val) ('z)
+`endif
+
+// Ufortunately per the Xilinx forums, Xilinx does not define
+// any variable that indicates that Vivado Synthesis is running
+// so as a result we identify Vivado merely as the exclusion of
+// Synopsys Design Compiler (DC). Support beyond DC and Vivado
+// will require modification of this macro.
+
+`ifdef SYNTHESIS
+  `ifdef DC
+  `define BSG_VIVADO_SYNTH_FAILS
+  `elsif CDS_TOOL_DEFINE
+  `define BSG_VIVADO_SYNTH_FAILS
+  `elsif SURELOG
+  `define BSG_VIVADO_SYNTH_FAILS
+  `elsif YOSYS
+  `define BSG_VIVADO_SYNTH_FAILS
+  `else
+  `define BSG_VIVADO_SYNTH_FAILS this_module_is_not_synthesizeable_in_vivado
+  `endif
+`else
+`define BSG_VIVADO_SYNTH_FAILS
+`endif
+
+// macro for denoting that a code snippet is unsynthesiable
+
+`ifdef SYNTHESIS
+  `define BSG_HIDE_FROM_SYNTHESIS
+`endif
+
+`ifdef SYNTHESIS
+`define BSG_HIDE_FROM_SYNTHESIS_EXPR(val)
+`else
+`define BSG_HIDE_FROM_SYNTHESIS_EXPR(val) val
+`endif
+
+`define BSG_STRINGIFY(x) `"x`"
+
+
+// For the modules that must be hardened, add this macro at the top.
+`ifdef SYNTHESIS
+`define BSG_SYNTH_MUST_HARDEN this_module_must_be_hardened
+`else
+`define BSG_SYNTH_MUST_HARDEN
+`endif
+
+
+// using C-style shifts instead of a[i] allows the parameter of BSG_GET_BIT to be a parameter subrange                                                                                                                                                                               
+// e.g., parameter[4:1][1], which DC 2016.12 does not allow                                                                                                                                                                                                                          
+
+`define BSG_GET_BIT(X,NUM) (((X)>>(NUM))&1'b1)
+
+// This version of countones works in synthesis, but only up to 64 bits                                                                                                                                                                                                              
+// we do a funny thing where we propagate X's in simulation if it is more than 64 bits                                                                                                                                                                                               
+// and in synthesis, go ahead and ignore the high bits                                                                                                                                                                      
+
+`define BSG_COUNTONES_SYNTH(y) ((($bits(y) < 65) ? 1'b0 : `BSG_UNDEFINED_IN_SIM(1'b0)) + (`BSG_GET_BIT(y,0) +`BSG_GET_BIT(y,1) +`BSG_GET_BIT(y,2) +`BSG_GET_BIT(y,3) +`BSG_GET_BIT(y,4) +`BSG_GET_BIT(y,5) +`BSG_GET_BIT(y,6)+`BSG_GET_BIT(y,7) +`BSG_GET_BIT(y,8)+`BSG_GET_BIT(y,9) \
+                                                                                       +`BSG_GET_BIT(y,10)+`BSG_GET_BIT(y,11)+`BSG_GET_BIT(y,12)+`BSG_GET_BIT(y,13)+`BSG_GET_BIT(y,14)+`BSG_GET_BIT(y,15)+`BSG_GET_BIT(y,16)+`BSG_GET_BIT(y,17)+`BSG_GET_BIT(y,18)+`BSG_GET_BIT(y,19) \
+                                                                                       +`BSG_GET_BIT(y,20)+`BSG_GET_BIT(y,21)+`BSG_GET_BIT(y,22)+`BSG_GET_BIT(y,23)+`BSG_GET_BIT(y,24)+`BSG_GET_BIT(y,25)+`BSG_GET_BIT(y,26)+`BSG_GET_BIT(y,27)+`BSG_GET_BIT(y,28)+`BSG_GET_BIT(y,29) \
+                                                                                       +`BSG_GET_BIT(y,30)+`BSG_GET_BIT(y,31)+`BSG_GET_BIT(y,32)+`BSG_GET_BIT(y,33)+`BSG_GET_BIT(y,34)+`BSG_GET_BIT(y,35)+`BSG_GET_BIT(y,36)+`BSG_GET_BIT(y,37)+`BSG_GET_BIT(y,38)+`BSG_GET_BIT(y,39) \
+                                                                                       +`BSG_GET_BIT(y,40)+`BSG_GET_BIT(y,41)+`BSG_GET_BIT(y,42)+`BSG_GET_BIT(y,43)+`BSG_GET_BIT(y,44)+`BSG_GET_BIT(y,45)+`BSG_GET_BIT(y,46)+`BSG_GET_BIT(y,47)+`BSG_GET_BIT(y,48)+`BSG_GET_BIT(y,49) \
+                                                                                       +`BSG_GET_BIT(y,50)+`BSG_GET_BIT(y,51)+`BSG_GET_BIT(y,52)+`BSG_GET_BIT(y,53)+`BSG_GET_BIT(y,54)+`BSG_GET_BIT(y,55)+`BSG_GET_BIT(y,56)+`BSG_GET_BIT(y,57)+`BSG_GET_BIT(y,58)+`BSG_GET_BIT(y,59) \
+                                                                                          +`BSG_GET_BIT(y,60)+`BSG_GET_BIT(y,61)+`BSG_GET_BIT(y,62)+`BSG_GET_BIT(y,63)))
+
+// nullify rpgroups
+`ifndef rpgroup
+`define rpgroup(x)
+`endif
+
+// verilog preprocessing -> if defined(A) && defined(B) then define C
+`define BSG_DEFIF_A_AND_B(A,B,C) \
+    `undef C \
+    `ifdef A \
+        `ifdef B \
+            `define C \
+        `endif \
+    `endif
+
+// verilog preprocessing -> if defined(A) && !defined(B) then define C
+`define BSG_DEFIF_A_AND_NOT_B(A,B,C) \
+    `undef C \
+    `ifdef A \
+        `ifndef B \
+            `define C \
+        `endif \
+    `endif
+
+// verilog preprocessing -> if !defined(A) && defined(B) then define C
+`define BSG_DEFIF_NOT_A_AND_B(A,B,C) `BSG_DEFIF_A_AND_NOT_B(B,A,C)
+
+// verilog preprocessing -> if !defined(A) && !defined(B) then define C
+`define BSG_DEFIF_NOT_A_AND_NOT_B(A,B,C) \
+    `undef C \
+    `ifndef A \
+        `ifndef B \
+            `define C \
+        `endif \
+    `endif
+
+// verilog preprocessing -> if defined(A) || defined(B) then define C
+`define BSG_DEFIF_A_OR_B(A,B,C) \
+    `undef C \
+    `ifdef A \
+        `define C \
+    `endif \
+    `ifdef B \
+        `define C \
+    `endif
+
+// verilog preprocessing -> if defined(A) || !defined(B) then define C
+`define BSG_DEFIF_A_OR_NOT_B(A,B,C) \
+    `undef C \
+    `ifdef A \
+        `define C \
+    `endif \
+    `ifndef B \
+        `define C \
+    `endif
+
+// verilog preprocessing -> if !defined(A) || defined(B) then define C
+`define BSG_DEFIF_NOT_A_OR_B(A,B,C) `BSG_DEFIF_A_OR_NOT_B(B,A,C)
+
+// verilog preprocessing -> if !defined(A) || !defined(B) then define C
+`define BSG_DEFIF_NOT_A_OR_NOT_B(A,B,C) \
+    `undef C \
+    `ifndef A \
+        `define C \
+    `endif \
+    `ifndef B \
+        `define C \
+    `endif
+
+`endif

--- a/docker_yosys.BUILD.bazel
+++ b/docker_yosys.BUILD.bazel
@@ -1,0 +1,56 @@
+"""BUILD file for extracting yosys + plugins from the ORFS Docker image.
+
+The upstream bazel-orfs //:docker_openroad.BUILD.bazel extracts only
+the OpenROAD binary and runtime libs. Our designs (bp_processor) need
+the slang frontend, which lives in the image's yosys plugin directory,
+so we re-extract the same image with a custom BUILD file exposing
+yosys, yosys-abc, and the yosys share tree (including plugins).
+
+Bazel's repository cache is content-addressed by sha256, so the image
+layers are downloaded once and shared between this repo and
+@docker_orfs_image.
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "ld.so",
+    srcs = ["_lib/ld-linux-x86-64.so.2"],
+)
+
+filegroup(
+    name = "lib",
+    srcs = glob(
+        [
+            "lib/x86_64-linux-gnu/**/*.so*",
+            "usr/lib/x86_64-linux-gnu/*.so*",
+            "OpenROAD-flow-scripts/tools/install/yosys/lib/*.so*",
+        ],
+        allow_empty = True,
+    ),
+)
+
+# All files under share/yosys (techlib cells, plugins including slang.so).
+filegroup(
+    name = "yosys_share",
+    srcs = glob(["OpenROAD-flow-scripts/tools/install/yosys/share/yosys/**"]),
+)
+
+filegroup(
+    name = "yosys",
+    srcs = ["OpenROAD-flow-scripts/tools/install/yosys/bin/yosys"],
+    data = [
+        ":ld.so",
+        ":lib",
+        ":yosys_share",
+    ],
+)
+
+filegroup(
+    name = "yosys-abc",
+    srcs = ["OpenROAD-flow-scripts/tools/install/yosys/bin/yosys-abc"],
+    data = [
+        ":ld.so",
+        ":lib",
+    ],
+)

--- a/patches/0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch
+++ b/patches/0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Wed, 2 Apr 2026 22:00:00 +0200
+Subject: [PATCH] fix: remove non-root overrides from MODULE.bazel
+
+When ORFS is fetched as a non-root dependency, git_override and
+orfs.default() directives are ignored/illegal.  Remove them so
+the module can be used as a dependency without errors.
+
+Signed-off-by: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+---
+ MODULE.bazel | 19 -------------------
+ 1 file changed, 19 deletions(-)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -8,13 +8,6 @@
+
+ bazel_dep(name = "bazel-orfs")
+
+-# To bump version, run: bazelisk run @bazel-orfs//:bump
+-git_override(
+-    module_name = "bazel-orfs",
+-    commit = "f8a4b694b37c8f5322323eba9a9ae37f9541ee17",
+-    remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
+-)
+-
+ bazel_dep(name = "rules_python", version = "1.8.5")
+ bazel_dep(name = "rules_shell", version = "0.6.1")
+
+@@ -36,15 +29,3 @@
+ use_repo(pip, "orfs-pip")
+
+ orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
+-
+-# To bump version, run: bazelisk run @bazel-orfs//:bump
+-orfs.default(
+-    image = "docker.io/openroad/orfs:v3.0-3273-gedf3d6bf",
+-    # Use local files instead of docker image
+-    makefile = "//flow:makefile",
+-    makefile_yosys = "//flow:makefile_yosys",
+-    pdk = "//flow:asap7",
+-    sha256 = "f5692c6325ebcf27cc348e033355ec95c82c35ace1af7e72a0d352624ada143e",
+-)
+-use_repo(orfs, "com_github_nixos_patchelf_download")
+-use_repo(orfs, "docker_orfs")
+--
+2.51.0
+

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/patches/bazel-orfs-docker-orfs-image-runtime-deps.patch
+++ b/patches/bazel-orfs-docker-orfs-image-runtime-deps.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] point OpenROAD runtime deps at @docker_orfs_image
+
+In zero-docker mode @docker_orfs is a stub with empty filegroups, so
+the default _tcl / _opengl / _qt_plugins labels on orfs rules resolve
+to nothing. OpenROAD's Qt runtime then fails to find the offscreen
+platform plugin at the finish stage when save_images.tcl calls
+gui::save_display_controls, crashing with GUI-0076/GUI-0077.
+
+Point the defaults at @docker_orfs_image (the real image extraction)
+so the plugin files land in ctx.files._qt_plugins, which in turn sets
+QT_PLUGIN_PATH / QT_QPA_PLATFORM_PLUGIN_PATH via environment.bzl.
+
+---
+ private/attrs.bzl | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/private/attrs.bzl b/private/attrs.bzl
+--- a/private/attrs.bzl
++++ b/private/attrs.bzl
+@@ -86,7 +86,7 @@
+         "_tcl": attr.label(
+             doc = "Tcl library.",
+             allow_files = True,
+-            default = Label("@docker_orfs//:tcl8.6"),
++            default = Label("@docker_orfs_image//:tcl8.6"),
+         ),
+         "_package_stage": attr.label(
+             doc = "Python script for creating portable stage tarballs.",
+@@ -119,7 +119,7 @@
+         "_opengl": attr.label(
+             doc = "OpenGL drivers.",
+             allow_files = True,
+-            default = Label("@docker_orfs//:opengl"),
++            default = Label("@docker_orfs_image//:opengl"),
+         ),
+         "_openroad": attr.label(
+             doc = "OpenROAD binary (fallback; prefer public 'openroad' attr).",
+@@ -138,7 +138,7 @@
+         "_qt_plugins": attr.label(
+             doc = "Qt plugins.",
+             allow_files = True,
+-            default = Label("@docker_orfs//:qt_plugins"),
++            default = Label("@docker_orfs_image//:qt_plugins"),
+         ),
+         "_ruby": attr.label(
+             doc = "Ruby library.",
+             allow_files = True,

--- a/patches/yosys-visibility.patch
+++ b/patches/yosys-visibility.patch
@@ -1,0 +1,11 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,5 +1,8 @@
++# Techlib cell definitions, plugins and other runtime data needed by the
++# synthesis flow.
+ share_tree(
+     name = "yosys_share",
++    visibility = ["//visibility:public"],
+     file_map = {f: share_dst(f) for f in _TECHLIBS_SHARE_SRCS},
+     renames = [
+         # lattice files also appear under ecp5/ with renamed destinations

--- a/tools/bump_orfs.sh
+++ b/tools/bump_orfs.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Sync the ORFS Docker image/sha256 in MODULE.bazel with the pinned
+# bazel-orfs commit's LATEST_ORFS_IMAGE. Optionally bump bazel-orfs
+# to HEAD first.
+#
+# Usage:
+#   ./tools/bump_orfs.sh             # sync image to match pinned bazel-orfs
+#   ./tools/bump_orfs.sh --latest    # bump bazel-orfs to main HEAD, then sync
+#   ./tools/bump_orfs.sh --check     # verify sync, exit 1 on mismatch (for CI)
+#
+# Requires: gh CLI authenticated to github.com.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MODULE="$REPO_DIR/MODULE.bazel"
+BAZEL_ORFS_REPO="The-OpenROAD-Project/bazel-orfs"
+
+MODE="sync"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --latest) MODE="latest"; shift ;;
+        --check)  MODE="check"; shift ;;
+        -h|--help)
+            sed -n '2,/^$/s/^# \{0,1\}//p' "$0"
+            exit 0
+            ;;
+        *) echo "ERROR: unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+# Extract current pinned commit from MODULE.bazel
+current_commit=$(grep -oP 'commit\s*=\s*"\K[0-9a-f]{40}' "$MODULE" | head -1)
+if [[ -z "$current_commit" ]]; then
+    echo "ERROR: could not find bazel-orfs commit in $MODULE" >&2
+    exit 1
+fi
+
+if [[ "$MODE" == "latest" ]]; then
+    echo "Fetching latest bazel-orfs main..."
+    target_commit=$(gh api "repos/$BAZEL_ORFS_REPO/commits/main" --jq '.sha')
+else
+    target_commit="$current_commit"
+fi
+
+echo "bazel-orfs commit: $target_commit"
+
+# Read extension.bzl at the target commit and extract image constants
+ext_bzl=$(gh api "repos/$BAZEL_ORFS_REPO/contents/extension.bzl?ref=$target_commit" \
+    --jq '.content' | base64 -d)
+
+target_image=$(echo "$ext_bzl" | grep -oP 'LATEST_ORFS_IMAGE\s*=\s*"\K[^"]+')
+target_sha256=$(echo "$ext_bzl" | grep -oP 'LATEST_ORFS_SHA256\s*=\s*"\K[^"]+')
+
+if [[ -z "$target_image" || -z "$target_sha256" ]]; then
+    echo "ERROR: could not extract LATEST_ORFS_IMAGE/SHA256 from bazel-orfs@$target_commit" >&2
+    echo "This commit may be too old — bump bazel-orfs with --latest first." >&2
+    exit 1
+fi
+
+echo "Image:  $target_image"
+echo "Sha256: $target_sha256"
+
+# Current values in MODULE.bazel
+current_image=$(grep -oP 'image\s*=\s*"\K[^"]+' "$MODULE" | head -1)
+current_sha256=$(grep -oP 'sha256\s*=\s*"\K[0-9a-f]{64}' "$MODULE" | head -1)
+
+if [[ "$MODE" == "check" ]]; then
+    ok=true
+    if [[ "$current_commit" != "$target_commit" ]]; then
+        echo "MISMATCH: bazel-orfs commit $current_commit != $target_commit" >&2
+        ok=false
+    fi
+    if [[ "$current_image" != "$target_image" ]]; then
+        echo "MISMATCH: image $current_image != $target_image" >&2
+        ok=false
+    fi
+    if [[ "$current_sha256" != "$target_sha256" ]]; then
+        echo "MISMATCH: sha256 $current_sha256 != $target_sha256" >&2
+        ok=false
+    fi
+    if $ok; then
+        echo "OK: MODULE.bazel in sync with bazel-orfs@$target_commit"
+        exit 0
+    fi
+    exit 1
+fi
+
+# Apply updates in-place
+if [[ "$current_commit" != "$target_commit" ]]; then
+    sed -i "s|$current_commit|$target_commit|" "$MODULE"
+fi
+if [[ "$current_image" != "$target_image" ]]; then
+    sed -i "s|$current_image|$target_image|" "$MODULE"
+fi
+if [[ "$current_sha256" != "$target_sha256" ]]; then
+    sed -i "s|$current_sha256|$target_sha256|" "$MODULE"
+fi
+
+if git -C "$REPO_DIR" diff --quiet -- "$MODULE"; then
+    echo "MODULE.bazel already up-to-date."
+else
+    echo "MODULE.bazel updated. Review with: git diff MODULE.bazel"
+fi


### PR DESCRIPTION
## Summary

- Fix Starlark errors and missing `bsg_defines.sv` in bp_processor release RTL so builds don't depend on submodule init
- Bump bazel-orfs to `da4ffdf2` with OCI-extracted OpenROAD (includes PR The-OpenROAD-Project/OpenROAD#9465 fixing MPL-0040 annealing failures with many SRAM macros)
- Switch to new bazel-orfs architecture: OCI image extraction for OpenROAD + yosys (slang plugin), PDKs from `@orfs//flow`, vendored patches for module-graph compatibility
- Add `tools/bump_orfs.sh` to keep ORFS image synced with pinned bazel-orfs commit
- Extract yosys + slang plugin from Docker image via `docker_pkg` (supported downstream pattern per bazel-orfs maintainers)
- Patch bazel-orfs `attrs.bzl` to route Qt/TCL/OpenGL runtime deps through `@docker_orfs_image` (fixes GUI-0077 crash at `save_images.tcl` finish stage)
- Tune asap7 bp_quad die area (`CORE_UTILIZATION=35`, halo 6)