### PR TITLE
Save K8s build artifacts even on failure

### DIFF
--- a/k8s/job-template.yaml
+++ b/k8s/job-template.yaml
@@ -59,7 +59,9 @@ spec:
             CACHE_FLAGS="$CACHE_FLAGS --remote_download_outputs=all"
           fi
 
-          bazel build $CACHE_FLAGS __BAZEL_TARGET__
+          # Capture build exit code so we can save artifacts even on failure
+          BUILD_RC=0
+          bazel build $CACHE_FLAGS __BAZEL_TARGET__ || BUILD_RC=$?
 
           # Copy build artifacts to persistent storage (when enabled)
           if [ "__UPLOAD_ARTIFACTS__" = "true" ]; then
@@ -85,6 +87,8 @@ spec:
               echo "WARNING: artifact directory $ARTIFACT_DIR not found"
             fi
           fi
+
+          exit $BUILD_RC
         volumeMounts:
         - name: repo
           mountPath: /repo


### PR DESCRIPTION
## Summary
- Capture bazel build exit code instead of exiting immediately on failure
- Artifacts are copied to the PVC regardless of build outcome
- Original exit code is returned after artifact save, so the job still reports failure correctly
- Enables debugging partial build results when the flow fails at any stage

## Test plan
- [ ] Submit a job with `--upload-artifacts` for a design that fails and verify artifacts are saved