### PR TITLE
Add documentation and quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,158 +1,90 @@
 # HighTide
 
-There are two ways to build designs: the **Bazel flow** (recommended) or the legacy **Make flow**.
+A VLSI design benchmark suite that runs open-source hardware designs through the [OpenROAD](https://github.com/The-OpenROAD-Project/OpenROAD) RTL-to-GDSII flow on academic and open-source technology nodes (ASAP7 7nm, NanGate 45nm, SkyWater 130nm).
 
-## Bazel Flow (recommended)
-
-### Prerequisites
-
-- Ubuntu 24.04 (or other Linux distribution supported by ORFS)
-- Docker (used by bazel-orfs to extract OpenROAD tools from the ORFS image)
-
-### Getting Started
-
-1. Install dependencies:
+## Quick Start
 
 ```bash
+# Install Bazel
 sudo apt install perl
 sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
 sudo chmod +x /usr/local/bin/bazel
-```
 
-2. Clone this repository:
-
-```bash
+# Clone and build
 git clone git@github.com:VLSIDA/HighTide.git
 cd HighTide
-```
-
-3. Build a design:
-
-```bash
 bazel build //designs/asap7/lfsr:lfsr_final
 ```
 
-No additional setup is needed. Bazel automatically fetches ORFS and bazel-orfs via `MODULE.bazel`.
+Requires Linux and Docker. Bazel automatically fetches ORFS and tools. See the [Quick Start Guide](docs/quickstart.md) for details.
 
-### Build Commands
+## Designs
+
+| Design | Type | asap7 | nangate45 | sky130hd |
+|--------|------|:-----:|:---------:|:--------:|
+| lfsr | LFSR/PRBS generator | x | x | x |
+| minimax | RISC-V RV32I core | x | x | x |
+| liteeth | Ethernet MAC (6 variants) | x | x | x |
+| NyuziProcessor | Multi-threaded GPGPU | x | x | |
+| bp_processor | Black-Parrot RISC-V (2 variants) | x | x | |
+| gemmini | ML systolic array | x | x | |
+| cnn | CNN accelerator | x | x | |
+| sha3 | SHA3 hash | x | x | |
+
+See the [Design Catalog](docs/designs.md) for the full matrix including variants and complexity.
+
+## Build Commands
 
 ```bash
-# Build a single design (full RTL-to-GDSII flow)
+# Single design, full flow
 bazel build //designs/asap7/lfsr:lfsr_final
 
-# Build all designs for a platform
+# Individual stages (synth, floorplan, place, cts, route, final)
+bazel build //designs/asap7/lfsr:lfsr_synth
+
+# All designs for a platform
 bazel build //designs/asap7/...
 
-# Build all designs across all platforms
+# All designs, all platforms
 bazel build //designs/...
 
-# Build individual stages
-bazel build //designs/asap7/lfsr:lfsr_synth
-bazel build //designs/asap7/lfsr:lfsr_floorplan
-bazel build //designs/asap7/lfsr:lfsr_place
-bazel build //designs/asap7/lfsr:lfsr_cts
-bazel build //designs/asap7/lfsr:lfsr_route
+# View build summary
+./tools/summary.sh
 ```
 
-### RTL Regeneration (Bazel)
+## Fetch Pre-built Results
 
-By default, designs use pre-generated RTL checked into the repository. Some designs use Verilog converted from SystemVerilog via sv2v, while others (e.g., bp_processor) use SystemVerilog directly with the yosys-slang plugin. To regenerate RTL from source repositories:
+Baseline results for all designs are available from a remote cache:
+
+```bash
+./tools/fetch_cache.sh              # all designs
+./tools/fetch_cache.sh asap7 lfsr   # specific design
+```
+
+## Documentation
+
+- **[Quick Start Guide](docs/quickstart.md)** — build your first design in 5 minutes
+- **[Design Catalog](docs/designs.md)** — all designs, platforms, and complexity
+- **[Architecture](docs/architecture.md)** — how the build system, RTL management, and caching work
+- **[Adding Designs](docs/adding-designs.md)** — how to add a new design to the suite
+- **[Kubernetes Builds](k8s/README.md)** — building at scale on NRP Nautilus
+
+## RTL Regeneration
+
+Designs use pre-generated Verilog by default. To regenerate from upstream source:
 
 ```bash
 bazel build --define update_rtl=true //designs/asap7/lfsr:lfsr_final
 ```
 
-This automatically initializes the git submodule and runs the design's generation script.
-Some designs require additional tools (sv2v, sbt, litex) on PATH.
+Some designs require additional tools (sv2v, JDK, Python) on PATH.
 
-### Build Results
+## Legacy Make Flow
 
-Outputs are in `bazel-bin/designs/<platform>/<design>/`:
-- `results/` — ODB and GDS files per stage (`1_synth.odb` through `6_final.gds`)
-- `reports/` — QoR reports per stage (timing, area, DRC)
-- `logs/` — Log files and JSON metrics per stage
-
-To view a summary table of all completed builds:
+The Make flow is still available for designs that have a `config.mk`:
 
 ```bash
-./tools/summary.sh
-```
-
-```
-Platform     Design                      Die Area  Core Area  Inst Area    Util%    Cells   Macr   IOs        WNS        TNS    Fmax(GHz)    Power(mW)   DRCs
-================================================================================================================================================================
-asap7        lfsr                   81.7       47.0       21.8     46.4      205      0    13      56.91       0.00         5.78        0.381      0
-```
-
-## Kubernetes (NRP Nautilus)
-
-Designs can be built at scale on the [NRP Nautilus](https://nationalresearchplatform.org/nautilus/) Kubernetes cluster. See [k8s/README.md](k8s/README.md) for full documentation on submitting jobs, monitoring, and managing builds.
-
-### Fetching Baseline Results
-
-HighTide generates baseline build results for all designs and stores them in a GCS remote cache. Users can fetch these baseline results locally without rebuilding:
-
-```bash
-# Fetch all cached designs
-./tools/fetch_cache.sh
-
-# Fetch all cached asap7 designs
-./tools/fetch_cache.sh asap7
-
-# Fetch a specific design
-./tools/fetch_cache.sh asap7 lfsr
-
-# Fetch only through a specific stage
-./tools/fetch_cache.sh --stage synth asap7
-```
-
-Each design reports whether it was fetched from the remote cache, found locally, or not cached. After fetching, view baseline results with `./tools/summary.sh`.
-
-## Make Flow (legacy)
-
-### Getting Started
-
-1. Clone this repository:
-
-```bash
-git clone git@github.com:VLSIDA/HighTide.git
-cd HighTide
-```
-
-2. Run the setup to clone ORFS as a submodule and link the settings:
-
-```bash
-./setup.sh
-```
-
-3. [Run ORFS](https://vlsida.github.io/chip-tutorials/orfs-installation.html#run-orfs-docker-image) (this will run the Docker image corresponding to our submodule):
-
-```bash
-./runorfs.sh
-```
-
-4. Run a design in the Docker image:
-
-```bash
+./setup.sh                  # init ORFS submodule
+./runorfs.sh                # launch Docker
 make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk
 ```
-
-### Dev RTL Generation (Make)
-
-By default, the suite will run using Verilog that has already been generated from its respective source (just like in ORFS). If the user wishes to amend changes to source files, the command `make update-rtl` should be used.
-- `make update-rtl` will perform the generation of Verilog from the source repo (it will also do any prerequisite installation as well).
-- The development folder for each design can be found under `designs/src/<DESIGN_NAME>/dev`
-
-## Goal/Objectives
-
-GOAL: Port open source designs to asap7/sky130/nangate45 technologies using ORFS, as a benchmark suite for ML projects.
-
-Objective 1: Setup github CI/CD (to work with google cloud compute engine)
-
-Objective 2: Formulate testbenches to verify the functionality of designs post-flow completion.
-
-Objective 3: Expand suite by creating various versions of designs that fail at specific parts of the flow.
-
-## Resources
-
-In order to change (or update) the UCSC_ML_suite repository, you'll need to submit a pull request. For more information on submitting a PR, see [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).

--- a/docs/adding-designs.md
+++ b/docs/adding-designs.md
@@ -1,0 +1,144 @@
+# Adding a New Design
+
+This guide covers adding a new open-source hardware design to the HighTide benchmark suite.
+
+For a fully guided workflow, use the Claude Code skill: `/new-design <design-name> <upstream-repo-url>`
+
+## Overview
+
+Adding a design involves:
+1. Adding the upstream repo as a git submodule
+2. Creating a build script to generate Verilog from the source HDL
+3. Creating platform-specific configuration (SDC, config.mk, BUILD.bazel)
+4. Creating FakeRAM files if the design has embedded memories
+5. Testing the build
+
+## Directory Structure
+
+A fully configured design looks like:
+
+```
+designs/
+├── src/<design>/
+│   ├── <design>.v              # Release RTL (pre-generated)
+│   ├── verilog.mk              # Make-flow RTL selection
+│   ├── BUILD.bazel             # Bazel RTL source definition
+│   └── dev/
+│       ├── repo/               # Git submodule (upstream source)
+│       └── setup.sh            # Build script to generate Verilog
+├── asap7/<design>/
+│   ├── BUILD.bazel             # Bazel flow config
+│   ├── config.mk               # Make flow config
+│   ├── constraint.sdc          # Timing constraints
+│   ├── pdn.tcl                 # (optional) Custom power delivery
+│   ├── io.tcl                  # (optional) Custom pin placement
+│   └── sram/                   # (if memories)
+│       ├── lef/*.lef
+│       └── lib/*.lib
+├── nangate45/<design>/         # Same structure, different params
+└── sky130hd/<design>/          # Same structure, different params
+```
+
+## Step-by-Step
+
+### 1. Add the submodule
+
+```bash
+git submodule add <upstream-url> designs/src/<design>/dev/repo
+```
+
+### 2. Create the build script
+
+`designs/src/<design>/dev/setup.sh` must convert the upstream HDL to plain Verilog. See existing examples:
+
+| Source Language | Reference Script |
+|----------------|-----------------|
+| SystemVerilog | `designs/src/minimax/dev/setup.sh` (sv2v) |
+| Pure Verilog | `designs/src/lfsr/dev/setup.sh` (copy) |
+| Chisel/Scala | `designs/src/gemmini/dev/setup.sh` (JDK + sbt) |
+| LiteX/Python | `designs/src/liteeth/dev/setup.sh` (venv + pip) |
+| Veriloggen | `designs/src/cnn/dev/setup.sh` (venv + pip) |
+
+### 3. Create timing constraints
+
+`designs/<platform>/<design>/constraint.sdc`:
+
+```tcl
+current_design <top_module>
+
+set clk_name  core_clock
+set clk_port_name clk
+set clk_period <period>           # See platform guidance below
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+```
+
+**Clock period guidance:**
+- asap7: 500-1000 ps
+- nangate45: 2-10 ns
+- sky130hd: 10-50 ns
+
+### 4. Create the Bazel build
+
+`designs/<platform>/<design>/BUILD.bazel`:
+
+```python
+load("//:defs.bzl", "hightide_design")
+
+hightide_design(
+    name = "<design>",
+    platform = "<platform>",
+    verilog_files = ["//designs/src/<design>:rtl"],
+    sources = {"SDC_FILE": [":constraint.sdc"]},
+    arguments = {
+        "CORE_UTILIZATION": "40",
+        "TNS_END_PERCENT": "100",
+    },
+)
+```
+
+For designs with FakeRAM, add SRAM sources:
+```python
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": ["//<parent>:sram_lefs"],
+        "ADDITIONAL_LIBS": ["//<parent>:sram_libs"],
+    },
+    arguments = {
+        "CORE_UTILIZATION": "40",
+        "MACRO_PLACE_HALO": "5 5",
+        "TNS_END_PERCENT": "100",
+    },
+```
+
+### 5. Create FakeRAM (if needed)
+
+If the design has large memories (typically >256 bits), create FakeRAM LEF/LIB files. Use existing files from the same platform as templates:
+- Pin names must match the Verilog module interface exactly
+- Metal layer names must match the platform
+- See `designs/src/bp_processor/dev/gen_fakeram.py` for an automated generator
+
+### 6. Test
+
+```bash
+bazel build //designs/<platform>/<design>:<design>_synth   # test synthesis first
+bazel build //designs/<platform>/<design>:<design>_final   # full flow
+```
+
+If the build fails, use `/debug-design <platform>/<design>` to diagnose.
+
+After a successful build, use `/optimize-ppa <platform>/<design>` to tune utilization and clock frequency.
+
+## Porting to Additional Platforms
+
+To add a design that already exists on one platform to another, use `/port-design <design> <source-platform> <target-platform>`. Key considerations:
+
+- Scale clock period proportionally between platforms
+- Create platform-specific FakeRAM files (different metal stacks)
+- Adjust utilization — designs may need lower utilization on larger nodes due to different routing resource ratios

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,107 @@
+# Architecture
+
+HighTide is a VLSI design benchmark suite built on [OpenROAD-flow-scripts (ORFS)](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts). It takes open-source hardware designs through the complete RTL-to-GDSII flow using [OpenROAD](https://github.com/The-OpenROAD-Project/OpenROAD) on academic and open-source technology nodes.
+
+## Build System
+
+HighTide uses [Bazel](https://bazel.build/) with the [bazel-orfs](https://github.com/The-OpenROAD-Project/bazel-orfs) ruleset. Bazel manages dependencies, caching, and build orchestration.
+
+```
+MODULE.bazel          # Declares bazel-orfs dependency and ORFS Docker image
+defs.bzl              # hightide_design() macro wrapping orfs_flow()
+BUILD.bazel           # Root config (update_rtl flag, nangate45 PDK)
+designs/
+├── src/<design>/     # RTL sources (shared across platforms)
+├── asap7/<design>/   # Platform-specific config (BUILD.bazel, constraint.sdc)
+├── nangate45/<design>/
+└── sky130hd/<design>/
+```
+
+### Key Relationships
+
+- **`MODULE.bazel`** declares the `bazel-orfs` dependency (pinned to a specific commit) and the ORFS Docker image (pinned to a specific tag + SHA256). bazel-orfs extracts OpenROAD and Yosys tools from the Docker image at build time.
+
+- **`defs.bzl`** defines `hightide_design()`, a thin wrapper around `orfs_flow()` that sets common defaults like `GDS_ALLOW_EMPTY = fakeram.*` and maps platform names to PDK labels.
+
+- **Each design's `BUILD.bazel`** calls `hightide_design()` with the design-specific parameters (utilization, density, SRAM files, etc.), mirroring what would be in a Make-flow `config.mk`.
+
+### Flow Stages
+
+The ORFS flow runs in 6 stages, each producing an ODB (OpenROAD Database) file:
+
+| Stage | Tool | Output | Description |
+|-------|------|--------|-------------|
+| 1 | Yosys | `1_synth.odb` | RTL synthesis to gate-level netlist |
+| 2 | OpenROAD | `2_floorplan.odb` | Die sizing, IO placement, power grid |
+| 3 | OpenROAD | `3_place.odb` | Global and detailed cell placement |
+| 4 | OpenROAD | `4_cts.odb` | Clock tree synthesis + timing repair |
+| 5 | OpenROAD | `5_route.odb` | Global and detailed routing |
+| 6 | OpenROAD | `6_final.odb/.gds` | Metal fill, GDSII output, final reports |
+
+## RTL Source Management
+
+Design RTL sources live at `designs/src/<design>/`. Each design has:
+
+- **Release RTL** — pre-generated Verilog checked into the repo
+- **Dev RTL** — a git submodule at `dev/repo/` with a `setup.sh` script that generates Verilog from the upstream source
+
+The `select()` mechanism in each design's `BUILD.bazel` switches between release and dev RTL based on the `--define update_rtl=true` flag.
+
+### HDL Conversion Pipeline
+
+| Source Language | Conversion Tool | Examples |
+|----------------|----------------|----------|
+| Verilog | None (direct) | lfsr, sha3 |
+| SystemVerilog | sv2v or yosys-slang | minimax (sv2v), NyuziProcessor (yosys-slang), bp_processor (yosys-slang) |
+| Chisel/Scala | JDK + sbt | gemmini |
+| LiteX/Python | Python venv + LiteX | liteeth |
+| Veriloggen/Python | Python venv + NNgen | cnn |
+
+## Design Configuration
+
+Each platform-specific design directory contains:
+
+| File | Required | Purpose |
+|------|----------|---------|
+| `BUILD.bazel` | Yes | Bazel target definition calling `hightide_design()` |
+| `config.mk` | Yes | Make-flow configuration (kept in sync with BUILD.bazel) |
+| `constraint.sdc` | Yes | Clock definitions and timing constraints |
+| `pdn.tcl` | No | Custom power delivery network (when default causes IR drop) |
+| `io.tcl` | No | Manual pin placement (when auto-placement causes congestion) |
+| `sram/lef/*.lef` | If memories | FakeRAM LEF files for memory macros |
+| `sram/lib/*.lib` | If memories | FakeRAM Liberty files for memory macros |
+| `macros.v` | If memories | Verilog wrapper remapping memory instantiations |
+
+### Key Parameters
+
+| Parameter | Description | Typical Range |
+|-----------|-------------|---------------|
+| `CORE_UTILIZATION` | Target cell density (%) | 35-80% |
+| `PLACE_DENSITY` | Placement density | 0.5-0.85 |
+| `TNS_END_PERCENT` | Timing closure aggressiveness | 100 |
+| `MACRO_PLACE_HALO` | Spacing around macros (um) | 5-8 |
+| `ABC_AREA` | Optimize synthesis for area | 0 or 1 |
+| `SYNTH_HIERARCHICAL` | Hierarchical synthesis | 0 or 1 |
+
+### Clock Period by Platform
+
+| Platform | Typical Range | Units |
+|----------|--------------|-------|
+| asap7 | 100-1000 | picoseconds |
+| nangate45 | 2-10 | nanoseconds |
+| sky130hd | 10-50 | nanoseconds |
+
+## FakeRAM
+
+Designs with embedded memories (register files, SRAMs, caches) use FakeRAM — LEF/LIB placeholder macros that provide physical pin models without internal logic. This allows the physical design flow to place and route around memories without needing actual SRAM compilers.
+
+FakeRAM files are platform-specific (different metal stacks and design rules) and live at `designs/<platform>/<design>/sram/`. The naming convention is `fakeram_<depth>x<width>_<ports>.{lef,lib}` where ports describes the memory type (e.g., `1rw`, `1r1w`, `2r1w`).
+
+The `GDS_ALLOW_EMPTY = fakeram.*` setting in `defs.bzl` tells the GDSII writer to accept empty GDS for FakeRAM macros.
+
+## Remote Cache and Artifacts
+
+- **Remote Bazel cache** — GCS bucket (`gs://hightide-bazel-cache`) stores build outputs for all designs. Local users can fetch baseline results with `./tools/fetch_cache.sh`.
+- **Artifact storage** — The `hightide-artifacts` PVC on Nautilus NRP stores full build outputs (results, reports, logs) from K8s jobs submitted with `--upload-artifacts`. Fetch locally with `./tools/fetch_artifacts.sh`.
+
+See [k8s/README.md](../k8s/README.md) for details on K8s builds and artifact management.

--- a/docs/designs.md
+++ b/docs/designs.md
@@ -1,0 +1,79 @@
+# Design Catalog
+
+HighTide ports open-source hardware designs across three technology platforms using the OpenROAD RTL-to-GDSII flow.
+
+## Platforms
+
+| Platform | Node | Description |
+|----------|------|-------------|
+| **asap7** | 7nm | Academic predictive PDK from ASU |
+| **nangate45** | 45nm | FreePDK with NanGate cell library |
+| **sky130hd** | 130nm | Open-source SkyWater 130nm high-density |
+
+## Design Matrix
+
+| Design | Description | Language | asap7 | nangate45 | sky130hd |
+|--------|-------------|----------|:-----:|:---------:|:--------:|
+| **lfsr** | LFSR/PRBS generator | Verilog | x | x | x |
+| **minimax** | RISC-V RV32I core | SystemVerilog (sv2v) | x | x | x |
+| **liteeth** | Ethernet MAC (6 variants) | LiteX/Python | x | x | x |
+| **NyuziProcessor** | Multi-threaded GPGPU | SystemVerilog (yosys-slang) | x | x | |
+| **bp_processor** | Black-Parrot RISC-V (bp_uno, bp_quad) | SystemVerilog (yosys-slang) | x | x | |
+| **gemmini** | ML systolic array accelerator | Chisel/Scala | x | x | |
+| **cnn** | CNN accelerator | Veriloggen/NNgen/Python | x | x | |
+| **sha3** | SHA3 hash engine | Verilog | x | x | |
+
+### Liteeth Variants
+
+The liteeth design has 6 configuration variants, each a different combination of protocol layer and PHY interface:
+
+| Variant | Protocol | PHY |
+|---------|----------|-----|
+| `liteeth_udp_usp_gth_sgmii` | UDP | USP GTH SGMII |
+| `liteeth_udp_raw_rgmii` | UDP raw | RGMII |
+| `liteeth_udp_stream_rgmii` | UDP stream | RGMII |
+| `liteeth_udp_stream_sgmii` | UDP stream | SGMII |
+| `liteeth_mac_wb_mii` | MAC (Wishbone) | MII |
+| `liteeth_mac_axi_mii` | MAC (AXI) | MII |
+
+### Black-Parrot Variants
+
+| Variant | Description |
+|---------|-------------|
+| `bp_uno` | Single-core BlackParrot |
+| `bp_quad` | Quad-core BlackParrot |
+
+## Design Complexity
+
+Designs range from small (lfsr, ~200 cells) to large (gemmini, bp_quad with thousands of cells and memory macros). Designs with embedded memories use FakeRAM — placeholder LEF/LIB black-box macros that provide pin-accurate physical models without internal logic.
+
+| Design | Approximate Size | Has FakeRAM | Hierarchical Synth |
+|--------|-----------------|:-----------:|:-------------------:|
+| lfsr | Small (~200 cells) | | |
+| minimax | Small (~1K cells) | | |
+| sha3 | Medium (~5K cells) | | |
+| liteeth | Medium (~2-8K cells) | x | |
+| NyuziProcessor | Large (~20K cells) | x | |
+| cnn | Large (~15K cells) | x | |
+| gemmini | Very large (~50K cells) | | |
+| bp_uno | Large (~30K cells) | x | x |
+| bp_quad | Very large (~100K+ cells) | x | x |
+
+## Build Targets
+
+Each design exposes Bazel targets for individual flow stages:
+
+```
+//designs/<platform>/<design>:<design>_synth       # Yosys synthesis
+//designs/<platform>/<design>:<design>_floorplan   # Floorplan + IO + PDN
+//designs/<platform>/<design>:<design>_place       # Global/detailed placement
+//designs/<platform>/<design>:<design>_cts         # Clock tree synthesis
+//designs/<platform>/<design>:<design>_route       # Global/detailed routing
+//designs/<platform>/<design>:<design>_final       # Metal fill + GDSII
+```
+
+For multi-level designs (liteeth, bp_processor), the target path includes the variant:
+```
+//designs/asap7/liteeth/liteeth_mac_wb_mii:liteeth_mac_wb_mii_final
+//designs/asap7/bp_processor/bp_quad:bp_quad_final
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,91 @@
+# Quick Start Guide
+
+Get a HighTide design built in under 5 minutes.
+
+## Prerequisites
+
+- Linux (Ubuntu 24.04 recommended)
+- Docker
+- ~10 GB disk for the ORFS Docker image (pulled automatically)
+
+## Install Bazel
+
+```bash
+sudo apt install perl
+sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+sudo chmod +x /usr/local/bin/bazel
+```
+
+## Clone and Build
+
+```bash
+git clone git@github.com:VLSIDA/HighTide.git
+cd HighTide
+bazel build //designs/asap7/lfsr:lfsr_final
+```
+
+That's it. Bazel fetches ORFS, extracts OpenROAD tools from Docker, and runs the full RTL-to-GDSII flow. The first build takes longer (~5 min for lfsr) as it downloads dependencies; subsequent builds are cached.
+
+## What Just Happened
+
+The LFSR design was synthesized, placed, routed, and finished through the complete ORFS flow on the ASAP7 7nm technology node. Outputs are at:
+
+```
+bazel-bin/designs/asap7/lfsr/
+├── results/asap7/lfsr_prbs_gen/base/
+│   ├── 1_synth.odb          # Synthesized netlist
+│   ├── 2_floorplan.odb      # Floorplanned design
+│   ├── 3_place.odb          # Placed design
+│   ├── 4_cts.odb            # Clock tree synthesized
+│   ├── 5_route.odb          # Routed design
+│   └── 6_final.odb/.gds     # Final layout
+├── reports/                  # Timing, area, DRC reports
+└── logs/                     # Per-stage logs and metrics
+```
+
+## View Build Summary
+
+```bash
+./tools/summary.sh
+```
+
+This prints a table of all completed builds with key metrics (die area, utilization, timing slack, Fmax, power, DRC count).
+
+## Build Other Designs
+
+```bash
+# Individual stages
+bazel build //designs/asap7/lfsr:lfsr_synth       # synthesis only
+bazel build //designs/asap7/lfsr:lfsr_place        # through placement
+
+# Different designs
+bazel build //designs/asap7/minimax:minimax_final  # RISC-V core
+bazel build //designs/asap7/sha3:sha3_final        # SHA3 hash
+
+# Different platforms
+bazel build //designs/nangate45/lfsr:lfsr_final    # 45nm
+bazel build //designs/sky130hd/lfsr:lfsr_final     # 130nm open-source
+
+# All designs for a platform
+bazel build //designs/asap7/...
+
+# Everything
+bazel build //designs/...
+```
+
+## Fetch Pre-built Results
+
+Instead of building locally, you can fetch baseline results from the remote cache:
+
+```bash
+./tools/fetch_cache.sh              # all designs
+./tools/fetch_cache.sh asap7        # all asap7 designs
+./tools/fetch_cache.sh asap7 lfsr   # specific design
+```
+
+## Next Steps
+
+- **[Design catalog](designs.md)** — all designs and their platform coverage
+- **[Architecture](architecture.md)** — how the build system works
+- **[Adding a design](adding-designs.md)** — how to add a new design to the suite
+- **[Kubernetes builds](../k8s/README.md)** — building at scale on NRP Nautilus


### PR DESCRIPTION
## Summary
- Restructure README into a concise entry point with links to detailed docs
- Add docs/quickstart.md — 5-minute build guide
- Add docs/designs.md — full design/platform matrix with variants and complexity
- Add docs/architecture.md — build system, flow stages, RTL management, caching
- Add docs/adding-designs.md — step-by-step for new designs with skill references