### PR TITLE
Refine docs: RTL flow, yosys-slang, streamlined README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ The release RTL is then run through the [OpenROAD-flow-scripts](https://github.c
 - **[Architecture](docs/architecture.md)** — build system, flow stages, RTL management, caching
 - **[Adding Designs](docs/adding-designs.md)** — how to add a new design to the suite
 - **[Kubernetes Builds](k8s/README.md)** — building at scale on NRP Nautilus
+- **[Legacy Make Flow](docs/make-flow.md)** — Docker-based Make flow (still functional)

--- a/README.md
+++ b/README.md
@@ -2,23 +2,11 @@
 
 A VLSI design benchmark suite that runs open-source hardware designs through the [OpenROAD](https://github.com/The-OpenROAD-Project/OpenROAD) RTL-to-GDSII flow on academic and open-source technology nodes (ASAP7 7nm, NanGate 45nm, SkyWater 130nm).
 
-## Quick Start
-
-```bash
-# Install Bazel
-sudo apt install perl
-sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
-sudo chmod +x /usr/local/bin/bazel
-
-# Clone and build
-git clone git@github.com:VLSIDA/HighTide.git
-cd HighTide
-bazel build //designs/asap7/lfsr:lfsr_final
-```
-
-Requires Linux and Docker. Bazel automatically fetches ORFS and tools. See the [Quick Start Guide](docs/quickstart.md) for details.
+**New here?** See the **[Quick Start Guide](docs/quickstart.md)** to build your first design in 5 minutes.
 
 ## Designs
+
+8 designs across 3 technology platforms, ranging from a small LFSR to a quad-core RISC-V processor:
 
 | Design | Type | asap7 | nangate45 | sky130hd |
 |--------|------|:-----:|:---------:|:--------:|
@@ -31,60 +19,22 @@ Requires Linux and Docker. Bazel automatically fetches ORFS and tools. See the [
 | cnn | CNN accelerator | x | x | |
 | sha3 | SHA3 hash | x | x | |
 
-See the [Design Catalog](docs/designs.md) for the full matrix including variants and complexity.
+## How It Works
 
-## Build Commands
+Each design's upstream source lives in a git submodule at `designs/src/<design>/dev/repo/`. A build script converts the source HDL (SystemVerilog, Chisel, LiteX, etc.) into plain Verilog, which is checked into the repo as the **release RTL** at `designs/src/<design>/`. The release RTL may include patches or modifications beyond simple conversion — for example, SRAM memories are replaced with FakeRAM black-box macros so the design can be synthesized without an SRAM compiler. This release RTL is what builds use by default — no submodule checkout or conversion tools needed.
 
-```bash
-# Single design, full flow
-bazel build //designs/asap7/lfsr:lfsr_final
-
-# Individual stages (synth, floorplan, place, cts, route, final)
-bazel build //designs/asap7/lfsr:lfsr_synth
-
-# All designs for a platform
-bazel build //designs/asap7/...
-
-# All designs, all platforms
-bazel build //designs/...
-
-# View build summary
-./tools/summary.sh
-```
-
-## Fetch Pre-built Results
-
-Baseline results for all designs are available from a remote cache:
-
-```bash
-./tools/fetch_cache.sh              # all designs
-./tools/fetch_cache.sh asap7 lfsr   # specific design
-```
-
-## Documentation
-
-- **[Quick Start Guide](docs/quickstart.md)** — build your first design in 5 minutes
-- **[Design Catalog](docs/designs.md)** — all designs, platforms, and complexity
-- **[Architecture](docs/architecture.md)** — how the build system, RTL management, and caching work
-- **[Adding Designs](docs/adding-designs.md)** — how to add a new design to the suite
-- **[Kubernetes Builds](k8s/README.md)** — building at scale on NRP Nautilus
-
-## RTL Regeneration
-
-Designs use pre-generated Verilog by default. To regenerate from upstream source:
+To regenerate RTL from the upstream source (e.g., after updating the submodule to a newer commit):
 
 ```bash
 bazel build --define update_rtl=true //designs/asap7/lfsr:lfsr_final
 ```
 
-Some designs require additional tools (sv2v, JDK, Python) on PATH.
+The release RTL is then run through the [OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts) RTL-to-GDSII flow: synthesis (Yosys) → floorplan → placement → clock tree synthesis → routing → GDSII output. Each design has per-platform configuration (clock constraints, utilization targets, pin placement) tuned for the target technology node.
 
-## Legacy Make Flow
+## Documentation
 
-The Make flow is still available for designs that have a `config.mk`:
-
-```bash
-./setup.sh                  # init ORFS submodule
-./runorfs.sh                # launch Docker
-make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk
-```
+- **[Quick Start Guide](docs/quickstart.md)** — install, build, and view results
+- **[Design Catalog](docs/designs.md)** — all designs, platforms, variants, and complexity
+- **[Architecture](docs/architecture.md)** — build system, flow stages, RTL management, caching
+- **[Adding Designs](docs/adding-designs.md)** — how to add a new design to the suite
+- **[Kubernetes Builds](k8s/README.md)** — building at scale on NRP Nautilus

--- a/docs/adding-designs.md
+++ b/docs/adding-designs.md
@@ -51,13 +51,36 @@ git submodule add <upstream-url> designs/src/<design>/dev/repo
 
 `designs/src/<design>/dev/setup.sh` must convert the upstream HDL to plain Verilog. See existing examples:
 
-| Source Language | Reference Script |
-|----------------|-----------------|
-| SystemVerilog | `designs/src/minimax/dev/setup.sh` (sv2v) |
-| Pure Verilog | `designs/src/lfsr/dev/setup.sh` (copy) |
-| Chisel/Scala | `designs/src/gemmini/dev/setup.sh` (JDK + sbt) |
-| LiteX/Python | `designs/src/liteeth/dev/setup.sh` (venv + pip) |
-| Veriloggen | `designs/src/cnn/dev/setup.sh` (venv + pip) |
+| Source Language | Approach | Reference |
+|----------------|----------|-----------|
+| Pure Verilog | Direct (no conversion) | `designs/src/lfsr/dev/setup.sh` |
+| SystemVerilog | **yosys-slang** (preferred) — synthesize SV directly | `designs/src/bp_processor/` |
+| SystemVerilog | sv2v — convert to Verilog first | `designs/src/minimax/dev/setup.sh` |
+| Chisel/Scala | JDK + sbt to generate Verilog | `designs/src/gemmini/dev/setup.sh` |
+| LiteX/Python | Python venv + LiteX | `designs/src/liteeth/dev/setup.sh` |
+| Veriloggen | Python venv + NNgen | `designs/src/cnn/dev/setup.sh` |
+
+#### Using yosys-slang for SystemVerilog
+
+For SystemVerilog designs, **yosys-slang is preferred over sv2v** because it handles parameter elaboration natively and avoids the sv2v conversion step. To use it:
+
+1. The `setup.sh` parses the upstream file list and include paths (no Verilog conversion needed)
+2. Set `"SYNTH_HDL_FRONTEND": "slang"` in the BUILD.bazel arguments
+3. Pass include directories via `"VERILOG_INCLUDE_DIRS": "<space-separated paths>"`
+4. Pass defines via `"VERILOG_DEFINES": "-D YOSYS"` (or other defines the design needs)
+
+See `designs/src/bp_processor/defs.bzl` for a complete example:
+```python
+BP_COMMON_ARGS = {
+    "SYNTH_HDL_FRONTEND": "slang",
+    "VERILOG_DEFINES": "-D YOSYS",
+    "VERILOG_INCLUDE_DIRS": BP_INCLUDE_DIRS_STR,
+    "SYNTH_HIERARCHICAL": "1",
+    ...
+}
+```
+
+The `setup.sh` for bp_processor (`designs/src/bp_processor/dev/setup.sh`) shows how to parse an upstream `flist.vcs` file list into the format needed by Bazel — it extracts source files and include directories without any HDL conversion.
 
 ### 3. Create timing constraints
 

--- a/docs/make-flow.md
+++ b/docs/make-flow.md
@@ -1,0 +1,99 @@
+# Legacy Make Flow
+
+The original HighTide build flow uses GNU Make and Docker. It is still functional but the **Bazel flow is recommended** for new work — see the [Quick Start Guide](quickstart.md).
+
+## Setup
+
+```bash
+# Clone the repo
+git clone git@github.com:VLSIDA/HighTide.git
+cd HighTide
+
+# Initialize the ORFS submodule and create symlinks
+./setup.sh
+```
+
+This clones OpenROAD-flow-scripts as a submodule and creates symlinks (`scripts/`, `util/`, `platforms/`) pointing into it.
+
+## Running a Build
+
+Launch the Docker container, then run Make inside it:
+
+```bash
+# Interactive (with terminal)
+./runorfs.sh
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk
+
+# Non-interactive (for scripting / CI)
+./runorfs_ni.sh make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk
+```
+
+The Docker image tag is extracted from `MODULE.bazel` to stay in sync with the Bazel flow.
+
+## Individual Stages
+
+```bash
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk do-synth       # Yosys synthesis
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk do-floorplan   # Floorplan + IO + PDN
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk do-place       # Global/detailed placement
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk do-cts         # Clock tree synthesis
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk do-route       # Global/detailed routing
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk do-finish      # Metal fill + GDSII
+```
+
+## Output Directories
+
+Build artifacts are organized by platform, design, and variant:
+
+```
+logs/<platform>/<design>/base/       # Per-stage log files
+objects/<platform>/<design>/base/    # Intermediate objects
+reports/<platform>/<design>/base/    # QoR reports (timing, area, DRC)
+results/<platform>/<design>/base/    # ODB and GDS files per stage
+```
+
+This layout is controlled by `settings.mk`, which overrides ORFS defaults.
+
+## RTL Regeneration
+
+To regenerate Verilog from the upstream source repository:
+
+```bash
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk update-rtl
+```
+
+This initializes the git submodule, runs the design's `setup.sh` to generate Verilog, then resumes the flow from the last completed stage.
+
+## Cleanup
+
+```bash
+# Remove dev-generated sources
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk clean_design
+
+# Full cleanup (sources + build artifacts)
+make DESIGN_CONFIG=./designs/asap7/lfsr/config.mk clean_all
+```
+
+## Design Configuration
+
+Each design's Make-flow configuration is in `designs/<platform>/<design>/config.mk`. This file sets:
+
+- `DESIGN_NAME`, `PLATFORM` — design identity
+- `VERILOG_FILES` — RTL sources (via `-include verilog.mk`)
+- `SDC_FILE` — timing constraints
+- `CORE_UTILIZATION`, `PLACE_DENSITY` — physical design parameters
+- `ADDITIONAL_LEFS`, `ADDITIONAL_LIBS` — FakeRAM files (if applicable)
+- `PDN_TCL`, `IO_CONSTRAINTS`, `FOOTPRINT_TCL` — custom physical design scripts
+
+The config.mk parameters mirror those in the Bazel BUILD.bazel files. Both are kept in sync so either flow can be used.
+
+## Differences from Bazel Flow
+
+| Aspect | Make Flow | Bazel Flow |
+|--------|-----------|------------|
+| Dependencies | Manual (`./setup.sh` + Docker) | Automatic (Bazel fetches everything) |
+| Caching | None (rebuild from scratch) | Remote + local Bazel cache |
+| Parallelism | One design at a time | Multiple designs in parallel |
+| Tool extraction | Docker container at runtime | OCI layer extraction at build time |
+| K8s support | No | Yes (`k8s/run.sh`) |
+| Config file | `config.mk` | `BUILD.bazel` |


### PR DESCRIPTION
## Summary
- Streamline README to project overview with RTL flow explanation and doc links
- Add yosys-slang example to adding-designs.md (preferred over sv2v for SystemVerilog)
- Add docs/make-flow.md covering the legacy Docker-based Make flow
- Explain release RTL may include patches (e.g., FakeRAM SRAM replacements)