### PR TITLE
Fix NyuziProcessor asap7: SDC bugs and CTS-0105 clock tree skip

### DIFF
--- a/designs/asap7/NyuziProcessor/BUILD.bazel
+++ b/designs/asap7/NyuziProcessor/BUILD.bazel
@@ -18,6 +18,7 @@ hightide_design(
         "SDC_FILE": [":constraint.sdc"],
         "ADDITIONAL_LEFS": [":sram_lefs"],
         "ADDITIONAL_LIBS": [":sram_libs"],
+        "PRE_CTS_TCL": [":pre_cts.tcl"],
     },
     arguments = {
         "SYNTH_HIERARCHICAL": "1",

--- a/designs/asap7/NyuziProcessor/constraint.sdc
+++ b/designs/asap7/NyuziProcessor/constraint.sdc
@@ -5,8 +5,7 @@ set clk_io_pct 0.2
 
 create_clock -name clk -period $clk_period [get_ports clk]
 
-set non_clock_inputs [remove_from_collection [all_inputs] [get_ports clk]]
-set_input_delay  [expr $clk_period * $clk_io_pct] -clock clk $non_clock_inputs
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock clk [all_inputs -no_clocks]
 set_output_delay [expr $clk_period * $clk_io_pct] -clock clk [all_outputs]
 
 set_false_path -from [get_ports reset]

--- a/designs/asap7/NyuziProcessor/constraint.sdc
+++ b/designs/asap7/NyuziProcessor/constraint.sdc
@@ -1,18 +1,12 @@
 current_design NyuziProcessor
 
-set clk_name  clk
-set clk_port_name clk
 set clk_period 1600
 set clk_io_pct 0.2
 
-set clk_port [get_ports $clk_port_name]
+create_clock -name clk -period $clk_period [get_ports clk]
 
-create_clock -name $clk_name -period $clk_period $clk_port
-
-set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name [lsearch -inline -all -regexp [all_inputs]]
-
-set outputs [lsearch -inline -all-regexp [all_outputs]]
-
-set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [lsearch -inline -all -exact $outputs $clk_name]
+set non_clock_inputs [remove_from_collection [all_inputs] [get_ports clk]]
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock clk $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock clk [all_outputs]
 
 set_false_path -from [get_ports reset]

--- a/designs/asap7/NyuziProcessor/pre_cts.tcl
+++ b/designs/asap7/NyuziProcessor/pre_cts.tcl
@@ -1,0 +1,18 @@
+# Workaround for OpenROAD CTS-0105 false skip.
+# https://github.com/The-OpenROAD-Project/OpenROAD/issues/10177
+#
+# Yosys hierarchical synthesis output port buffers arrive with
+# dbSourceType::TIMING, causing CTS to mistake them for pre-existing
+# clock tree buffers and skip the clock net. Reset them to NETLIST
+# so CTS builds the tree.
+
+set block [[[ord::get_db] getChip] getBlock]
+set count 0
+foreach inst [$block getInsts] {
+    if {[string match "output*" [$inst getName]] &&
+        [$inst getSourceType] == "TIMING"} {
+        $inst setSourceType NETLIST
+        incr count
+    }
+}
+puts "PRE_CTS workaround: reset $count output buffer(s) from TIMING to NETLIST"


### PR DESCRIPTION
## Summary

- Fix broken `set_output_delay` in NyuziProcessor SDC — the old `lsearch` expression matched nothing, so no output paths were constrained
- Use `all_inputs -no_clocks` (OpenSTA-supported) instead of `remove_from_collection`
- Work around OpenROAD CTS-0105 false skip ([OpenROAD #10177](https://github.com/The-OpenROAD-Project/OpenROAD/issues/10177)): the resizer's `buffer_ports` inserts a `TIMING`-sourced buffer on the `clk→m_aclk` output path, causing CTS to mistake it for a pre-existing clock tree buffer and skip the entire clock net — leaving 41k flops unbuffered

## Results

Before: CTS inserted 0 buffers, post-GRT clock skew of 377 ns on a 1.6 ns clock, design unroutable (ground to a halt in detailed routing after 22+ hours)

After:

| Metric | Value |
|--------|-------|
| Setup WNS | +94.86 ps (clean) |
| Hold WNS | +1.94 ps (clean) |
| Fmax | 687.9 MHz (target 625 MHz) |
| CTS buffers | 9 |
| Utilization | 55.97% |

## Test plan

- [x] Verified CTS workaround on minimal reproducer (8-flop design with `assign clk_out = clk`)
- [x] Full NyuziProcessor asap7 build completed on NRP Nautilus — zero timing violations