### PR TITLE
Rename stale HighTide2 references to HighTide

### DIFF
--- a/.claude/skills/debug-design/SKILL.md
+++ b/.claude/skills/debug-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug-design
-description: Analyze and debug a failing HighTide2 design. Diagnose synthesis problems, memory inference issues, congestion, timing violations, and placement/routing failures. Can generate layout images for visual diagnosis.
+description: Analyze and debug a failing HighTide design. Diagnose synthesis problems, memory inference issues, congestion, timing violations, and placement/routing failures. Can generate layout images for visual diagnosis.
 argument-hint: "<platform>/<design> [stage] [issue-description]"
 ---
 

--- a/.claude/skills/find-designs/SKILL.md
+++ b/.claude/skills/find-designs/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: find-designs
-description: Search for new open-source hardware designs that would be good candidates for the HighTide2 benchmark suite and open GitHub issues to propose them.
+description: Search for new open-source hardware designs that would be good candidates for the HighTide benchmark suite and open GitHub issues to propose them.
 argument-hint: "[optional: category or keyword to focus on, e.g. 'processors', 'accelerators', 'peripherals']"
 ---
 
 # Find New Benchmark Designs
 
-Search for interesting open-source hardware designs that would be good additions to the HighTide2 benchmark suite, then open GitHub issues to propose adding them.
+Search for interesting open-source hardware designs that would be good additions to the HighTide benchmark suite, then open GitHub issues to propose adding them.
 
 ## Selection Criteria
 

--- a/.claude/skills/improve-skills/SKILL.md
+++ b/.claude/skills/improve-skills/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: improve-skills
-description: Review past experiences from debugging, optimization, porting, and design work, then update existing HighTide2 skills or propose new ones. Use after completing a session that revealed new patterns, workarounds, or failure modes.
+description: Review past experiences from debugging, optimization, porting, and design work, then update existing HighTide skills or propose new ones. Use after completing a session that revealed new patterns, workarounds, or failure modes.
 argument-hint: "[optional: skill-name to focus on, or 'all' to audit everything]"
 ---
 
 # Improve Skills from Experience
 
-Review recent work and update the HighTide2 skills to capture new knowledge. This prevents the team from rediscovering the same solutions.
+Review recent work and update the HighTide skills to capture new knowledge. This prevents the team from rediscovering the same solutions.
 
 ## Step 1: Gather Recent Experience
 

--- a/.claude/skills/new-design/SKILL.md
+++ b/.claude/skills/new-design/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: new-design
-description: Incorporate a new open-source hardware design into the HighTide2 benchmark suite. Use when adding a design that doesn't exist yet in the project.
+description: Incorporate a new open-source hardware design into the HighTide benchmark suite. Use when adding a design that doesn't exist yet in the project.
 argument-hint: "[design-name] [upstream-repo-url]"
 ---
 
 # Incorporate a New Design
 
-You are adding a new design called `$0` from upstream repository `$1` into the HighTide2 benchmark suite.
+You are adding a new design called `$0` from upstream repository `$1` into the HighTide benchmark suite.
 
 ## Step-by-step Process
 

--- a/.claude/skills/optimize-ppa/SKILL.md
+++ b/.claude/skills/optimize-ppa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimize-ppa
-description: Optimize power, performance, and area (PPA) for a HighTide2 design. Maximize cell utilization and clock frequency while maintaining a clean flow (no DRC violations).
+description: Optimize power, performance, and area (PPA) for a HighTide design. Maximize cell utilization and clock frequency while maintaining a clean flow (no DRC violations).
 argument-hint: "<platform>/<design>"
 ---
 

--- a/.claude/skills/port-design/SKILL.md
+++ b/.claude/skills/port-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: port-design
-description: Port an existing HighTide2 design from one technology platform to another (e.g., asap7 to nangate45 or sky130hd). Use when a design exists for one platform and needs to be added to another.
+description: Port an existing HighTide design from one technology platform to another (e.g., asap7 to nangate45 or sky130hd). Use when a design exists for one platform and needs to be added to another.
 argument-hint: "[design-name] [source-platform] [target-platform]"
 ---
 

--- a/.claude/skills/update-design/SKILL.md
+++ b/.claude/skills/update-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-design
-description: Check for upstream updates to existing HighTide2 designs and tools, summarize what changed, and apply updates. Use when a design needs to be refreshed, or with no arguments to audit all designs for available updates.
+description: Check for upstream updates to existing HighTide designs and tools, summarize what changed, and apply updates. Use when a design needs to be refreshed, or with no arguments to audit all designs for available updates.
 argument-hint: "[design-name or 'all'] [platform]"
 ---
 
@@ -80,7 +80,7 @@ Let the user decide which updates to apply. Small changes that don't affect RTL 
    cd designs/src/$0/dev/repo
    git fetch origin
    git checkout <new-commit-or-tag>
-   cd /home/mrg/HighTide2
+   cd /home/mrg/HighTide
    ```
 
 2. **Check if `setup.sh` needs changes:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-HighTide2 is a VLSI design benchmark suite built on OpenROAD-flow-scripts (ORFS). It ports open-source hardware designs to asap7/sky130hd/nangate45 technologies using the OpenROAD RTL-to-GDSII flow, serving as a benchmark suite for ML projects.
+HighTide is a VLSI design benchmark suite built on OpenROAD-flow-scripts (ORFS). It ports open-source hardware designs to asap7/sky130hd/nangate45 technologies using the OpenROAD RTL-to-GDSII flow, serving as a benchmark suite for ML projects.
 
 ## Setup
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-"""HighTide2 module — uses bazel-orfs with OpenROAD extracted from the
+"""HighTide module — uses bazel-orfs with OpenROAD extracted from the
 ORFS Docker image (zero-source OpenROAD build).
 
 Mirrors the bazel-orfs test/docker/MODULE.bazel pattern.

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,4 +1,4 @@
-"""Shared Starlark helpers for HighTide2 design definitions."""
+"""Shared Starlark helpers for HighTide design definitions."""
 
 load("@bazel-orfs//:openroad.bzl", "orfs_flow")
 
@@ -10,7 +10,7 @@ PDKS = {
 }
 
 def hightide_design(name, platform, verilog_files, top = None, arguments = {}, sources = {}, **kwargs):
-    """Wraps orfs_flow with HighTide2 defaults.
+    """Wraps orfs_flow with HighTide defaults.
 
     Automatically sets GDS_ALLOW_EMPTY for FakeRAM and maps platform
     names to PDK labels.


### PR DESCRIPTION
## Summary

The repo name, branch names, K8s job prefixes (`<user>-hightide-<platform>-<design>`), and CI workflows all use **HighTide**. A few files still referred to the project as **HighTide2** — sweep those out so the name is consistent.

Touches 10 files, 15 occurrences: \`CLAUDE.md\`, \`MODULE.bazel\`, \`defs.bzl\`, and 7 \`.claude/skills/*/SKILL.md\` files. Mechanical \`sed\` replacement; no semantic changes.

## Test plan

- [x] \`grep -r HighTide2\` → 0 matches
- [x] Diff reviewed — only the identifier \`HighTide2\` replaced, no other text altered