### PR TITLE
Bump yosys-slang to eabdfd1 to fix vortex interface-array modport driver bug

### DIFF
--- a/yosys_slang.bzl
+++ b/yosys_slang.bzl
@@ -12,7 +12,7 @@ def _yosys_slang_impl(_module_ctx):
     new_git_repository(
         name = "yosys-slang",
         remote = "https://github.com/povik/yosys-slang.git",
-        commit = "4e53d772996184b07e9bfe784060f96e6cb0a267",
+        commit = "eabdfd1b836f08047de64dca93c286f2a935d68a",
         init_submodules = True,
         build_file = Label("//:yosys_slang.BUILD.bazel"),
     )


### PR DESCRIPTION
## Summary
- Bumps the yosys-slang pin in \`yosys_slang.bzl\` from \`4e53d77\` to \`eabdfd1\` to pick up upstream povik/yosys-slang#300 (\"Fix interface output port undriven detection in nested --keep-hierarchy\", merged 2026-04-22).
- Restores asap7 vortex synthesis, which regressed when #71 switched from the docker-extracted yosys-slang (effectively commit \`64b44616\`) to source-built \`4e53d77\`.
- No other changes.

## Background
yosys-slang \`4e53d77\` inserts a spurious constant \`1'x\` driver on every output-direction bit of each interface-array modport port that is driven by a child cell via a single-element array-slice connection (or by a local genvar-loop assign to \`arr[i].<bit>\`). The extra driver wins at \`opt_clean\`, silently dropping the real driver; a downstream \`hierarchy -check\` on the reloaded RTLIL then errors with \`Output port ... connected to constants: 1'x\`.

On vortex this yielded ~8,000 \"Driver-driver conflict\" warnings and a fatal error at \`1_2_yosys\`:

\`\`\`
ERROR: Output port VX_alu_unit...dispatch_unit.dispatch_if[0].ready (VX_dispatch_unit) is connected to constants: 1'x
\`\`\`

Bisect (against a 60-line minimal reproducer) pinpointed the first bad commit as upstream \`712830f\` \"Redo undriven variable detection\" (2026-02-02). Reported at povik/yosys-slang#304. The fix at \`eabdfd1\` calls \`netlist.register_driven(port)\` for Out/InOut modport ports in the \`scopes_remap\` branch so the real driver is credited before \`finalize_variable_initialization\` runs.

## Test plan
- [x] Minimal reproducer: yosys-slang \`4e53d77\` → 18 driver-driver warnings; yosys-slang \`eabdfd1\` → 0 warnings.
- [ ] Full \`//designs/asap7/vortex:vortex_final\` build on NRP Nautilus (job \`mrg-hightide-asap7-vortex\` submitted on the \`vortex\` branch with \`--upload-artifacts\`).
- [ ] Spot-check other bazel designs are unaffected (pin change is tiny, but the remote cache will pick up fresh synthesis results for all slang-frontend designs).