### PR TITLE
liteeth_udp_stream_sgmii: work around OpenROAD ODB-1200 in CTS hold-repair

### DIFF
--- a/designs/asap7/liteeth/liteeth_udp_stream_sgmii/BUILD.bazel
+++ b/designs/asap7/liteeth/liteeth_udp_stream_sgmii/BUILD.bazel
@@ -14,5 +14,16 @@ hightide_design(
         "CORE_UTILIZATION": "40",
         "PLACE_DENSITY": "0.3",
         "MACRO_PLACE_HALO": "5 5",
+        # Workaround for OpenROAD ODB-1200 crash in post-CTS hold-repair
+        # (tested at OR 5f1bd87f, bazel-orfs pin from PR #71). The new
+        # RSZ-0100 move sequence (UnbufferMove first) orphans a load pin
+        # during repair, then a later InsertBufferBeforeLoads pass trips
+        # an ODB consistency check (cts.tcl:82, ODB-1200). Fires
+        # deterministically on this netlist at iter ~141 of a 346-
+        # endpoint hold-violation sweep. Skipping CTS repair_timing
+        # bypasses it; downstream GRT/route still do their own hold
+        # fixes. Remove once upstream OpenROAD is patched — tracked in
+        # https://github.com/VLSIDA/HighTide/issues/75.
+        "SKIP_CTS_REPAIR_TIMING": "1",
     },
 )

--- a/designs/asap7/liteeth/liteeth_udp_stream_sgmii/constraint.sdc
+++ b/designs/asap7/liteeth/liteeth_udp_stream_sgmii/constraint.sdc
@@ -11,5 +11,12 @@ create_clock -name $clk_name -period $clk_period $clk_port
 
 set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
 
-set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs 
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
 set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+# sys_reset is an async reset input synchronized internally by
+# udpcore_int_rst; don't time the port-to-synchronizer path.
+set _rst_ports [get_ports -quiet sys_reset]
+if { [llength $_rst_ports] } {
+    set_false_path -from $_rst_ports
+}


### PR DESCRIPTION
## Summary

- Set `SKIP_CTS_REPAIR_TIMING=1` on `designs/asap7/liteeth/liteeth_udp_stream_sgmii` to bypass a deterministic OpenROAD crash in post-CTS hold-repair (tested at OR commit `5f1bd87f`, bazel-orfs pin from #71).
- Add a principled `set_false_path -from [get_ports sys_reset]` to the SDC (async reset input synchronized internally; port-to-synchronizer path shouldn't be timed).
- Tracking re-enable: #75.

## The bug

```
[INFO RSZ-0100] Repair move sequence: UnbufferMove SizeUpMove SwapPinsMove BufferMove CloneMove SplitLoadMove
[INFO RSZ-0098] No setup violations found
[INFO RSZ-0046] Found 347 endpoints with hold violations.
...
[ERROR ODB-1200] InsertBufferBeforeLoads: Load pin '_34829_/SN' is not connected to net '_03825_'.
Error: cts.tcl, 82 ODB-1200
```

The new RSZ-0100 move sequence (UnbufferMove first) orphans a load pin, then a later `InsertBufferBeforeLoads` pass trips an ODB consistency check. Fires at iter ~141 of a 347-endpoint hold-violation sweep. Bit-for-bit reproducible across runs.

Workarounds I tried and ruled out (see #75 and commit message for details):
- `set_dont_touch` on reset net pattern — no-op (name didn't survive Yosys flat-synth).
- `set_false_path` on reset cone — `RSZ-0046` dropped only 347 → 346; the 346 other violations are datapath, not reset.

`SKIP_CTS_REPAIR_TIMING=1` is the only thing that works. Downstream GRT and route still run their own hold-repair passes.

## Test plan

- [x] `./k8s/run.sh --branch liteeth --upload-artifacts asap7 liteeth_udp_stream_sgmii` — full k8s flow now completes end-to-end (41% util, 14886 µm², clean `6_final.gds` on asap7).
- [ ] Post-merge: other liteeth variants continue to pass (expected; this change is scoped to one BUILD.bazel + SDC).