### PR TITLE
Lower coralnpu asap7 CORE_UTILIZATION 50→40 to fix PSM VSS connectivity

### DIFF
--- a/designs/asap7/coralnpu/BUILD.bazel
+++ b/designs/asap7/coralnpu/BUILD.bazel
@@ -22,7 +22,7 @@ hightide_design(
     },
     arguments = {
         "SYNTH_HIERARCHICAL": "1",
-        "CORE_UTILIZATION": "50",
+        "CORE_UTILIZATION": "40",
         "PLACE_DENSITY_LB_ADDON": "0.20",
         "MACRO_PLACE_HALO": "6 6",
         "TNS_END_PERCENT": "100",

--- a/designs/asap7/coralnpu/config.mk
+++ b/designs/asap7/coralnpu/config.mk
@@ -9,7 +9,7 @@ export SYNTH_HIERARCHICAL = 1
 
 export SDC_FILE      = $(BENCH_DESIGN_HOME)/$(PLATFORM)/coralnpu/constraint.sdc
 
-export CORE_UTILIZATION = 50
+export CORE_UTILIZATION = 40
 export PLACE_DENSITY_LB_ADDON = 0.20
 
 export MACRO_PLACE_HALO    = 6 6


### PR DESCRIPTION
## Summary
- RTLMP placed the two 104×43 µm FakeRAM macros (itcm/dtcm) flush against the left and right core edges at the original `CORE_UTILIZATION=50`, leaving only a 5.97 µm sliver between each macro and the core boundary.
- The default asap7 PDN (`grid_strategy-M1-M2-M5-M6.tcl`, M5 pitch 5.4 µm) only fit one M5 stripe pair in each sliver, and PDN-0195 removed all M2→M5 vias for that pair across the macro Y range.
- M1/M2 VSS follow-pin rails in the slivers were left unconnected, causing PSM-0069 to fail at 6_final with thousands of unconnected M1 shapes on VSS.
- Dropping `CORE_UTILIZATION` to 40 gives RTLMP enough die area to keep macros away from the core boundary, so the default PDN connects cleanly.

## Test plan
- [x] `bazel build //designs/asap7/coralnpu:coralnpu_final` on Nautilus (mrg-hightide-asap7-coralnpu) completes through 6_final
- [x] `VSS.rpt` and `VDD.rpt` are empty (no PSM connectivity violations)
- [x] `5_route_drc.rpt` is empty (no DRC violations)
- [x] Timing closes: tns=0, wns=0, fmax=333.6 MHz (target 333.3 MHz @ 3 ns)