### PR TITLE
Fix asap7/gemmini routing: interleave right-edge pin order

### DIFF
--- a/designs/asap7/gemmini/io.tcl
+++ b/designs/asap7/gemmini/io.tcl
@@ -140,17 +140,23 @@ set left_pins [concat \
     [bus_pins io_in_d 8] \
 ]
 
-# RIGHT (512 pins): in_b(8b x 32), in_valid(1b x 32), in_last(1b x 32),
-#   in_id(2b x 32), out_valid(1b x 32), out_id(2b x 32), out_last(1b x 32)
-set right_pins [concat \
-    [bus_pins io_in_b 8] \
-    [bus_pins io_in_valid 1] \
-    [bus_pins io_in_last 1] \
-    [bus_pins io_in_id 2] \
-    [bus_pins io_out_valid 1] \
-    [bus_pins io_out_id 2] \
-    [bus_pins io_out_last 1] \
-]
+# RIGHT (512 pins): interleave by mesh row (i, j) so high-fanout control
+# signals (io_in_id, io_out_id, io_in_valid/last, io_out_valid/last) are
+# spread along the full edge instead of clustered in the vertical middle.
+# Each row contributes 16 pins:
+#   in_b[8], in_valid, in_last, in_id[2], out_valid, out_id[2], out_last.
+set right_pins {}
+for {set i 0} {$i < 16} {incr i} {
+    for {set j 0} {$j < 2} {incr j} {
+        foreach p [expand_port "io_in_b_${i}_${j}"  8] { lappend right_pins $p }
+        foreach p [expand_port "io_in_valid_${i}_${j}"  1] { lappend right_pins $p }
+        foreach p [expand_port "io_in_last_${i}_${j}"   1] { lappend right_pins $p }
+        foreach p [expand_port "io_in_id_${i}_${j}"     2] { lappend right_pins $p }
+        foreach p [expand_port "io_out_valid_${i}_${j}" 1] { lappend right_pins $p }
+        foreach p [expand_port "io_out_id_${i}_${j}"    2] { lappend right_pins $p }
+        foreach p [expand_port "io_out_last_${i}_${j}"  1] { lappend right_pins $p }
+    }
+}
 
 # TOP (866 pins): out_b(20b x 32), in_control(7b x 32), clock, reset
 set top_pins [concat \


### PR DESCRIPTION
## Summary
- Right-edge IO pins are now interleaved by mesh row `(i, j)` instead of grouped by signal type — each of the 32 rows contributes its 16 pins (`in_b[8]`, `in_valid`, `in_last`, `in_id[2]`, `out_valid`, `out_id[2]`, `out_last`) contiguously.
- Same 512 pins, no utilization or floorplan changes.

## Why
The previous layout grouped all `io_in_id`, `io_out_valid`, `io_out_id`, `io_in_last`, `io_out_last` pins (the high-fanout broadcast signals) into a narrow ~55 µm vertical band in the middle of the right edge. GRT failed with `[ERROR GRT-0116] Global routing finished with congestion` and **1674 congestion violations clustered in x=430–440 µm, y=260–340 µm** — exactly where those pins landed on M4.

Overall routing utilization was only 15.48 % across M2–M7; the failure was purely localized pin-access congestion. Spreading the broadcast bits across the full 441 µm right edge (one set per mesh row) eliminates the hotspot.

## Validation
Built `//designs/asap7/gemmini:gemmini_final` end-to-end on Nautilus NRP:

| Stage | Result |
|---|---|
| 5_1_grt | clean (no GRT-0116) |
| 5_2_route | `Found 0 net violations`, `Found 0 pin violations` (antenna), elapsed 3 h 38 m |
| 6_final | 1.09 GB ODB, design area 73 986 µm² @ 38 % util, 1.7 M instances |

## Test plan
- [x] `bazel build //designs/asap7/gemmini:gemmini_final` (run on Nautilus job `mrg-hightide-asap7-gemmini-xptvf`, completed successfully)
- [x] Verify `5_2_route.odb` produced with 0 antenna violations
- [x] Verify `6_final.odb` produced