### PR TITLE
Add sky130hd gemmini port

### DIFF
--- a/designs/sky130hd/gemmini/BUILD.bazel
+++ b/designs/sky130hd/gemmini/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//:defs.bzl", "hightide_design")
+
+hightide_design(
+    name = "gemmini",
+    platform = "sky130hd",
+    verilog_files = ["//designs/src/gemmini:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+    },
+    arguments = {
+        "CORE_UTILIZATION": "30",
+    },
+)

--- a/designs/sky130hd/gemmini/config.mk
+++ b/designs/sky130hd/gemmini/config.mk
@@ -1,0 +1,8 @@
+export DESIGN_NAME = gemmini
+export PLATFORM    = sky130hd
+
+-include $(BENCH_DESIGN_HOME)/src/$(DESIGN_NAME)/verilog.mk
+
+export SDC_FILE      = $(BENCH_DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
+
+export CORE_UTILIZATION = 30

--- a/designs/sky130hd/gemmini/constraint.sdc
+++ b/designs/sky130hd/gemmini/constraint.sdc
@@ -1,0 +1,15 @@
+current_design gemmini
+
+set clk_name  clk
+set clk_port_name clock
+set clk_period 10
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]


### PR DESCRIPTION
## Summary
- New `designs/sky130hd/gemmini/` mirroring the minimal nangate45 config (constraint.sdc, config.mk, BUILD.bazel)
- Clock period **10 ns** (calibrated from cross-platform `lfsr` 10.2× and `minimax` 10.0× sky130hd/asap7 ratios; gemmini's asap7 SDC is 1.0 ns)
- `CORE_UTILIZATION = 30` (lowered slightly from asap7's 35% — gemmini was tight at 35% on asap7 even after the io.tcl pin-interleaving fix)
- No custom `io.tcl`/`pdn.tcl` yet; the larger sky130hd geometry has plenty of routing margin (see validation)

## Validation
Built `//designs/sky130hd/gemmini:gemmini_final` end-to-end on Nautilus NRP (`mrg-hightide-sky130hd-gemmini-gqxvz`):

| Stage | Result |
|---|---|
| 5_1_grt | clean (no GRT-0116) |
| 5_2_route | detail route complete in **1h 41m**, 2 net + 2 pin antenna violations remaining post-repair |
| 6_final | 1.00 GB ODB, design area **4,913,720 µm² @ 34% util** (~14.4 mm²) |

Job ended with `SuccessCriteriaMet`; final ODB sealed.

## Comparison across platforms

| Platform | Detail-route | Final area | Util | Antenna |
|---|---|---|---|---|
| asap7 | 3h 38m | 73,986 µm² | 38% | 0 / 0 |
| nangate45 | 17m 44s | 933,583 µm² | 36% | 0 / 0 |
| sky130hd | 1h 41m | 4,913,720 µm² | 34% | 2 / 2 |

The 2 residual antenna violations on sky130hd are minor and don't block the flow — they could be cleaned up in a follow-up by tuning `ANTENNA_FIXING_*` or adding diodes. Out of scope for the initial port.

## Test plan
- [x] `bazel build //designs/sky130hd/gemmini:gemmini_final` (Nautilus job, succeeded)
- [x] Verify `6_final.odb` produced (1.00 GB)
- [x] Verify detail routing completes (1h 41m elapsed)