### PR TITLE
CLAUDE.md: fix Bazel target docs to match hightide_design() output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,13 @@ No additional setup needed — Bazel fetches ORFS and bazel-orfs automatically v
 ### Bazel Flow (recommended)
 
 ```bash
-# Build a single design (full flow + stage images)
-bazel build //designs/asap7/lfsr:lfsr
-
-# Build just the RTL-to-GDS flow without images
+# Build the full RTL-to-GDS flow for one design
 bazel build //designs/asap7/lfsr:lfsr_final
+
+# Build a design across all available platforms
+bazel build //designs/asap7/minimax:minimax_final \
+            //designs/nangate45/minimax:minimax_final \
+            //designs/sky130hd/minimax:minimax_final
 
 # Build all designs for a platform
 bazel build //designs/asap7/...
@@ -43,16 +45,14 @@ bazel build //designs/asap7/...
 bazel build //designs/...
 
 # Build with dev RTL generation (requires submodule init + tools)
-bazel build --define update_rtl=true //designs/asap7/lfsr:lfsr
+bazel build --define update_rtl=true //designs/asap7/lfsr:lfsr_final
 
 # Build individual stages (target suffixes: _synth, _floorplan, _place, _cts, _grt, _route, _final)
 bazel build //designs/asap7/lfsr:lfsr_synth
 bazel build //designs/asap7/lfsr:lfsr_place
-
-# Build stage images (placement + density heatmap per stage)
-bazel build //designs/asap7/lfsr:lfsr_place_images     # single stage
-bazel build //designs/asap7/lfsr:lfsr_images           # all stages
 ```
+
+Note: `hightide_design()` exposes only the per-stage `orfs_flow` targets (`_synth` … `_final`) plus `_generate_abstract` / `_generate_metadata`. There is no aggregate `:<design>` target — use `:<design>_final` for the full flow.
 
 ### Make Flow (legacy)
 
@@ -91,9 +91,8 @@ make DESIGN_CONFIG=... clean_all      # Full cleanup
 ### Key Relationships (Bazel Flow)
 
 - **`MODULE.bazel`** — Declares dependencies on `bazel-orfs` (via `git_override`) and configures the ORFS Docker image for tool extraction
-- **`defs.bzl`** — `hightide_design()` macro wrapping `orfs_flow()` with common defaults (`GDS_ALLOW_EMPTY`, platform-to-PDK mapping, per-stage image generation)
-- **`tools/save_stage_image.tcl`** — TCL script that generates placement and density heatmap images via OpenROAD's headless GUI; used by `orfs_run` targets created by `hightide_design()`
-- **`BUILD.bazel`** (root) — Defines `//:update_rtl` config setting and nangate45 `orfs_pdk` (not in ORFS's defaults)
+- **`defs.bzl`** — `hightide_design()` macro wrapping `orfs_flow()` with common defaults (`GDS_ALLOW_EMPTY`, platform-to-PDK mapping)
+- **`BUILD.bazel`** (root) — Defines `//:update_rtl` config setting and the `merge_yosys_share` target that bundles the yosys-slang plugin
 - Each design has a `BUILD.bazel` calling `hightide_design()` with parameters mirroring its `config.mk`
 - RTL sources at `designs/src/<design>/BUILD.bazel` use `select()` to switch between release and dev RTL
 
@@ -139,11 +138,10 @@ Dev mode requires: `git submodule update --init designs/src/<design>/dev/repo` b
 - `reports/.../` — QoR reports per stage
 
 **Bazel flow:** Build artifacts go to `bazel-bin/designs/<platform>/<design>/`. Key outputs:
-- `<design>_final` — Final GDS, ODB, and reports
-- `<design>_<stage>_placement.webp` — Layout image after each stage (floorplan, place, cts, grt, route)
-- `<design>_<stage>_density.webp` — Placement density heatmap after each stage
-- `<design>` — Builds full flow + all stage images (default target)
-- `<design>_images` — All stage images only
+- `results/<platform>/<design>/base/6_final.{odb,v,sdc,spef}` — Final ODB and netlist (and `6_final.gds` when `GDS_ALLOW_EMPTY` is not suppressing GDS write)
+- `results/<platform>/<design>/base/<N>_<stage>.{odb,sdc,...}` — Per-stage outputs (1_synth, 2_floorplan, 3_place, 4_cts, 5_1_grt, 5_2_route, 6_final)
+- `reports/<platform>/<design>/base/` — QoR and OpenROAD-generated `.webp.png` heatmaps/placement images written by ORFS's own report stage
+- `logs/<platform>/<design>/base/` — Per-stage logs
 
 ### FakeRAM
 


### PR DESCRIPTION
## Summary
- Drop references to non-existent Bazel targets (`:<design>`, `:<design>_images`, `:<design>_<stage>_images`) and the never-added `tools/save_stage_image.tcl` script.
- Document the real per-stage `orfs_flow` targets emitted by `hightide_design()` (`_synth` … `_final`) and add a cross-platform minimax build example.
- Replace the stale claim that the root `BUILD.bazel` defines a nangate45 `orfs_pdk` (it ships upstream in ORFS now); document `merge_yosys_share` instead.
- Rewrite the Bazel output-directories section to describe what's actually written under `bazel-bin/designs/<platform>/<design>/{results,reports,logs}/`.

## Test plan
- [x] `bazel build //designs/asap7/minimax:minimax_final //designs/nangate45/minimax:minimax_final //designs/sky130hd/minimax:minimax_final` — all three platforms build (mostly remote-cache hits; 34 actions ran locally).
- [x] `bazel query //designs/asap7/lfsr:*` confirms only `_synth`/`_floorplan`/`_place`/`_cts`/`_grt`/`_route`/`_final`/`_generate_*` targets exist — no `:lfsr` / `:lfsr_images`.