### PR TITLE
Add sky130hd sha3 port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Dev mode requires: `git submodule update --init designs/src/<design>/dev/repo` b
 |----------|------|---------|
 | asap7 | 7nm academic | gemmini, minimax, cnn, sha3, lfsr, NyuziProcessor, bp_processor/bp_uno/bp_quad, liteeth (6 variants), snitch_cluster, floonoc |
 | nangate45 | 45nm | minimax, lfsr, NyuziProcessor, liteeth (6 variants) |
-| sky130hd | 130nm open | minimax, lfsr, liteeth (6 variants) |
+| sky130hd | 130nm open | minimax, lfsr, sha3, liteeth (6 variants) |
 
 ### Output Directories
 

--- a/designs/sky130hd/sha3/BUILD.bazel
+++ b/designs/sky130hd/sha3/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//:defs.bzl", "hightide_design")
+
+hightide_design(
+    name = "sha3",
+    platform = "sky130hd",
+    verilog_files = ["//designs/src/sha3:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+    },
+    arguments = {
+        "CORE_UTILIZATION": "25",
+        "PLACE_DENSITY_LB_ADDON": "0.20",
+    },
+)

--- a/designs/sky130hd/sha3/config.mk
+++ b/designs/sky130hd/sha3/config.mk
@@ -1,0 +1,10 @@
+export DESIGN_NAME = sha3
+export PLATFORM    = sky130hd
+
+-include $(BENCH_DESIGN_HOME)/src/$(DESIGN_NAME)/verilog.mk
+
+export SDC_FILE      = $(BENCH_DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
+
+export CORE_UTILIZATION = 25
+
+export PLACE_DENSITY_LB_ADDON = 0.20

--- a/designs/sky130hd/sha3/constraint.sdc
+++ b/designs/sky130hd/sha3/constraint.sdc
@@ -1,0 +1,15 @@
+current_design sha3
+
+set clk_name  clk
+set clk_port_name clock
+set clk_period 10
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]


### PR DESCRIPTION
## Summary
- Ports the existing sha3 design to the sky130hd platform alongside its asap7 and nangate45 ports.
- 10 ns clock period (scaled from nangate45's 2.5 ns based on the lfsr/minimax sky130hd-vs-nangate45 ratios) and `CORE_UTILIZATION=25` with `PLACE_DENSITY_LB_ADDON=0.20`. An initial 35% utilization hit GRT-0116 congestion on the wide combinational keccak datapath; 25% routes cleanly.
- Updates CLAUDE.md's platform table to list sha3 under sky130hd.

## Test plan
- [x] \`bazel build //designs/sky130hd/sha3:sha3_synth\` — passes
- [x] \`bazel build //designs/sky130hd/sha3:sha3_final\` — passes; 0 DRCs, WNS/TNS 0, worst slack +0.76 ns, fmax ≈ 108 MHz, 0 setup/hold/slew/fanout/cap violations
- [x] \`bazel build //designs/asap7/sha3:sha3_final //designs/nangate45/sha3:sha3_final\` — both still pass (cache hits)