### PR TITLE
Add coralnpu (CoreMiniAxi) on nangate45

### DIFF
--- a/designs/nangate45/coralnpu/BUILD.bazel
+++ b/designs/nangate45/coralnpu/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//:defs.bzl", "hightide_design")
+
+filegroup(
+    name = "sram_lefs",
+    srcs = glob(["sram/lef/*.lef"]),
+)
+
+filegroup(
+    name = "sram_libs",
+    srcs = glob(["sram/lib/*.lib"]),
+)
+
+hightide_design(
+    name = "coralnpu",
+    platform = "nangate45",
+    top = "CoreMiniAxi",
+    verilog_files = ["//designs/src/coralnpu:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": [":sram_lefs"],
+        "ADDITIONAL_LIBS": [":sram_libs"],
+    },
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "CORE_UTILIZATION": "40",
+        "PLACE_DENSITY_LB_ADDON": "0.20",
+        "MACRO_PLACE_HALO": "40 40",
+        "TNS_END_PERCENT": "100",
+    },
+)

--- a/designs/nangate45/coralnpu/config.mk
+++ b/designs/nangate45/coralnpu/config.mk
@@ -1,0 +1,17 @@
+export DESIGN_NAME = CoreMiniAxi
+export PLATFORM    = nangate45
+export DESIGN_NICKNAME = coralnpu
+export DESIGN_RESULTS_NAME = coralnpu
+
+-include $(BENCH_DESIGN_HOME)/src/coralnpu/verilog.mk
+
+export SYNTH_HIERARCHICAL = 1
+
+export SDC_FILE      = $(BENCH_DESIGN_HOME)/$(PLATFORM)/coralnpu/constraint.sdc
+
+export CORE_UTILIZATION = 40
+export PLACE_DENSITY_LB_ADDON = 0.20
+
+export MACRO_PLACE_HALO    = 40 40
+
+export TNS_END_PERCENT     = 100

--- a/designs/nangate45/coralnpu/constraint.sdc
+++ b/designs/nangate45/coralnpu/constraint.sdc
@@ -1,0 +1,18 @@
+current_design CoreMiniAxi
+
+set clk_name  io_aclk
+set clk_port_name io_aclk
+set clk_period 9
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set non_clock_outputs [lsearch -inline -all -not -exact [all_outputs] $clk_port]
+
+set_input_delay [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_false_path -from [get_ports io_aresetn]

--- a/designs/nangate45/coralnpu/sram/lef/fakeram_2048x128_1rw.lef
+++ b/designs/nangate45/coralnpu/sram/lef/fakeram_2048x128_1rw.lef
@@ -1,0 +1,3056 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_2048x128_1rw
+  FOREIGN fakeram_2048x128_1rw 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 418.760 BY 499.800 ;
+  CLASS BLOCK ;
+  PIN rw0_wmask_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 0.805 0.210 0.875 ;
+    END
+  END rw0_wmask_in[0]
+  PIN rw0_wmask_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 7.805 0.210 7.875 ;
+    END
+  END rw0_wmask_in[1]
+  PIN rw0_wmask_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 14.805 0.210 14.875 ;
+    END
+  END rw0_wmask_in[2]
+  PIN rw0_wmask_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 21.805 0.210 21.875 ;
+    END
+  END rw0_wmask_in[3]
+  PIN rw0_wmask_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 0.805 418.760 0.875 ;
+    END
+  END rw0_wmask_in[4]
+  PIN rw0_wmask_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 7.805 418.760 7.875 ;
+    END
+  END rw0_wmask_in[5]
+  PIN rw0_wmask_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 14.805 418.760 14.875 ;
+    END
+  END rw0_wmask_in[6]
+  PIN rw0_wmask_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 21.805 418.760 21.875 ;
+    END
+  END rw0_wmask_in[7]
+  PIN rw0_wmask_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 1.105 499.590 1.175 499.800 ;
+    END
+  END rw0_wmask_in[8]
+  PIN rw0_wmask_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 4.145 499.590 4.215 499.800 ;
+    END
+  END rw0_wmask_in[9]
+  PIN rw0_wmask_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 7.185 499.590 7.255 499.800 ;
+    END
+  END rw0_wmask_in[10]
+  PIN rw0_wmask_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 10.225 499.590 10.295 499.800 ;
+    END
+  END rw0_wmask_in[11]
+  PIN rw0_wmask_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 13.265 499.590 13.335 499.800 ;
+    END
+  END rw0_wmask_in[12]
+  PIN rw0_wmask_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 16.305 499.590 16.375 499.800 ;
+    END
+  END rw0_wmask_in[13]
+  PIN rw0_wmask_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 19.345 499.590 19.415 499.800 ;
+    END
+  END rw0_wmask_in[14]
+  PIN rw0_wmask_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 22.385 499.590 22.455 499.800 ;
+    END
+  END rw0_wmask_in[15]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 28.805 0.210 28.875 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 35.805 0.210 35.875 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 42.805 0.210 42.875 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 49.805 0.210 49.875 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 56.805 0.210 56.875 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 63.805 0.210 63.875 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 70.805 0.210 70.875 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 77.805 0.210 77.875 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 84.805 0.210 84.875 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 91.805 0.210 91.875 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 98.805 0.210 98.875 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 105.805 0.210 105.875 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 112.805 0.210 112.875 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 119.805 0.210 119.875 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 126.805 0.210 126.875 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 133.805 0.210 133.875 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 140.805 0.210 140.875 ;
+    END
+  END rw0_wd_in[16]
+  PIN rw0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 147.805 0.210 147.875 ;
+    END
+  END rw0_wd_in[17]
+  PIN rw0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 154.805 0.210 154.875 ;
+    END
+  END rw0_wd_in[18]
+  PIN rw0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 161.805 0.210 161.875 ;
+    END
+  END rw0_wd_in[19]
+  PIN rw0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 168.805 0.210 168.875 ;
+    END
+  END rw0_wd_in[20]
+  PIN rw0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 175.805 0.210 175.875 ;
+    END
+  END rw0_wd_in[21]
+  PIN rw0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 182.805 0.210 182.875 ;
+    END
+  END rw0_wd_in[22]
+  PIN rw0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 189.805 0.210 189.875 ;
+    END
+  END rw0_wd_in[23]
+  PIN rw0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 196.805 0.210 196.875 ;
+    END
+  END rw0_wd_in[24]
+  PIN rw0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 203.805 0.210 203.875 ;
+    END
+  END rw0_wd_in[25]
+  PIN rw0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 210.805 0.210 210.875 ;
+    END
+  END rw0_wd_in[26]
+  PIN rw0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 217.805 0.210 217.875 ;
+    END
+  END rw0_wd_in[27]
+  PIN rw0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 224.805 0.210 224.875 ;
+    END
+  END rw0_wd_in[28]
+  PIN rw0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 231.805 0.210 231.875 ;
+    END
+  END rw0_wd_in[29]
+  PIN rw0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 238.805 0.210 238.875 ;
+    END
+  END rw0_wd_in[30]
+  PIN rw0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 245.805 0.210 245.875 ;
+    END
+  END rw0_wd_in[31]
+  PIN rw0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 28.805 418.760 28.875 ;
+    END
+  END rw0_wd_in[32]
+  PIN rw0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 35.805 418.760 35.875 ;
+    END
+  END rw0_wd_in[33]
+  PIN rw0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 42.805 418.760 42.875 ;
+    END
+  END rw0_wd_in[34]
+  PIN rw0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 49.805 418.760 49.875 ;
+    END
+  END rw0_wd_in[35]
+  PIN rw0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 56.805 418.760 56.875 ;
+    END
+  END rw0_wd_in[36]
+  PIN rw0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 63.805 418.760 63.875 ;
+    END
+  END rw0_wd_in[37]
+  PIN rw0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 70.805 418.760 70.875 ;
+    END
+  END rw0_wd_in[38]
+  PIN rw0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 77.805 418.760 77.875 ;
+    END
+  END rw0_wd_in[39]
+  PIN rw0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 84.805 418.760 84.875 ;
+    END
+  END rw0_wd_in[40]
+  PIN rw0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 91.805 418.760 91.875 ;
+    END
+  END rw0_wd_in[41]
+  PIN rw0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 98.805 418.760 98.875 ;
+    END
+  END rw0_wd_in[42]
+  PIN rw0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 105.805 418.760 105.875 ;
+    END
+  END rw0_wd_in[43]
+  PIN rw0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 112.805 418.760 112.875 ;
+    END
+  END rw0_wd_in[44]
+  PIN rw0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 119.805 418.760 119.875 ;
+    END
+  END rw0_wd_in[45]
+  PIN rw0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 126.805 418.760 126.875 ;
+    END
+  END rw0_wd_in[46]
+  PIN rw0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 133.805 418.760 133.875 ;
+    END
+  END rw0_wd_in[47]
+  PIN rw0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 140.805 418.760 140.875 ;
+    END
+  END rw0_wd_in[48]
+  PIN rw0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 147.805 418.760 147.875 ;
+    END
+  END rw0_wd_in[49]
+  PIN rw0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 154.805 418.760 154.875 ;
+    END
+  END rw0_wd_in[50]
+  PIN rw0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 161.805 418.760 161.875 ;
+    END
+  END rw0_wd_in[51]
+  PIN rw0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 168.805 418.760 168.875 ;
+    END
+  END rw0_wd_in[52]
+  PIN rw0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 175.805 418.760 175.875 ;
+    END
+  END rw0_wd_in[53]
+  PIN rw0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 182.805 418.760 182.875 ;
+    END
+  END rw0_wd_in[54]
+  PIN rw0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 189.805 418.760 189.875 ;
+    END
+  END rw0_wd_in[55]
+  PIN rw0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 196.805 418.760 196.875 ;
+    END
+  END rw0_wd_in[56]
+  PIN rw0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 203.805 418.760 203.875 ;
+    END
+  END rw0_wd_in[57]
+  PIN rw0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 210.805 418.760 210.875 ;
+    END
+  END rw0_wd_in[58]
+  PIN rw0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 217.805 418.760 217.875 ;
+    END
+  END rw0_wd_in[59]
+  PIN rw0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 224.805 418.760 224.875 ;
+    END
+  END rw0_wd_in[60]
+  PIN rw0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 231.805 418.760 231.875 ;
+    END
+  END rw0_wd_in[61]
+  PIN rw0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 238.805 418.760 238.875 ;
+    END
+  END rw0_wd_in[62]
+  PIN rw0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 245.805 418.760 245.875 ;
+    END
+  END rw0_wd_in[63]
+  PIN rw0_wd_in[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 1.105 0.000 1.175 0.210 ;
+    END
+  END rw0_wd_in[64]
+  PIN rw0_wd_in[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 4.335 0.000 4.405 0.210 ;
+    END
+  END rw0_wd_in[65]
+  PIN rw0_wd_in[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 7.565 0.000 7.635 0.210 ;
+    END
+  END rw0_wd_in[66]
+  PIN rw0_wd_in[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 10.795 0.000 10.865 0.210 ;
+    END
+  END rw0_wd_in[67]
+  PIN rw0_wd_in[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 14.025 0.000 14.095 0.210 ;
+    END
+  END rw0_wd_in[68]
+  PIN rw0_wd_in[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 17.255 0.000 17.325 0.210 ;
+    END
+  END rw0_wd_in[69]
+  PIN rw0_wd_in[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 20.485 0.000 20.555 0.210 ;
+    END
+  END rw0_wd_in[70]
+  PIN rw0_wd_in[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 23.715 0.000 23.785 0.210 ;
+    END
+  END rw0_wd_in[71]
+  PIN rw0_wd_in[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 26.945 0.000 27.015 0.210 ;
+    END
+  END rw0_wd_in[72]
+  PIN rw0_wd_in[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 30.175 0.000 30.245 0.210 ;
+    END
+  END rw0_wd_in[73]
+  PIN rw0_wd_in[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 33.405 0.000 33.475 0.210 ;
+    END
+  END rw0_wd_in[74]
+  PIN rw0_wd_in[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 36.635 0.000 36.705 0.210 ;
+    END
+  END rw0_wd_in[75]
+  PIN rw0_wd_in[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 39.865 0.000 39.935 0.210 ;
+    END
+  END rw0_wd_in[76]
+  PIN rw0_wd_in[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 43.095 0.000 43.165 0.210 ;
+    END
+  END rw0_wd_in[77]
+  PIN rw0_wd_in[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 46.325 0.000 46.395 0.210 ;
+    END
+  END rw0_wd_in[78]
+  PIN rw0_wd_in[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 49.555 0.000 49.625 0.210 ;
+    END
+  END rw0_wd_in[79]
+  PIN rw0_wd_in[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 52.785 0.000 52.855 0.210 ;
+    END
+  END rw0_wd_in[80]
+  PIN rw0_wd_in[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 56.015 0.000 56.085 0.210 ;
+    END
+  END rw0_wd_in[81]
+  PIN rw0_wd_in[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 59.245 0.000 59.315 0.210 ;
+    END
+  END rw0_wd_in[82]
+  PIN rw0_wd_in[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 62.475 0.000 62.545 0.210 ;
+    END
+  END rw0_wd_in[83]
+  PIN rw0_wd_in[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 65.705 0.000 65.775 0.210 ;
+    END
+  END rw0_wd_in[84]
+  PIN rw0_wd_in[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 68.935 0.000 69.005 0.210 ;
+    END
+  END rw0_wd_in[85]
+  PIN rw0_wd_in[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 72.165 0.000 72.235 0.210 ;
+    END
+  END rw0_wd_in[86]
+  PIN rw0_wd_in[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 75.395 0.000 75.465 0.210 ;
+    END
+  END rw0_wd_in[87]
+  PIN rw0_wd_in[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 78.625 0.000 78.695 0.210 ;
+    END
+  END rw0_wd_in[88]
+  PIN rw0_wd_in[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 81.855 0.000 81.925 0.210 ;
+    END
+  END rw0_wd_in[89]
+  PIN rw0_wd_in[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 85.085 0.000 85.155 0.210 ;
+    END
+  END rw0_wd_in[90]
+  PIN rw0_wd_in[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 88.315 0.000 88.385 0.210 ;
+    END
+  END rw0_wd_in[91]
+  PIN rw0_wd_in[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 91.545 0.000 91.615 0.210 ;
+    END
+  END rw0_wd_in[92]
+  PIN rw0_wd_in[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 94.775 0.000 94.845 0.210 ;
+    END
+  END rw0_wd_in[93]
+  PIN rw0_wd_in[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 98.005 0.000 98.075 0.210 ;
+    END
+  END rw0_wd_in[94]
+  PIN rw0_wd_in[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 101.235 0.000 101.305 0.210 ;
+    END
+  END rw0_wd_in[95]
+  PIN rw0_wd_in[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 104.465 0.000 104.535 0.210 ;
+    END
+  END rw0_wd_in[96]
+  PIN rw0_wd_in[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 107.695 0.000 107.765 0.210 ;
+    END
+  END rw0_wd_in[97]
+  PIN rw0_wd_in[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 110.925 0.000 110.995 0.210 ;
+    END
+  END rw0_wd_in[98]
+  PIN rw0_wd_in[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 114.155 0.000 114.225 0.210 ;
+    END
+  END rw0_wd_in[99]
+  PIN rw0_wd_in[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 117.385 0.000 117.455 0.210 ;
+    END
+  END rw0_wd_in[100]
+  PIN rw0_wd_in[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 120.615 0.000 120.685 0.210 ;
+    END
+  END rw0_wd_in[101]
+  PIN rw0_wd_in[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 123.845 0.000 123.915 0.210 ;
+    END
+  END rw0_wd_in[102]
+  PIN rw0_wd_in[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 127.075 0.000 127.145 0.210 ;
+    END
+  END rw0_wd_in[103]
+  PIN rw0_wd_in[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 130.305 0.000 130.375 0.210 ;
+    END
+  END rw0_wd_in[104]
+  PIN rw0_wd_in[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 133.535 0.000 133.605 0.210 ;
+    END
+  END rw0_wd_in[105]
+  PIN rw0_wd_in[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 136.765 0.000 136.835 0.210 ;
+    END
+  END rw0_wd_in[106]
+  PIN rw0_wd_in[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 139.995 0.000 140.065 0.210 ;
+    END
+  END rw0_wd_in[107]
+  PIN rw0_wd_in[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 143.225 0.000 143.295 0.210 ;
+    END
+  END rw0_wd_in[108]
+  PIN rw0_wd_in[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 146.455 0.000 146.525 0.210 ;
+    END
+  END rw0_wd_in[109]
+  PIN rw0_wd_in[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 149.685 0.000 149.755 0.210 ;
+    END
+  END rw0_wd_in[110]
+  PIN rw0_wd_in[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 152.915 0.000 152.985 0.210 ;
+    END
+  END rw0_wd_in[111]
+  PIN rw0_wd_in[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 156.145 0.000 156.215 0.210 ;
+    END
+  END rw0_wd_in[112]
+  PIN rw0_wd_in[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 159.375 0.000 159.445 0.210 ;
+    END
+  END rw0_wd_in[113]
+  PIN rw0_wd_in[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 162.605 0.000 162.675 0.210 ;
+    END
+  END rw0_wd_in[114]
+  PIN rw0_wd_in[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 165.835 0.000 165.905 0.210 ;
+    END
+  END rw0_wd_in[115]
+  PIN rw0_wd_in[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 169.065 0.000 169.135 0.210 ;
+    END
+  END rw0_wd_in[116]
+  PIN rw0_wd_in[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 172.295 0.000 172.365 0.210 ;
+    END
+  END rw0_wd_in[117]
+  PIN rw0_wd_in[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 175.525 0.000 175.595 0.210 ;
+    END
+  END rw0_wd_in[118]
+  PIN rw0_wd_in[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 178.755 0.000 178.825 0.210 ;
+    END
+  END rw0_wd_in[119]
+  PIN rw0_wd_in[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 181.985 0.000 182.055 0.210 ;
+    END
+  END rw0_wd_in[120]
+  PIN rw0_wd_in[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 185.215 0.000 185.285 0.210 ;
+    END
+  END rw0_wd_in[121]
+  PIN rw0_wd_in[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 188.445 0.000 188.515 0.210 ;
+    END
+  END rw0_wd_in[122]
+  PIN rw0_wd_in[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 191.675 0.000 191.745 0.210 ;
+    END
+  END rw0_wd_in[123]
+  PIN rw0_wd_in[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 194.905 0.000 194.975 0.210 ;
+    END
+  END rw0_wd_in[124]
+  PIN rw0_wd_in[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 198.135 0.000 198.205 0.210 ;
+    END
+  END rw0_wd_in[125]
+  PIN rw0_wd_in[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 201.365 0.000 201.435 0.210 ;
+    END
+  END rw0_wd_in[126]
+  PIN rw0_wd_in[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 204.595 0.000 204.665 0.210 ;
+    END
+  END rw0_wd_in[127]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 207.825 0.000 207.895 0.210 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 211.055 0.000 211.125 0.210 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 214.285 0.000 214.355 0.210 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 217.515 0.000 217.585 0.210 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 220.745 0.000 220.815 0.210 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 223.975 0.000 224.045 0.210 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 227.205 0.000 227.275 0.210 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 230.435 0.000 230.505 0.210 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 233.665 0.000 233.735 0.210 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 236.895 0.000 236.965 0.210 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 240.125 0.000 240.195 0.210 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 243.355 0.000 243.425 0.210 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 246.585 0.000 246.655 0.210 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.815 0.000 249.885 0.210 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 253.045 0.000 253.115 0.210 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 256.275 0.000 256.345 0.210 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 259.505 0.000 259.575 0.210 ;
+    END
+  END rw0_rd_out[16]
+  PIN rw0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 262.735 0.000 262.805 0.210 ;
+    END
+  END rw0_rd_out[17]
+  PIN rw0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 265.965 0.000 266.035 0.210 ;
+    END
+  END rw0_rd_out[18]
+  PIN rw0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 269.195 0.000 269.265 0.210 ;
+    END
+  END rw0_rd_out[19]
+  PIN rw0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 272.425 0.000 272.495 0.210 ;
+    END
+  END rw0_rd_out[20]
+  PIN rw0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 275.655 0.000 275.725 0.210 ;
+    END
+  END rw0_rd_out[21]
+  PIN rw0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 278.885 0.000 278.955 0.210 ;
+    END
+  END rw0_rd_out[22]
+  PIN rw0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 282.115 0.000 282.185 0.210 ;
+    END
+  END rw0_rd_out[23]
+  PIN rw0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 285.345 0.000 285.415 0.210 ;
+    END
+  END rw0_rd_out[24]
+  PIN rw0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 288.575 0.000 288.645 0.210 ;
+    END
+  END rw0_rd_out[25]
+  PIN rw0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 291.805 0.000 291.875 0.210 ;
+    END
+  END rw0_rd_out[26]
+  PIN rw0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 295.035 0.000 295.105 0.210 ;
+    END
+  END rw0_rd_out[27]
+  PIN rw0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 298.265 0.000 298.335 0.210 ;
+    END
+  END rw0_rd_out[28]
+  PIN rw0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 301.495 0.000 301.565 0.210 ;
+    END
+  END rw0_rd_out[29]
+  PIN rw0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 304.725 0.000 304.795 0.210 ;
+    END
+  END rw0_rd_out[30]
+  PIN rw0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 307.955 0.000 308.025 0.210 ;
+    END
+  END rw0_rd_out[31]
+  PIN rw0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 311.185 0.000 311.255 0.210 ;
+    END
+  END rw0_rd_out[32]
+  PIN rw0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 314.415 0.000 314.485 0.210 ;
+    END
+  END rw0_rd_out[33]
+  PIN rw0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 317.645 0.000 317.715 0.210 ;
+    END
+  END rw0_rd_out[34]
+  PIN rw0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 320.875 0.000 320.945 0.210 ;
+    END
+  END rw0_rd_out[35]
+  PIN rw0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 324.105 0.000 324.175 0.210 ;
+    END
+  END rw0_rd_out[36]
+  PIN rw0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 327.335 0.000 327.405 0.210 ;
+    END
+  END rw0_rd_out[37]
+  PIN rw0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 330.565 0.000 330.635 0.210 ;
+    END
+  END rw0_rd_out[38]
+  PIN rw0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 333.795 0.000 333.865 0.210 ;
+    END
+  END rw0_rd_out[39]
+  PIN rw0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 337.025 0.000 337.095 0.210 ;
+    END
+  END rw0_rd_out[40]
+  PIN rw0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 340.255 0.000 340.325 0.210 ;
+    END
+  END rw0_rd_out[41]
+  PIN rw0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 343.485 0.000 343.555 0.210 ;
+    END
+  END rw0_rd_out[42]
+  PIN rw0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 346.715 0.000 346.785 0.210 ;
+    END
+  END rw0_rd_out[43]
+  PIN rw0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 349.945 0.000 350.015 0.210 ;
+    END
+  END rw0_rd_out[44]
+  PIN rw0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 353.175 0.000 353.245 0.210 ;
+    END
+  END rw0_rd_out[45]
+  PIN rw0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 356.405 0.000 356.475 0.210 ;
+    END
+  END rw0_rd_out[46]
+  PIN rw0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 359.635 0.000 359.705 0.210 ;
+    END
+  END rw0_rd_out[47]
+  PIN rw0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 362.865 0.000 362.935 0.210 ;
+    END
+  END rw0_rd_out[48]
+  PIN rw0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 366.095 0.000 366.165 0.210 ;
+    END
+  END rw0_rd_out[49]
+  PIN rw0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 369.325 0.000 369.395 0.210 ;
+    END
+  END rw0_rd_out[50]
+  PIN rw0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 372.555 0.000 372.625 0.210 ;
+    END
+  END rw0_rd_out[51]
+  PIN rw0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 375.785 0.000 375.855 0.210 ;
+    END
+  END rw0_rd_out[52]
+  PIN rw0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 379.015 0.000 379.085 0.210 ;
+    END
+  END rw0_rd_out[53]
+  PIN rw0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 382.245 0.000 382.315 0.210 ;
+    END
+  END rw0_rd_out[54]
+  PIN rw0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 385.475 0.000 385.545 0.210 ;
+    END
+  END rw0_rd_out[55]
+  PIN rw0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 388.705 0.000 388.775 0.210 ;
+    END
+  END rw0_rd_out[56]
+  PIN rw0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 391.935 0.000 392.005 0.210 ;
+    END
+  END rw0_rd_out[57]
+  PIN rw0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 395.165 0.000 395.235 0.210 ;
+    END
+  END rw0_rd_out[58]
+  PIN rw0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 398.395 0.000 398.465 0.210 ;
+    END
+  END rw0_rd_out[59]
+  PIN rw0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 401.625 0.000 401.695 0.210 ;
+    END
+  END rw0_rd_out[60]
+  PIN rw0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 404.855 0.000 404.925 0.210 ;
+    END
+  END rw0_rd_out[61]
+  PIN rw0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 408.085 0.000 408.155 0.210 ;
+    END
+  END rw0_rd_out[62]
+  PIN rw0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 411.315 0.000 411.385 0.210 ;
+    END
+  END rw0_rd_out[63]
+  PIN rw0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 25.425 499.590 25.495 499.800 ;
+    END
+  END rw0_rd_out[64]
+  PIN rw0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 28.465 499.590 28.535 499.800 ;
+    END
+  END rw0_rd_out[65]
+  PIN rw0_rd_out[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 31.505 499.590 31.575 499.800 ;
+    END
+  END rw0_rd_out[66]
+  PIN rw0_rd_out[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 34.545 499.590 34.615 499.800 ;
+    END
+  END rw0_rd_out[67]
+  PIN rw0_rd_out[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 37.585 499.590 37.655 499.800 ;
+    END
+  END rw0_rd_out[68]
+  PIN rw0_rd_out[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 40.625 499.590 40.695 499.800 ;
+    END
+  END rw0_rd_out[69]
+  PIN rw0_rd_out[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 43.665 499.590 43.735 499.800 ;
+    END
+  END rw0_rd_out[70]
+  PIN rw0_rd_out[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 46.705 499.590 46.775 499.800 ;
+    END
+  END rw0_rd_out[71]
+  PIN rw0_rd_out[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 49.745 499.590 49.815 499.800 ;
+    END
+  END rw0_rd_out[72]
+  PIN rw0_rd_out[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 52.785 499.590 52.855 499.800 ;
+    END
+  END rw0_rd_out[73]
+  PIN rw0_rd_out[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 55.825 499.590 55.895 499.800 ;
+    END
+  END rw0_rd_out[74]
+  PIN rw0_rd_out[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 58.865 499.590 58.935 499.800 ;
+    END
+  END rw0_rd_out[75]
+  PIN rw0_rd_out[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 61.905 499.590 61.975 499.800 ;
+    END
+  END rw0_rd_out[76]
+  PIN rw0_rd_out[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 64.945 499.590 65.015 499.800 ;
+    END
+  END rw0_rd_out[77]
+  PIN rw0_rd_out[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 67.985 499.590 68.055 499.800 ;
+    END
+  END rw0_rd_out[78]
+  PIN rw0_rd_out[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 71.025 499.590 71.095 499.800 ;
+    END
+  END rw0_rd_out[79]
+  PIN rw0_rd_out[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 74.065 499.590 74.135 499.800 ;
+    END
+  END rw0_rd_out[80]
+  PIN rw0_rd_out[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 77.105 499.590 77.175 499.800 ;
+    END
+  END rw0_rd_out[81]
+  PIN rw0_rd_out[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 80.145 499.590 80.215 499.800 ;
+    END
+  END rw0_rd_out[82]
+  PIN rw0_rd_out[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 83.185 499.590 83.255 499.800 ;
+    END
+  END rw0_rd_out[83]
+  PIN rw0_rd_out[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 86.225 499.590 86.295 499.800 ;
+    END
+  END rw0_rd_out[84]
+  PIN rw0_rd_out[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 89.265 499.590 89.335 499.800 ;
+    END
+  END rw0_rd_out[85]
+  PIN rw0_rd_out[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 92.305 499.590 92.375 499.800 ;
+    END
+  END rw0_rd_out[86]
+  PIN rw0_rd_out[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 95.345 499.590 95.415 499.800 ;
+    END
+  END rw0_rd_out[87]
+  PIN rw0_rd_out[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 98.385 499.590 98.455 499.800 ;
+    END
+  END rw0_rd_out[88]
+  PIN rw0_rd_out[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 101.425 499.590 101.495 499.800 ;
+    END
+  END rw0_rd_out[89]
+  PIN rw0_rd_out[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 104.465 499.590 104.535 499.800 ;
+    END
+  END rw0_rd_out[90]
+  PIN rw0_rd_out[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 107.505 499.590 107.575 499.800 ;
+    END
+  END rw0_rd_out[91]
+  PIN rw0_rd_out[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 110.545 499.590 110.615 499.800 ;
+    END
+  END rw0_rd_out[92]
+  PIN rw0_rd_out[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 113.585 499.590 113.655 499.800 ;
+    END
+  END rw0_rd_out[93]
+  PIN rw0_rd_out[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 116.625 499.590 116.695 499.800 ;
+    END
+  END rw0_rd_out[94]
+  PIN rw0_rd_out[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 119.665 499.590 119.735 499.800 ;
+    END
+  END rw0_rd_out[95]
+  PIN rw0_rd_out[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 122.705 499.590 122.775 499.800 ;
+    END
+  END rw0_rd_out[96]
+  PIN rw0_rd_out[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 125.745 499.590 125.815 499.800 ;
+    END
+  END rw0_rd_out[97]
+  PIN rw0_rd_out[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 128.785 499.590 128.855 499.800 ;
+    END
+  END rw0_rd_out[98]
+  PIN rw0_rd_out[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 131.825 499.590 131.895 499.800 ;
+    END
+  END rw0_rd_out[99]
+  PIN rw0_rd_out[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 134.865 499.590 134.935 499.800 ;
+    END
+  END rw0_rd_out[100]
+  PIN rw0_rd_out[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 137.905 499.590 137.975 499.800 ;
+    END
+  END rw0_rd_out[101]
+  PIN rw0_rd_out[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 140.945 499.590 141.015 499.800 ;
+    END
+  END rw0_rd_out[102]
+  PIN rw0_rd_out[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 143.985 499.590 144.055 499.800 ;
+    END
+  END rw0_rd_out[103]
+  PIN rw0_rd_out[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 147.025 499.590 147.095 499.800 ;
+    END
+  END rw0_rd_out[104]
+  PIN rw0_rd_out[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 150.065 499.590 150.135 499.800 ;
+    END
+  END rw0_rd_out[105]
+  PIN rw0_rd_out[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 153.105 499.590 153.175 499.800 ;
+    END
+  END rw0_rd_out[106]
+  PIN rw0_rd_out[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 156.145 499.590 156.215 499.800 ;
+    END
+  END rw0_rd_out[107]
+  PIN rw0_rd_out[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 159.185 499.590 159.255 499.800 ;
+    END
+  END rw0_rd_out[108]
+  PIN rw0_rd_out[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 162.225 499.590 162.295 499.800 ;
+    END
+  END rw0_rd_out[109]
+  PIN rw0_rd_out[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 165.265 499.590 165.335 499.800 ;
+    END
+  END rw0_rd_out[110]
+  PIN rw0_rd_out[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 168.305 499.590 168.375 499.800 ;
+    END
+  END rw0_rd_out[111]
+  PIN rw0_rd_out[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 171.345 499.590 171.415 499.800 ;
+    END
+  END rw0_rd_out[112]
+  PIN rw0_rd_out[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 174.385 499.590 174.455 499.800 ;
+    END
+  END rw0_rd_out[113]
+  PIN rw0_rd_out[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 177.425 499.590 177.495 499.800 ;
+    END
+  END rw0_rd_out[114]
+  PIN rw0_rd_out[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 180.465 499.590 180.535 499.800 ;
+    END
+  END rw0_rd_out[115]
+  PIN rw0_rd_out[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 183.505 499.590 183.575 499.800 ;
+    END
+  END rw0_rd_out[116]
+  PIN rw0_rd_out[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 186.545 499.590 186.615 499.800 ;
+    END
+  END rw0_rd_out[117]
+  PIN rw0_rd_out[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 189.585 499.590 189.655 499.800 ;
+    END
+  END rw0_rd_out[118]
+  PIN rw0_rd_out[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 192.625 499.590 192.695 499.800 ;
+    END
+  END rw0_rd_out[119]
+  PIN rw0_rd_out[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 195.665 499.590 195.735 499.800 ;
+    END
+  END rw0_rd_out[120]
+  PIN rw0_rd_out[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 198.705 499.590 198.775 499.800 ;
+    END
+  END rw0_rd_out[121]
+  PIN rw0_rd_out[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 201.745 499.590 201.815 499.800 ;
+    END
+  END rw0_rd_out[122]
+  PIN rw0_rd_out[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 204.785 499.590 204.855 499.800 ;
+    END
+  END rw0_rd_out[123]
+  PIN rw0_rd_out[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 207.825 499.590 207.895 499.800 ;
+    END
+  END rw0_rd_out[124]
+  PIN rw0_rd_out[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 210.865 499.590 210.935 499.800 ;
+    END
+  END rw0_rd_out[125]
+  PIN rw0_rd_out[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 213.905 499.590 213.975 499.800 ;
+    END
+  END rw0_rd_out[126]
+  PIN rw0_rd_out[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 216.945 499.590 217.015 499.800 ;
+    END
+  END rw0_rd_out[127]
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 252.805 0.210 252.875 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 259.805 0.210 259.875 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 266.805 0.210 266.875 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 273.805 0.210 273.875 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 280.805 0.210 280.875 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 287.805 0.210 287.875 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 252.805 418.760 252.875 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 259.805 418.760 259.875 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 266.805 418.760 266.875 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_addr_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 273.805 418.760 273.875 ;
+    END
+  END rw0_addr_in[9]
+  PIN rw0_addr_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 418.550 280.805 418.760 280.875 ;
+    END
+  END rw0_addr_in[10]
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 219.985 499.590 220.055 499.800 ;
+    END
+  END rw0_we_in
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 223.025 499.590 223.095 499.800 ;
+    END
+  END rw0_ce_in
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 226.065 499.590 226.135 499.800 ;
+    END
+  END rw0_clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER metal4 ;
+      RECT 1.140 0.700 417.620 0.980 ;
+      RECT 1.140 2.940 417.620 3.220 ;
+      RECT 1.140 5.180 417.620 5.460 ;
+      RECT 1.140 7.420 417.620 7.700 ;
+      RECT 1.140 9.660 417.620 9.940 ;
+      RECT 1.140 11.900 417.620 12.180 ;
+      RECT 1.140 14.140 417.620 14.420 ;
+      RECT 1.140 16.380 417.620 16.660 ;
+      RECT 1.140 18.620 417.620 18.900 ;
+      RECT 1.140 20.860 417.620 21.140 ;
+      RECT 1.140 23.100 417.620 23.380 ;
+      RECT 1.140 25.340 417.620 25.620 ;
+      RECT 1.140 27.580 417.620 27.860 ;
+      RECT 1.140 29.820 417.620 30.100 ;
+      RECT 1.140 32.060 417.620 32.340 ;
+      RECT 1.140 34.300 417.620 34.580 ;
+      RECT 1.140 36.540 417.620 36.820 ;
+      RECT 1.140 38.780 417.620 39.060 ;
+      RECT 1.140 41.020 417.620 41.300 ;
+      RECT 1.140 43.260 417.620 43.540 ;
+      RECT 1.140 45.500 417.620 45.780 ;
+      RECT 1.140 47.740 417.620 48.020 ;
+      RECT 1.140 49.980 417.620 50.260 ;
+      RECT 1.140 52.220 417.620 52.500 ;
+      RECT 1.140 54.460 417.620 54.740 ;
+      RECT 1.140 56.700 417.620 56.980 ;
+      RECT 1.140 58.940 417.620 59.220 ;
+      RECT 1.140 61.180 417.620 61.460 ;
+      RECT 1.140 63.420 417.620 63.700 ;
+      RECT 1.140 65.660 417.620 65.940 ;
+      RECT 1.140 67.900 417.620 68.180 ;
+      RECT 1.140 70.140 417.620 70.420 ;
+      RECT 1.140 72.380 417.620 72.660 ;
+      RECT 1.140 74.620 417.620 74.900 ;
+      RECT 1.140 76.860 417.620 77.140 ;
+      RECT 1.140 79.100 417.620 79.380 ;
+      RECT 1.140 81.340 417.620 81.620 ;
+      RECT 1.140 83.580 417.620 83.860 ;
+      RECT 1.140 85.820 417.620 86.100 ;
+      RECT 1.140 88.060 417.620 88.340 ;
+      RECT 1.140 90.300 417.620 90.580 ;
+      RECT 1.140 92.540 417.620 92.820 ;
+      RECT 1.140 94.780 417.620 95.060 ;
+      RECT 1.140 97.020 417.620 97.300 ;
+      RECT 1.140 99.260 417.620 99.540 ;
+      RECT 1.140 101.500 417.620 101.780 ;
+      RECT 1.140 103.740 417.620 104.020 ;
+      RECT 1.140 105.980 417.620 106.260 ;
+      RECT 1.140 108.220 417.620 108.500 ;
+      RECT 1.140 110.460 417.620 110.740 ;
+      RECT 1.140 112.700 417.620 112.980 ;
+      RECT 1.140 114.940 417.620 115.220 ;
+      RECT 1.140 117.180 417.620 117.460 ;
+      RECT 1.140 119.420 417.620 119.700 ;
+      RECT 1.140 121.660 417.620 121.940 ;
+      RECT 1.140 123.900 417.620 124.180 ;
+      RECT 1.140 126.140 417.620 126.420 ;
+      RECT 1.140 128.380 417.620 128.660 ;
+      RECT 1.140 130.620 417.620 130.900 ;
+      RECT 1.140 132.860 417.620 133.140 ;
+      RECT 1.140 135.100 417.620 135.380 ;
+      RECT 1.140 137.340 417.620 137.620 ;
+      RECT 1.140 139.580 417.620 139.860 ;
+      RECT 1.140 141.820 417.620 142.100 ;
+      RECT 1.140 144.060 417.620 144.340 ;
+      RECT 1.140 146.300 417.620 146.580 ;
+      RECT 1.140 148.540 417.620 148.820 ;
+      RECT 1.140 150.780 417.620 151.060 ;
+      RECT 1.140 153.020 417.620 153.300 ;
+      RECT 1.140 155.260 417.620 155.540 ;
+      RECT 1.140 157.500 417.620 157.780 ;
+      RECT 1.140 159.740 417.620 160.020 ;
+      RECT 1.140 161.980 417.620 162.260 ;
+      RECT 1.140 164.220 417.620 164.500 ;
+      RECT 1.140 166.460 417.620 166.740 ;
+      RECT 1.140 168.700 417.620 168.980 ;
+      RECT 1.140 170.940 417.620 171.220 ;
+      RECT 1.140 173.180 417.620 173.460 ;
+      RECT 1.140 175.420 417.620 175.700 ;
+      RECT 1.140 177.660 417.620 177.940 ;
+      RECT 1.140 179.900 417.620 180.180 ;
+      RECT 1.140 182.140 417.620 182.420 ;
+      RECT 1.140 184.380 417.620 184.660 ;
+      RECT 1.140 186.620 417.620 186.900 ;
+      RECT 1.140 188.860 417.620 189.140 ;
+      RECT 1.140 191.100 417.620 191.380 ;
+      RECT 1.140 193.340 417.620 193.620 ;
+      RECT 1.140 195.580 417.620 195.860 ;
+      RECT 1.140 197.820 417.620 198.100 ;
+      RECT 1.140 200.060 417.620 200.340 ;
+      RECT 1.140 202.300 417.620 202.580 ;
+      RECT 1.140 204.540 417.620 204.820 ;
+      RECT 1.140 206.780 417.620 207.060 ;
+      RECT 1.140 209.020 417.620 209.300 ;
+      RECT 1.140 211.260 417.620 211.540 ;
+      RECT 1.140 213.500 417.620 213.780 ;
+      RECT 1.140 215.740 417.620 216.020 ;
+      RECT 1.140 217.980 417.620 218.260 ;
+      RECT 1.140 220.220 417.620 220.500 ;
+      RECT 1.140 222.460 417.620 222.740 ;
+      RECT 1.140 224.700 417.620 224.980 ;
+      RECT 1.140 226.940 417.620 227.220 ;
+      RECT 1.140 229.180 417.620 229.460 ;
+      RECT 1.140 231.420 417.620 231.700 ;
+      RECT 1.140 233.660 417.620 233.940 ;
+      RECT 1.140 235.900 417.620 236.180 ;
+      RECT 1.140 238.140 417.620 238.420 ;
+      RECT 1.140 240.380 417.620 240.660 ;
+      RECT 1.140 242.620 417.620 242.900 ;
+      RECT 1.140 244.860 417.620 245.140 ;
+      RECT 1.140 247.100 417.620 247.380 ;
+      RECT 1.140 249.340 417.620 249.620 ;
+      RECT 1.140 251.580 417.620 251.860 ;
+      RECT 1.140 253.820 417.620 254.100 ;
+      RECT 1.140 256.060 417.620 256.340 ;
+      RECT 1.140 258.300 417.620 258.580 ;
+      RECT 1.140 260.540 417.620 260.820 ;
+      RECT 1.140 262.780 417.620 263.060 ;
+      RECT 1.140 265.020 417.620 265.300 ;
+      RECT 1.140 267.260 417.620 267.540 ;
+      RECT 1.140 269.500 417.620 269.780 ;
+      RECT 1.140 271.740 417.620 272.020 ;
+      RECT 1.140 273.980 417.620 274.260 ;
+      RECT 1.140 276.220 417.620 276.500 ;
+      RECT 1.140 278.460 417.620 278.740 ;
+      RECT 1.140 280.700 417.620 280.980 ;
+      RECT 1.140 282.940 417.620 283.220 ;
+      RECT 1.140 285.180 417.620 285.460 ;
+      RECT 1.140 287.420 417.620 287.700 ;
+      RECT 1.140 289.660 417.620 289.940 ;
+      RECT 1.140 291.900 417.620 292.180 ;
+      RECT 1.140 294.140 417.620 294.420 ;
+      RECT 1.140 296.380 417.620 296.660 ;
+      RECT 1.140 298.620 417.620 298.900 ;
+      RECT 1.140 300.860 417.620 301.140 ;
+      RECT 1.140 303.100 417.620 303.380 ;
+      RECT 1.140 305.340 417.620 305.620 ;
+      RECT 1.140 307.580 417.620 307.860 ;
+      RECT 1.140 309.820 417.620 310.100 ;
+      RECT 1.140 312.060 417.620 312.340 ;
+      RECT 1.140 314.300 417.620 314.580 ;
+      RECT 1.140 316.540 417.620 316.820 ;
+      RECT 1.140 318.780 417.620 319.060 ;
+      RECT 1.140 321.020 417.620 321.300 ;
+      RECT 1.140 323.260 417.620 323.540 ;
+      RECT 1.140 325.500 417.620 325.780 ;
+      RECT 1.140 327.740 417.620 328.020 ;
+      RECT 1.140 329.980 417.620 330.260 ;
+      RECT 1.140 332.220 417.620 332.500 ;
+      RECT 1.140 334.460 417.620 334.740 ;
+      RECT 1.140 336.700 417.620 336.980 ;
+      RECT 1.140 338.940 417.620 339.220 ;
+      RECT 1.140 341.180 417.620 341.460 ;
+      RECT 1.140 343.420 417.620 343.700 ;
+      RECT 1.140 345.660 417.620 345.940 ;
+      RECT 1.140 347.900 417.620 348.180 ;
+      RECT 1.140 350.140 417.620 350.420 ;
+      RECT 1.140 352.380 417.620 352.660 ;
+      RECT 1.140 354.620 417.620 354.900 ;
+      RECT 1.140 356.860 417.620 357.140 ;
+      RECT 1.140 359.100 417.620 359.380 ;
+      RECT 1.140 361.340 417.620 361.620 ;
+      RECT 1.140 363.580 417.620 363.860 ;
+      RECT 1.140 365.820 417.620 366.100 ;
+      RECT 1.140 368.060 417.620 368.340 ;
+      RECT 1.140 370.300 417.620 370.580 ;
+      RECT 1.140 372.540 417.620 372.820 ;
+      RECT 1.140 374.780 417.620 375.060 ;
+      RECT 1.140 377.020 417.620 377.300 ;
+      RECT 1.140 379.260 417.620 379.540 ;
+      RECT 1.140 381.500 417.620 381.780 ;
+      RECT 1.140 383.740 417.620 384.020 ;
+      RECT 1.140 385.980 417.620 386.260 ;
+      RECT 1.140 388.220 417.620 388.500 ;
+      RECT 1.140 390.460 417.620 390.740 ;
+      RECT 1.140 392.700 417.620 392.980 ;
+      RECT 1.140 394.940 417.620 395.220 ;
+      RECT 1.140 397.180 417.620 397.460 ;
+      RECT 1.140 399.420 417.620 399.700 ;
+      RECT 1.140 401.660 417.620 401.940 ;
+      RECT 1.140 403.900 417.620 404.180 ;
+      RECT 1.140 406.140 417.620 406.420 ;
+      RECT 1.140 408.380 417.620 408.660 ;
+      RECT 1.140 410.620 417.620 410.900 ;
+      RECT 1.140 412.860 417.620 413.140 ;
+      RECT 1.140 415.100 417.620 415.380 ;
+      RECT 1.140 417.340 417.620 417.620 ;
+      RECT 1.140 419.580 417.620 419.860 ;
+      RECT 1.140 421.820 417.620 422.100 ;
+      RECT 1.140 424.060 417.620 424.340 ;
+      RECT 1.140 426.300 417.620 426.580 ;
+      RECT 1.140 428.540 417.620 428.820 ;
+      RECT 1.140 430.780 417.620 431.060 ;
+      RECT 1.140 433.020 417.620 433.300 ;
+      RECT 1.140 435.260 417.620 435.540 ;
+      RECT 1.140 437.500 417.620 437.780 ;
+      RECT 1.140 439.740 417.620 440.020 ;
+      RECT 1.140 441.980 417.620 442.260 ;
+      RECT 1.140 444.220 417.620 444.500 ;
+      RECT 1.140 446.460 417.620 446.740 ;
+      RECT 1.140 448.700 417.620 448.980 ;
+      RECT 1.140 450.940 417.620 451.220 ;
+      RECT 1.140 453.180 417.620 453.460 ;
+      RECT 1.140 455.420 417.620 455.700 ;
+      RECT 1.140 457.660 417.620 457.940 ;
+      RECT 1.140 459.900 417.620 460.180 ;
+      RECT 1.140 462.140 417.620 462.420 ;
+      RECT 1.140 464.380 417.620 464.660 ;
+      RECT 1.140 466.620 417.620 466.900 ;
+      RECT 1.140 468.860 417.620 469.140 ;
+      RECT 1.140 471.100 417.620 471.380 ;
+      RECT 1.140 473.340 417.620 473.620 ;
+      RECT 1.140 475.580 417.620 475.860 ;
+      RECT 1.140 477.820 417.620 478.100 ;
+      RECT 1.140 480.060 417.620 480.340 ;
+      RECT 1.140 482.300 417.620 482.580 ;
+      RECT 1.140 484.540 417.620 484.820 ;
+      RECT 1.140 486.780 417.620 487.060 ;
+      RECT 1.140 489.020 417.620 489.300 ;
+      RECT 1.140 491.260 417.620 491.540 ;
+      RECT 1.140 493.500 417.620 493.780 ;
+      RECT 1.140 495.740 417.620 496.020 ;
+      RECT 1.140 497.980 417.620 498.260 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER metal4 ;
+      RECT 1.140 0.700 417.620 0.980 ;
+      RECT 1.140 2.940 417.620 3.220 ;
+      RECT 1.140 5.180 417.620 5.460 ;
+      RECT 1.140 7.420 417.620 7.700 ;
+      RECT 1.140 9.660 417.620 9.940 ;
+      RECT 1.140 11.900 417.620 12.180 ;
+      RECT 1.140 14.140 417.620 14.420 ;
+      RECT 1.140 16.380 417.620 16.660 ;
+      RECT 1.140 18.620 417.620 18.900 ;
+      RECT 1.140 20.860 417.620 21.140 ;
+      RECT 1.140 23.100 417.620 23.380 ;
+      RECT 1.140 25.340 417.620 25.620 ;
+      RECT 1.140 27.580 417.620 27.860 ;
+      RECT 1.140 29.820 417.620 30.100 ;
+      RECT 1.140 32.060 417.620 32.340 ;
+      RECT 1.140 34.300 417.620 34.580 ;
+      RECT 1.140 36.540 417.620 36.820 ;
+      RECT 1.140 38.780 417.620 39.060 ;
+      RECT 1.140 41.020 417.620 41.300 ;
+      RECT 1.140 43.260 417.620 43.540 ;
+      RECT 1.140 45.500 417.620 45.780 ;
+      RECT 1.140 47.740 417.620 48.020 ;
+      RECT 1.140 49.980 417.620 50.260 ;
+      RECT 1.140 52.220 417.620 52.500 ;
+      RECT 1.140 54.460 417.620 54.740 ;
+      RECT 1.140 56.700 417.620 56.980 ;
+      RECT 1.140 58.940 417.620 59.220 ;
+      RECT 1.140 61.180 417.620 61.460 ;
+      RECT 1.140 63.420 417.620 63.700 ;
+      RECT 1.140 65.660 417.620 65.940 ;
+      RECT 1.140 67.900 417.620 68.180 ;
+      RECT 1.140 70.140 417.620 70.420 ;
+      RECT 1.140 72.380 417.620 72.660 ;
+      RECT 1.140 74.620 417.620 74.900 ;
+      RECT 1.140 76.860 417.620 77.140 ;
+      RECT 1.140 79.100 417.620 79.380 ;
+      RECT 1.140 81.340 417.620 81.620 ;
+      RECT 1.140 83.580 417.620 83.860 ;
+      RECT 1.140 85.820 417.620 86.100 ;
+      RECT 1.140 88.060 417.620 88.340 ;
+      RECT 1.140 90.300 417.620 90.580 ;
+      RECT 1.140 92.540 417.620 92.820 ;
+      RECT 1.140 94.780 417.620 95.060 ;
+      RECT 1.140 97.020 417.620 97.300 ;
+      RECT 1.140 99.260 417.620 99.540 ;
+      RECT 1.140 101.500 417.620 101.780 ;
+      RECT 1.140 103.740 417.620 104.020 ;
+      RECT 1.140 105.980 417.620 106.260 ;
+      RECT 1.140 108.220 417.620 108.500 ;
+      RECT 1.140 110.460 417.620 110.740 ;
+      RECT 1.140 112.700 417.620 112.980 ;
+      RECT 1.140 114.940 417.620 115.220 ;
+      RECT 1.140 117.180 417.620 117.460 ;
+      RECT 1.140 119.420 417.620 119.700 ;
+      RECT 1.140 121.660 417.620 121.940 ;
+      RECT 1.140 123.900 417.620 124.180 ;
+      RECT 1.140 126.140 417.620 126.420 ;
+      RECT 1.140 128.380 417.620 128.660 ;
+      RECT 1.140 130.620 417.620 130.900 ;
+      RECT 1.140 132.860 417.620 133.140 ;
+      RECT 1.140 135.100 417.620 135.380 ;
+      RECT 1.140 137.340 417.620 137.620 ;
+      RECT 1.140 139.580 417.620 139.860 ;
+      RECT 1.140 141.820 417.620 142.100 ;
+      RECT 1.140 144.060 417.620 144.340 ;
+      RECT 1.140 146.300 417.620 146.580 ;
+      RECT 1.140 148.540 417.620 148.820 ;
+      RECT 1.140 150.780 417.620 151.060 ;
+      RECT 1.140 153.020 417.620 153.300 ;
+      RECT 1.140 155.260 417.620 155.540 ;
+      RECT 1.140 157.500 417.620 157.780 ;
+      RECT 1.140 159.740 417.620 160.020 ;
+      RECT 1.140 161.980 417.620 162.260 ;
+      RECT 1.140 164.220 417.620 164.500 ;
+      RECT 1.140 166.460 417.620 166.740 ;
+      RECT 1.140 168.700 417.620 168.980 ;
+      RECT 1.140 170.940 417.620 171.220 ;
+      RECT 1.140 173.180 417.620 173.460 ;
+      RECT 1.140 175.420 417.620 175.700 ;
+      RECT 1.140 177.660 417.620 177.940 ;
+      RECT 1.140 179.900 417.620 180.180 ;
+      RECT 1.140 182.140 417.620 182.420 ;
+      RECT 1.140 184.380 417.620 184.660 ;
+      RECT 1.140 186.620 417.620 186.900 ;
+      RECT 1.140 188.860 417.620 189.140 ;
+      RECT 1.140 191.100 417.620 191.380 ;
+      RECT 1.140 193.340 417.620 193.620 ;
+      RECT 1.140 195.580 417.620 195.860 ;
+      RECT 1.140 197.820 417.620 198.100 ;
+      RECT 1.140 200.060 417.620 200.340 ;
+      RECT 1.140 202.300 417.620 202.580 ;
+      RECT 1.140 204.540 417.620 204.820 ;
+      RECT 1.140 206.780 417.620 207.060 ;
+      RECT 1.140 209.020 417.620 209.300 ;
+      RECT 1.140 211.260 417.620 211.540 ;
+      RECT 1.140 213.500 417.620 213.780 ;
+      RECT 1.140 215.740 417.620 216.020 ;
+      RECT 1.140 217.980 417.620 218.260 ;
+      RECT 1.140 220.220 417.620 220.500 ;
+      RECT 1.140 222.460 417.620 222.740 ;
+      RECT 1.140 224.700 417.620 224.980 ;
+      RECT 1.140 226.940 417.620 227.220 ;
+      RECT 1.140 229.180 417.620 229.460 ;
+      RECT 1.140 231.420 417.620 231.700 ;
+      RECT 1.140 233.660 417.620 233.940 ;
+      RECT 1.140 235.900 417.620 236.180 ;
+      RECT 1.140 238.140 417.620 238.420 ;
+      RECT 1.140 240.380 417.620 240.660 ;
+      RECT 1.140 242.620 417.620 242.900 ;
+      RECT 1.140 244.860 417.620 245.140 ;
+      RECT 1.140 247.100 417.620 247.380 ;
+      RECT 1.140 249.340 417.620 249.620 ;
+      RECT 1.140 251.580 417.620 251.860 ;
+      RECT 1.140 253.820 417.620 254.100 ;
+      RECT 1.140 256.060 417.620 256.340 ;
+      RECT 1.140 258.300 417.620 258.580 ;
+      RECT 1.140 260.540 417.620 260.820 ;
+      RECT 1.140 262.780 417.620 263.060 ;
+      RECT 1.140 265.020 417.620 265.300 ;
+      RECT 1.140 267.260 417.620 267.540 ;
+      RECT 1.140 269.500 417.620 269.780 ;
+      RECT 1.140 271.740 417.620 272.020 ;
+      RECT 1.140 273.980 417.620 274.260 ;
+      RECT 1.140 276.220 417.620 276.500 ;
+      RECT 1.140 278.460 417.620 278.740 ;
+      RECT 1.140 280.700 417.620 280.980 ;
+      RECT 1.140 282.940 417.620 283.220 ;
+      RECT 1.140 285.180 417.620 285.460 ;
+      RECT 1.140 287.420 417.620 287.700 ;
+      RECT 1.140 289.660 417.620 289.940 ;
+      RECT 1.140 291.900 417.620 292.180 ;
+      RECT 1.140 294.140 417.620 294.420 ;
+      RECT 1.140 296.380 417.620 296.660 ;
+      RECT 1.140 298.620 417.620 298.900 ;
+      RECT 1.140 300.860 417.620 301.140 ;
+      RECT 1.140 303.100 417.620 303.380 ;
+      RECT 1.140 305.340 417.620 305.620 ;
+      RECT 1.140 307.580 417.620 307.860 ;
+      RECT 1.140 309.820 417.620 310.100 ;
+      RECT 1.140 312.060 417.620 312.340 ;
+      RECT 1.140 314.300 417.620 314.580 ;
+      RECT 1.140 316.540 417.620 316.820 ;
+      RECT 1.140 318.780 417.620 319.060 ;
+      RECT 1.140 321.020 417.620 321.300 ;
+      RECT 1.140 323.260 417.620 323.540 ;
+      RECT 1.140 325.500 417.620 325.780 ;
+      RECT 1.140 327.740 417.620 328.020 ;
+      RECT 1.140 329.980 417.620 330.260 ;
+      RECT 1.140 332.220 417.620 332.500 ;
+      RECT 1.140 334.460 417.620 334.740 ;
+      RECT 1.140 336.700 417.620 336.980 ;
+      RECT 1.140 338.940 417.620 339.220 ;
+      RECT 1.140 341.180 417.620 341.460 ;
+      RECT 1.140 343.420 417.620 343.700 ;
+      RECT 1.140 345.660 417.620 345.940 ;
+      RECT 1.140 347.900 417.620 348.180 ;
+      RECT 1.140 350.140 417.620 350.420 ;
+      RECT 1.140 352.380 417.620 352.660 ;
+      RECT 1.140 354.620 417.620 354.900 ;
+      RECT 1.140 356.860 417.620 357.140 ;
+      RECT 1.140 359.100 417.620 359.380 ;
+      RECT 1.140 361.340 417.620 361.620 ;
+      RECT 1.140 363.580 417.620 363.860 ;
+      RECT 1.140 365.820 417.620 366.100 ;
+      RECT 1.140 368.060 417.620 368.340 ;
+      RECT 1.140 370.300 417.620 370.580 ;
+      RECT 1.140 372.540 417.620 372.820 ;
+      RECT 1.140 374.780 417.620 375.060 ;
+      RECT 1.140 377.020 417.620 377.300 ;
+      RECT 1.140 379.260 417.620 379.540 ;
+      RECT 1.140 381.500 417.620 381.780 ;
+      RECT 1.140 383.740 417.620 384.020 ;
+      RECT 1.140 385.980 417.620 386.260 ;
+      RECT 1.140 388.220 417.620 388.500 ;
+      RECT 1.140 390.460 417.620 390.740 ;
+      RECT 1.140 392.700 417.620 392.980 ;
+      RECT 1.140 394.940 417.620 395.220 ;
+      RECT 1.140 397.180 417.620 397.460 ;
+      RECT 1.140 399.420 417.620 399.700 ;
+      RECT 1.140 401.660 417.620 401.940 ;
+      RECT 1.140 403.900 417.620 404.180 ;
+      RECT 1.140 406.140 417.620 406.420 ;
+      RECT 1.140 408.380 417.620 408.660 ;
+      RECT 1.140 410.620 417.620 410.900 ;
+      RECT 1.140 412.860 417.620 413.140 ;
+      RECT 1.140 415.100 417.620 415.380 ;
+      RECT 1.140 417.340 417.620 417.620 ;
+      RECT 1.140 419.580 417.620 419.860 ;
+      RECT 1.140 421.820 417.620 422.100 ;
+      RECT 1.140 424.060 417.620 424.340 ;
+      RECT 1.140 426.300 417.620 426.580 ;
+      RECT 1.140 428.540 417.620 428.820 ;
+      RECT 1.140 430.780 417.620 431.060 ;
+      RECT 1.140 433.020 417.620 433.300 ;
+      RECT 1.140 435.260 417.620 435.540 ;
+      RECT 1.140 437.500 417.620 437.780 ;
+      RECT 1.140 439.740 417.620 440.020 ;
+      RECT 1.140 441.980 417.620 442.260 ;
+      RECT 1.140 444.220 417.620 444.500 ;
+      RECT 1.140 446.460 417.620 446.740 ;
+      RECT 1.140 448.700 417.620 448.980 ;
+      RECT 1.140 450.940 417.620 451.220 ;
+      RECT 1.140 453.180 417.620 453.460 ;
+      RECT 1.140 455.420 417.620 455.700 ;
+      RECT 1.140 457.660 417.620 457.940 ;
+      RECT 1.140 459.900 417.620 460.180 ;
+      RECT 1.140 462.140 417.620 462.420 ;
+      RECT 1.140 464.380 417.620 464.660 ;
+      RECT 1.140 466.620 417.620 466.900 ;
+      RECT 1.140 468.860 417.620 469.140 ;
+      RECT 1.140 471.100 417.620 471.380 ;
+      RECT 1.140 473.340 417.620 473.620 ;
+      RECT 1.140 475.580 417.620 475.860 ;
+      RECT 1.140 477.820 417.620 478.100 ;
+      RECT 1.140 480.060 417.620 480.340 ;
+      RECT 1.140 482.300 417.620 482.580 ;
+      RECT 1.140 484.540 417.620 484.820 ;
+      RECT 1.140 486.780 417.620 487.060 ;
+      RECT 1.140 489.020 417.620 489.300 ;
+      RECT 1.140 491.260 417.620 491.540 ;
+      RECT 1.140 493.500 417.620 493.780 ;
+      RECT 1.140 495.740 417.620 496.020 ;
+      RECT 1.140 497.980 417.620 498.260 ;
+    END
+  END VDD
+  OBS
+    LAYER metal1 ;
+    RECT 0 0 418.760 499.800 ;
+    LAYER metal2 ;
+    RECT 0 0 418.760 499.800 ;
+    LAYER metal3 ;
+    RECT 0 0 418.760 499.800 ;
+    LAYER metal4 ;
+    RECT 0 0 418.760 499.800 ;
+    LAYER OVERLAP ;
+    RECT 0 0 418.760 499.800 ;
+  END
+END fakeram_2048x128_1rw
+
+END LIBRARY

--- a/designs/nangate45/coralnpu/sram/lef/fakeram_2048x128_1rw.lef
+++ b/designs/nangate45/coralnpu/sram/lef/fakeram_2048x128_1rw.lef
@@ -10,7 +10,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 0.805 0.210 0.875 ;
     END
   END rw0_wmask_in[0]
@@ -19,7 +19,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 7.805 0.210 7.875 ;
     END
   END rw0_wmask_in[1]
@@ -28,7 +28,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 14.805 0.210 14.875 ;
     END
   END rw0_wmask_in[2]
@@ -37,7 +37,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 21.805 0.210 21.875 ;
     END
   END rw0_wmask_in[3]
@@ -46,7 +46,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 0.805 418.760 0.875 ;
     END
   END rw0_wmask_in[4]
@@ -55,7 +55,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 7.805 418.760 7.875 ;
     END
   END rw0_wmask_in[5]
@@ -64,7 +64,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 14.805 418.760 14.875 ;
     END
   END rw0_wmask_in[6]
@@ -73,7 +73,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 21.805 418.760 21.875 ;
     END
   END rw0_wmask_in[7]
@@ -82,7 +82,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 1.105 499.590 1.175 499.800 ;
     END
   END rw0_wmask_in[8]
@@ -91,7 +91,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 4.145 499.590 4.215 499.800 ;
     END
   END rw0_wmask_in[9]
@@ -100,7 +100,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 7.185 499.590 7.255 499.800 ;
     END
   END rw0_wmask_in[10]
@@ -109,7 +109,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 10.225 499.590 10.295 499.800 ;
     END
   END rw0_wmask_in[11]
@@ -118,7 +118,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 13.265 499.590 13.335 499.800 ;
     END
   END rw0_wmask_in[12]
@@ -127,7 +127,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 16.305 499.590 16.375 499.800 ;
     END
   END rw0_wmask_in[13]
@@ -136,7 +136,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 19.345 499.590 19.415 499.800 ;
     END
   END rw0_wmask_in[14]
@@ -145,7 +145,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 22.385 499.590 22.455 499.800 ;
     END
   END rw0_wmask_in[15]
@@ -154,7 +154,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 28.805 0.210 28.875 ;
     END
   END rw0_wd_in[0]
@@ -163,7 +163,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 35.805 0.210 35.875 ;
     END
   END rw0_wd_in[1]
@@ -172,7 +172,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 42.805 0.210 42.875 ;
     END
   END rw0_wd_in[2]
@@ -181,7 +181,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 49.805 0.210 49.875 ;
     END
   END rw0_wd_in[3]
@@ -190,7 +190,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 56.805 0.210 56.875 ;
     END
   END rw0_wd_in[4]
@@ -199,7 +199,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 63.805 0.210 63.875 ;
     END
   END rw0_wd_in[5]
@@ -208,7 +208,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 70.805 0.210 70.875 ;
     END
   END rw0_wd_in[6]
@@ -217,7 +217,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 77.805 0.210 77.875 ;
     END
   END rw0_wd_in[7]
@@ -226,7 +226,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 84.805 0.210 84.875 ;
     END
   END rw0_wd_in[8]
@@ -235,7 +235,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 91.805 0.210 91.875 ;
     END
   END rw0_wd_in[9]
@@ -244,7 +244,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 98.805 0.210 98.875 ;
     END
   END rw0_wd_in[10]
@@ -253,7 +253,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 105.805 0.210 105.875 ;
     END
   END rw0_wd_in[11]
@@ -262,7 +262,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 112.805 0.210 112.875 ;
     END
   END rw0_wd_in[12]
@@ -271,7 +271,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 119.805 0.210 119.875 ;
     END
   END rw0_wd_in[13]
@@ -280,7 +280,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 126.805 0.210 126.875 ;
     END
   END rw0_wd_in[14]
@@ -289,7 +289,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 133.805 0.210 133.875 ;
     END
   END rw0_wd_in[15]
@@ -298,7 +298,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 140.805 0.210 140.875 ;
     END
   END rw0_wd_in[16]
@@ -307,7 +307,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 147.805 0.210 147.875 ;
     END
   END rw0_wd_in[17]
@@ -316,7 +316,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 154.805 0.210 154.875 ;
     END
   END rw0_wd_in[18]
@@ -325,7 +325,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 161.805 0.210 161.875 ;
     END
   END rw0_wd_in[19]
@@ -334,7 +334,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 168.805 0.210 168.875 ;
     END
   END rw0_wd_in[20]
@@ -343,7 +343,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 175.805 0.210 175.875 ;
     END
   END rw0_wd_in[21]
@@ -352,7 +352,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 182.805 0.210 182.875 ;
     END
   END rw0_wd_in[22]
@@ -361,7 +361,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 189.805 0.210 189.875 ;
     END
   END rw0_wd_in[23]
@@ -370,7 +370,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 196.805 0.210 196.875 ;
     END
   END rw0_wd_in[24]
@@ -379,7 +379,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 203.805 0.210 203.875 ;
     END
   END rw0_wd_in[25]
@@ -388,7 +388,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 210.805 0.210 210.875 ;
     END
   END rw0_wd_in[26]
@@ -397,7 +397,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 217.805 0.210 217.875 ;
     END
   END rw0_wd_in[27]
@@ -406,7 +406,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 224.805 0.210 224.875 ;
     END
   END rw0_wd_in[28]
@@ -415,7 +415,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 231.805 0.210 231.875 ;
     END
   END rw0_wd_in[29]
@@ -424,7 +424,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 238.805 0.210 238.875 ;
     END
   END rw0_wd_in[30]
@@ -433,7 +433,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 245.805 0.210 245.875 ;
     END
   END rw0_wd_in[31]
@@ -442,7 +442,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 28.805 418.760 28.875 ;
     END
   END rw0_wd_in[32]
@@ -451,7 +451,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 35.805 418.760 35.875 ;
     END
   END rw0_wd_in[33]
@@ -460,7 +460,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 42.805 418.760 42.875 ;
     END
   END rw0_wd_in[34]
@@ -469,7 +469,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 49.805 418.760 49.875 ;
     END
   END rw0_wd_in[35]
@@ -478,7 +478,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 56.805 418.760 56.875 ;
     END
   END rw0_wd_in[36]
@@ -487,7 +487,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 63.805 418.760 63.875 ;
     END
   END rw0_wd_in[37]
@@ -496,7 +496,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 70.805 418.760 70.875 ;
     END
   END rw0_wd_in[38]
@@ -505,7 +505,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 77.805 418.760 77.875 ;
     END
   END rw0_wd_in[39]
@@ -514,7 +514,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 84.805 418.760 84.875 ;
     END
   END rw0_wd_in[40]
@@ -523,7 +523,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 91.805 418.760 91.875 ;
     END
   END rw0_wd_in[41]
@@ -532,7 +532,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 98.805 418.760 98.875 ;
     END
   END rw0_wd_in[42]
@@ -541,7 +541,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 105.805 418.760 105.875 ;
     END
   END rw0_wd_in[43]
@@ -550,7 +550,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 112.805 418.760 112.875 ;
     END
   END rw0_wd_in[44]
@@ -559,7 +559,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 119.805 418.760 119.875 ;
     END
   END rw0_wd_in[45]
@@ -568,7 +568,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 126.805 418.760 126.875 ;
     END
   END rw0_wd_in[46]
@@ -577,7 +577,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 133.805 418.760 133.875 ;
     END
   END rw0_wd_in[47]
@@ -586,7 +586,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 140.805 418.760 140.875 ;
     END
   END rw0_wd_in[48]
@@ -595,7 +595,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 147.805 418.760 147.875 ;
     END
   END rw0_wd_in[49]
@@ -604,7 +604,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 154.805 418.760 154.875 ;
     END
   END rw0_wd_in[50]
@@ -613,7 +613,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 161.805 418.760 161.875 ;
     END
   END rw0_wd_in[51]
@@ -622,7 +622,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 168.805 418.760 168.875 ;
     END
   END rw0_wd_in[52]
@@ -631,7 +631,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 175.805 418.760 175.875 ;
     END
   END rw0_wd_in[53]
@@ -640,7 +640,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 182.805 418.760 182.875 ;
     END
   END rw0_wd_in[54]
@@ -649,7 +649,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 189.805 418.760 189.875 ;
     END
   END rw0_wd_in[55]
@@ -658,7 +658,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 196.805 418.760 196.875 ;
     END
   END rw0_wd_in[56]
@@ -667,7 +667,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 203.805 418.760 203.875 ;
     END
   END rw0_wd_in[57]
@@ -676,7 +676,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 210.805 418.760 210.875 ;
     END
   END rw0_wd_in[58]
@@ -685,7 +685,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 217.805 418.760 217.875 ;
     END
   END rw0_wd_in[59]
@@ -694,7 +694,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 224.805 418.760 224.875 ;
     END
   END rw0_wd_in[60]
@@ -703,7 +703,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 231.805 418.760 231.875 ;
     END
   END rw0_wd_in[61]
@@ -712,7 +712,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 238.805 418.760 238.875 ;
     END
   END rw0_wd_in[62]
@@ -721,7 +721,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 245.805 418.760 245.875 ;
     END
   END rw0_wd_in[63]
@@ -730,7 +730,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 1.105 0.000 1.175 0.210 ;
     END
   END rw0_wd_in[64]
@@ -739,7 +739,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 4.335 0.000 4.405 0.210 ;
     END
   END rw0_wd_in[65]
@@ -748,7 +748,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 7.565 0.000 7.635 0.210 ;
     END
   END rw0_wd_in[66]
@@ -757,7 +757,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 10.795 0.000 10.865 0.210 ;
     END
   END rw0_wd_in[67]
@@ -766,7 +766,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 14.025 0.000 14.095 0.210 ;
     END
   END rw0_wd_in[68]
@@ -775,7 +775,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 17.255 0.000 17.325 0.210 ;
     END
   END rw0_wd_in[69]
@@ -784,7 +784,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 20.485 0.000 20.555 0.210 ;
     END
   END rw0_wd_in[70]
@@ -793,7 +793,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 23.715 0.000 23.785 0.210 ;
     END
   END rw0_wd_in[71]
@@ -802,7 +802,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 26.945 0.000 27.015 0.210 ;
     END
   END rw0_wd_in[72]
@@ -811,7 +811,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 30.175 0.000 30.245 0.210 ;
     END
   END rw0_wd_in[73]
@@ -820,7 +820,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 33.405 0.000 33.475 0.210 ;
     END
   END rw0_wd_in[74]
@@ -829,7 +829,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 36.635 0.000 36.705 0.210 ;
     END
   END rw0_wd_in[75]
@@ -838,7 +838,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 39.865 0.000 39.935 0.210 ;
     END
   END rw0_wd_in[76]
@@ -847,7 +847,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 43.095 0.000 43.165 0.210 ;
     END
   END rw0_wd_in[77]
@@ -856,7 +856,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 46.325 0.000 46.395 0.210 ;
     END
   END rw0_wd_in[78]
@@ -865,7 +865,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 49.555 0.000 49.625 0.210 ;
     END
   END rw0_wd_in[79]
@@ -874,7 +874,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 52.785 0.000 52.855 0.210 ;
     END
   END rw0_wd_in[80]
@@ -883,7 +883,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 56.015 0.000 56.085 0.210 ;
     END
   END rw0_wd_in[81]
@@ -892,7 +892,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 59.245 0.000 59.315 0.210 ;
     END
   END rw0_wd_in[82]
@@ -901,7 +901,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 62.475 0.000 62.545 0.210 ;
     END
   END rw0_wd_in[83]
@@ -910,7 +910,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 65.705 0.000 65.775 0.210 ;
     END
   END rw0_wd_in[84]
@@ -919,7 +919,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 68.935 0.000 69.005 0.210 ;
     END
   END rw0_wd_in[85]
@@ -928,7 +928,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 72.165 0.000 72.235 0.210 ;
     END
   END rw0_wd_in[86]
@@ -937,7 +937,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 75.395 0.000 75.465 0.210 ;
     END
   END rw0_wd_in[87]
@@ -946,7 +946,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 78.625 0.000 78.695 0.210 ;
     END
   END rw0_wd_in[88]
@@ -955,7 +955,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 81.855 0.000 81.925 0.210 ;
     END
   END rw0_wd_in[89]
@@ -964,7 +964,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 85.085 0.000 85.155 0.210 ;
     END
   END rw0_wd_in[90]
@@ -973,7 +973,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 88.315 0.000 88.385 0.210 ;
     END
   END rw0_wd_in[91]
@@ -982,7 +982,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 91.545 0.000 91.615 0.210 ;
     END
   END rw0_wd_in[92]
@@ -991,7 +991,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 94.775 0.000 94.845 0.210 ;
     END
   END rw0_wd_in[93]
@@ -1000,7 +1000,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 98.005 0.000 98.075 0.210 ;
     END
   END rw0_wd_in[94]
@@ -1009,7 +1009,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 101.235 0.000 101.305 0.210 ;
     END
   END rw0_wd_in[95]
@@ -1018,7 +1018,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 104.465 0.000 104.535 0.210 ;
     END
   END rw0_wd_in[96]
@@ -1027,7 +1027,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 107.695 0.000 107.765 0.210 ;
     END
   END rw0_wd_in[97]
@@ -1036,7 +1036,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 110.925 0.000 110.995 0.210 ;
     END
   END rw0_wd_in[98]
@@ -1045,7 +1045,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 114.155 0.000 114.225 0.210 ;
     END
   END rw0_wd_in[99]
@@ -1054,7 +1054,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 117.385 0.000 117.455 0.210 ;
     END
   END rw0_wd_in[100]
@@ -1063,7 +1063,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 120.615 0.000 120.685 0.210 ;
     END
   END rw0_wd_in[101]
@@ -1072,7 +1072,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 123.845 0.000 123.915 0.210 ;
     END
   END rw0_wd_in[102]
@@ -1081,7 +1081,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 127.075 0.000 127.145 0.210 ;
     END
   END rw0_wd_in[103]
@@ -1090,7 +1090,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 130.305 0.000 130.375 0.210 ;
     END
   END rw0_wd_in[104]
@@ -1099,7 +1099,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 133.535 0.000 133.605 0.210 ;
     END
   END rw0_wd_in[105]
@@ -1108,7 +1108,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 136.765 0.000 136.835 0.210 ;
     END
   END rw0_wd_in[106]
@@ -1117,7 +1117,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 139.995 0.000 140.065 0.210 ;
     END
   END rw0_wd_in[107]
@@ -1126,7 +1126,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 143.225 0.000 143.295 0.210 ;
     END
   END rw0_wd_in[108]
@@ -1135,7 +1135,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 146.455 0.000 146.525 0.210 ;
     END
   END rw0_wd_in[109]
@@ -1144,7 +1144,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 149.685 0.000 149.755 0.210 ;
     END
   END rw0_wd_in[110]
@@ -1153,7 +1153,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 152.915 0.000 152.985 0.210 ;
     END
   END rw0_wd_in[111]
@@ -1162,7 +1162,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 156.145 0.000 156.215 0.210 ;
     END
   END rw0_wd_in[112]
@@ -1171,7 +1171,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 159.375 0.000 159.445 0.210 ;
     END
   END rw0_wd_in[113]
@@ -1180,7 +1180,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 162.605 0.000 162.675 0.210 ;
     END
   END rw0_wd_in[114]
@@ -1189,7 +1189,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 165.835 0.000 165.905 0.210 ;
     END
   END rw0_wd_in[115]
@@ -1198,7 +1198,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 169.065 0.000 169.135 0.210 ;
     END
   END rw0_wd_in[116]
@@ -1207,7 +1207,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 172.295 0.000 172.365 0.210 ;
     END
   END rw0_wd_in[117]
@@ -1216,7 +1216,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 175.525 0.000 175.595 0.210 ;
     END
   END rw0_wd_in[118]
@@ -1225,7 +1225,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 178.755 0.000 178.825 0.210 ;
     END
   END rw0_wd_in[119]
@@ -1234,7 +1234,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 181.985 0.000 182.055 0.210 ;
     END
   END rw0_wd_in[120]
@@ -1243,7 +1243,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 185.215 0.000 185.285 0.210 ;
     END
   END rw0_wd_in[121]
@@ -1252,7 +1252,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 188.445 0.000 188.515 0.210 ;
     END
   END rw0_wd_in[122]
@@ -1261,7 +1261,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 191.675 0.000 191.745 0.210 ;
     END
   END rw0_wd_in[123]
@@ -1270,7 +1270,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 194.905 0.000 194.975 0.210 ;
     END
   END rw0_wd_in[124]
@@ -1279,7 +1279,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 198.135 0.000 198.205 0.210 ;
     END
   END rw0_wd_in[125]
@@ -1288,7 +1288,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 201.365 0.000 201.435 0.210 ;
     END
   END rw0_wd_in[126]
@@ -1297,7 +1297,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 204.595 0.000 204.665 0.210 ;
     END
   END rw0_wd_in[127]
@@ -1306,7 +1306,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 207.825 0.000 207.895 0.210 ;
     END
   END rw0_rd_out[0]
@@ -1315,7 +1315,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 211.055 0.000 211.125 0.210 ;
     END
   END rw0_rd_out[1]
@@ -1324,7 +1324,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 214.285 0.000 214.355 0.210 ;
     END
   END rw0_rd_out[2]
@@ -1333,7 +1333,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 217.515 0.000 217.585 0.210 ;
     END
   END rw0_rd_out[3]
@@ -1342,7 +1342,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 220.745 0.000 220.815 0.210 ;
     END
   END rw0_rd_out[4]
@@ -1351,7 +1351,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 223.975 0.000 224.045 0.210 ;
     END
   END rw0_rd_out[5]
@@ -1360,7 +1360,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 227.205 0.000 227.275 0.210 ;
     END
   END rw0_rd_out[6]
@@ -1369,7 +1369,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 230.435 0.000 230.505 0.210 ;
     END
   END rw0_rd_out[7]
@@ -1378,7 +1378,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 233.665 0.000 233.735 0.210 ;
     END
   END rw0_rd_out[8]
@@ -1387,7 +1387,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 236.895 0.000 236.965 0.210 ;
     END
   END rw0_rd_out[9]
@@ -1396,7 +1396,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 240.125 0.000 240.195 0.210 ;
     END
   END rw0_rd_out[10]
@@ -1405,7 +1405,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 243.355 0.000 243.425 0.210 ;
     END
   END rw0_rd_out[11]
@@ -1414,7 +1414,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 246.585 0.000 246.655 0.210 ;
     END
   END rw0_rd_out[12]
@@ -1423,7 +1423,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 249.815 0.000 249.885 0.210 ;
     END
   END rw0_rd_out[13]
@@ -1432,7 +1432,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 253.045 0.000 253.115 0.210 ;
     END
   END rw0_rd_out[14]
@@ -1441,7 +1441,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 256.275 0.000 256.345 0.210 ;
     END
   END rw0_rd_out[15]
@@ -1450,7 +1450,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 259.505 0.000 259.575 0.210 ;
     END
   END rw0_rd_out[16]
@@ -1459,7 +1459,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 262.735 0.000 262.805 0.210 ;
     END
   END rw0_rd_out[17]
@@ -1468,7 +1468,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 265.965 0.000 266.035 0.210 ;
     END
   END rw0_rd_out[18]
@@ -1477,7 +1477,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 269.195 0.000 269.265 0.210 ;
     END
   END rw0_rd_out[19]
@@ -1486,7 +1486,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 272.425 0.000 272.495 0.210 ;
     END
   END rw0_rd_out[20]
@@ -1495,7 +1495,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 275.655 0.000 275.725 0.210 ;
     END
   END rw0_rd_out[21]
@@ -1504,7 +1504,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 278.885 0.000 278.955 0.210 ;
     END
   END rw0_rd_out[22]
@@ -1513,7 +1513,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 282.115 0.000 282.185 0.210 ;
     END
   END rw0_rd_out[23]
@@ -1522,7 +1522,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 285.345 0.000 285.415 0.210 ;
     END
   END rw0_rd_out[24]
@@ -1531,7 +1531,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 288.575 0.000 288.645 0.210 ;
     END
   END rw0_rd_out[25]
@@ -1540,7 +1540,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 291.805 0.000 291.875 0.210 ;
     END
   END rw0_rd_out[26]
@@ -1549,7 +1549,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 295.035 0.000 295.105 0.210 ;
     END
   END rw0_rd_out[27]
@@ -1558,7 +1558,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 298.265 0.000 298.335 0.210 ;
     END
   END rw0_rd_out[28]
@@ -1567,7 +1567,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 301.495 0.000 301.565 0.210 ;
     END
   END rw0_rd_out[29]
@@ -1576,7 +1576,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 304.725 0.000 304.795 0.210 ;
     END
   END rw0_rd_out[30]
@@ -1585,7 +1585,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 307.955 0.000 308.025 0.210 ;
     END
   END rw0_rd_out[31]
@@ -1594,7 +1594,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 311.185 0.000 311.255 0.210 ;
     END
   END rw0_rd_out[32]
@@ -1603,7 +1603,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 314.415 0.000 314.485 0.210 ;
     END
   END rw0_rd_out[33]
@@ -1612,7 +1612,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 317.645 0.000 317.715 0.210 ;
     END
   END rw0_rd_out[34]
@@ -1621,7 +1621,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 320.875 0.000 320.945 0.210 ;
     END
   END rw0_rd_out[35]
@@ -1630,7 +1630,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 324.105 0.000 324.175 0.210 ;
     END
   END rw0_rd_out[36]
@@ -1639,7 +1639,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 327.335 0.000 327.405 0.210 ;
     END
   END rw0_rd_out[37]
@@ -1648,7 +1648,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 330.565 0.000 330.635 0.210 ;
     END
   END rw0_rd_out[38]
@@ -1657,7 +1657,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 333.795 0.000 333.865 0.210 ;
     END
   END rw0_rd_out[39]
@@ -1666,7 +1666,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 337.025 0.000 337.095 0.210 ;
     END
   END rw0_rd_out[40]
@@ -1675,7 +1675,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 340.255 0.000 340.325 0.210 ;
     END
   END rw0_rd_out[41]
@@ -1684,7 +1684,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 343.485 0.000 343.555 0.210 ;
     END
   END rw0_rd_out[42]
@@ -1693,7 +1693,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 346.715 0.000 346.785 0.210 ;
     END
   END rw0_rd_out[43]
@@ -1702,7 +1702,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 349.945 0.000 350.015 0.210 ;
     END
   END rw0_rd_out[44]
@@ -1711,7 +1711,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 353.175 0.000 353.245 0.210 ;
     END
   END rw0_rd_out[45]
@@ -1720,7 +1720,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 356.405 0.000 356.475 0.210 ;
     END
   END rw0_rd_out[46]
@@ -1729,7 +1729,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 359.635 0.000 359.705 0.210 ;
     END
   END rw0_rd_out[47]
@@ -1738,7 +1738,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 362.865 0.000 362.935 0.210 ;
     END
   END rw0_rd_out[48]
@@ -1747,7 +1747,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 366.095 0.000 366.165 0.210 ;
     END
   END rw0_rd_out[49]
@@ -1756,7 +1756,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 369.325 0.000 369.395 0.210 ;
     END
   END rw0_rd_out[50]
@@ -1765,7 +1765,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 372.555 0.000 372.625 0.210 ;
     END
   END rw0_rd_out[51]
@@ -1774,7 +1774,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 375.785 0.000 375.855 0.210 ;
     END
   END rw0_rd_out[52]
@@ -1783,7 +1783,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 379.015 0.000 379.085 0.210 ;
     END
   END rw0_rd_out[53]
@@ -1792,7 +1792,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 382.245 0.000 382.315 0.210 ;
     END
   END rw0_rd_out[54]
@@ -1801,7 +1801,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 385.475 0.000 385.545 0.210 ;
     END
   END rw0_rd_out[55]
@@ -1810,7 +1810,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 388.705 0.000 388.775 0.210 ;
     END
   END rw0_rd_out[56]
@@ -1819,7 +1819,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 391.935 0.000 392.005 0.210 ;
     END
   END rw0_rd_out[57]
@@ -1828,7 +1828,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 395.165 0.000 395.235 0.210 ;
     END
   END rw0_rd_out[58]
@@ -1837,7 +1837,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 398.395 0.000 398.465 0.210 ;
     END
   END rw0_rd_out[59]
@@ -1846,7 +1846,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 401.625 0.000 401.695 0.210 ;
     END
   END rw0_rd_out[60]
@@ -1855,7 +1855,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 404.855 0.000 404.925 0.210 ;
     END
   END rw0_rd_out[61]
@@ -1864,7 +1864,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 408.085 0.000 408.155 0.210 ;
     END
   END rw0_rd_out[62]
@@ -1873,7 +1873,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 411.315 0.000 411.385 0.210 ;
     END
   END rw0_rd_out[63]
@@ -1882,7 +1882,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 25.425 499.590 25.495 499.800 ;
     END
   END rw0_rd_out[64]
@@ -1891,7 +1891,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 28.465 499.590 28.535 499.800 ;
     END
   END rw0_rd_out[65]
@@ -1900,7 +1900,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 31.505 499.590 31.575 499.800 ;
     END
   END rw0_rd_out[66]
@@ -1909,7 +1909,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 34.545 499.590 34.615 499.800 ;
     END
   END rw0_rd_out[67]
@@ -1918,7 +1918,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 37.585 499.590 37.655 499.800 ;
     END
   END rw0_rd_out[68]
@@ -1927,7 +1927,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 40.625 499.590 40.695 499.800 ;
     END
   END rw0_rd_out[69]
@@ -1936,7 +1936,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 43.665 499.590 43.735 499.800 ;
     END
   END rw0_rd_out[70]
@@ -1945,7 +1945,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 46.705 499.590 46.775 499.800 ;
     END
   END rw0_rd_out[71]
@@ -1954,7 +1954,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 49.745 499.590 49.815 499.800 ;
     END
   END rw0_rd_out[72]
@@ -1963,7 +1963,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 52.785 499.590 52.855 499.800 ;
     END
   END rw0_rd_out[73]
@@ -1972,7 +1972,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 55.825 499.590 55.895 499.800 ;
     END
   END rw0_rd_out[74]
@@ -1981,7 +1981,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 58.865 499.590 58.935 499.800 ;
     END
   END rw0_rd_out[75]
@@ -1990,7 +1990,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 61.905 499.590 61.975 499.800 ;
     END
   END rw0_rd_out[76]
@@ -1999,7 +1999,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 64.945 499.590 65.015 499.800 ;
     END
   END rw0_rd_out[77]
@@ -2008,7 +2008,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 67.985 499.590 68.055 499.800 ;
     END
   END rw0_rd_out[78]
@@ -2017,7 +2017,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 71.025 499.590 71.095 499.800 ;
     END
   END rw0_rd_out[79]
@@ -2026,7 +2026,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 74.065 499.590 74.135 499.800 ;
     END
   END rw0_rd_out[80]
@@ -2035,7 +2035,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 77.105 499.590 77.175 499.800 ;
     END
   END rw0_rd_out[81]
@@ -2044,7 +2044,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 80.145 499.590 80.215 499.800 ;
     END
   END rw0_rd_out[82]
@@ -2053,7 +2053,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 83.185 499.590 83.255 499.800 ;
     END
   END rw0_rd_out[83]
@@ -2062,7 +2062,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 86.225 499.590 86.295 499.800 ;
     END
   END rw0_rd_out[84]
@@ -2071,7 +2071,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 89.265 499.590 89.335 499.800 ;
     END
   END rw0_rd_out[85]
@@ -2080,7 +2080,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 92.305 499.590 92.375 499.800 ;
     END
   END rw0_rd_out[86]
@@ -2089,7 +2089,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 95.345 499.590 95.415 499.800 ;
     END
   END rw0_rd_out[87]
@@ -2098,7 +2098,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 98.385 499.590 98.455 499.800 ;
     END
   END rw0_rd_out[88]
@@ -2107,7 +2107,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 101.425 499.590 101.495 499.800 ;
     END
   END rw0_rd_out[89]
@@ -2116,7 +2116,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 104.465 499.590 104.535 499.800 ;
     END
   END rw0_rd_out[90]
@@ -2125,7 +2125,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 107.505 499.590 107.575 499.800 ;
     END
   END rw0_rd_out[91]
@@ -2134,7 +2134,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 110.545 499.590 110.615 499.800 ;
     END
   END rw0_rd_out[92]
@@ -2143,7 +2143,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 113.585 499.590 113.655 499.800 ;
     END
   END rw0_rd_out[93]
@@ -2152,7 +2152,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 116.625 499.590 116.695 499.800 ;
     END
   END rw0_rd_out[94]
@@ -2161,7 +2161,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 119.665 499.590 119.735 499.800 ;
     END
   END rw0_rd_out[95]
@@ -2170,7 +2170,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 122.705 499.590 122.775 499.800 ;
     END
   END rw0_rd_out[96]
@@ -2179,7 +2179,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 125.745 499.590 125.815 499.800 ;
     END
   END rw0_rd_out[97]
@@ -2188,7 +2188,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 128.785 499.590 128.855 499.800 ;
     END
   END rw0_rd_out[98]
@@ -2197,7 +2197,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 131.825 499.590 131.895 499.800 ;
     END
   END rw0_rd_out[99]
@@ -2206,7 +2206,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 134.865 499.590 134.935 499.800 ;
     END
   END rw0_rd_out[100]
@@ -2215,7 +2215,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 137.905 499.590 137.975 499.800 ;
     END
   END rw0_rd_out[101]
@@ -2224,7 +2224,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 140.945 499.590 141.015 499.800 ;
     END
   END rw0_rd_out[102]
@@ -2233,7 +2233,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 143.985 499.590 144.055 499.800 ;
     END
   END rw0_rd_out[103]
@@ -2242,7 +2242,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 147.025 499.590 147.095 499.800 ;
     END
   END rw0_rd_out[104]
@@ -2251,7 +2251,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 150.065 499.590 150.135 499.800 ;
     END
   END rw0_rd_out[105]
@@ -2260,7 +2260,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 153.105 499.590 153.175 499.800 ;
     END
   END rw0_rd_out[106]
@@ -2269,7 +2269,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 156.145 499.590 156.215 499.800 ;
     END
   END rw0_rd_out[107]
@@ -2278,7 +2278,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 159.185 499.590 159.255 499.800 ;
     END
   END rw0_rd_out[108]
@@ -2287,7 +2287,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 162.225 499.590 162.295 499.800 ;
     END
   END rw0_rd_out[109]
@@ -2296,7 +2296,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 165.265 499.590 165.335 499.800 ;
     END
   END rw0_rd_out[110]
@@ -2305,7 +2305,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 168.305 499.590 168.375 499.800 ;
     END
   END rw0_rd_out[111]
@@ -2314,7 +2314,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 171.345 499.590 171.415 499.800 ;
     END
   END rw0_rd_out[112]
@@ -2323,7 +2323,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 174.385 499.590 174.455 499.800 ;
     END
   END rw0_rd_out[113]
@@ -2332,7 +2332,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 177.425 499.590 177.495 499.800 ;
     END
   END rw0_rd_out[114]
@@ -2341,7 +2341,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 180.465 499.590 180.535 499.800 ;
     END
   END rw0_rd_out[115]
@@ -2350,7 +2350,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 183.505 499.590 183.575 499.800 ;
     END
   END rw0_rd_out[116]
@@ -2359,7 +2359,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 186.545 499.590 186.615 499.800 ;
     END
   END rw0_rd_out[117]
@@ -2368,7 +2368,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 189.585 499.590 189.655 499.800 ;
     END
   END rw0_rd_out[118]
@@ -2377,7 +2377,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 192.625 499.590 192.695 499.800 ;
     END
   END rw0_rd_out[119]
@@ -2386,7 +2386,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 195.665 499.590 195.735 499.800 ;
     END
   END rw0_rd_out[120]
@@ -2395,7 +2395,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 198.705 499.590 198.775 499.800 ;
     END
   END rw0_rd_out[121]
@@ -2404,7 +2404,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 201.745 499.590 201.815 499.800 ;
     END
   END rw0_rd_out[122]
@@ -2413,7 +2413,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 204.785 499.590 204.855 499.800 ;
     END
   END rw0_rd_out[123]
@@ -2422,7 +2422,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 207.825 499.590 207.895 499.800 ;
     END
   END rw0_rd_out[124]
@@ -2431,7 +2431,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 210.865 499.590 210.935 499.800 ;
     END
   END rw0_rd_out[125]
@@ -2440,7 +2440,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 213.905 499.590 213.975 499.800 ;
     END
   END rw0_rd_out[126]
@@ -2449,7 +2449,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 216.945 499.590 217.015 499.800 ;
     END
   END rw0_rd_out[127]
@@ -2458,7 +2458,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 252.805 0.210 252.875 ;
     END
   END rw0_addr_in[0]
@@ -2467,7 +2467,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 259.805 0.210 259.875 ;
     END
   END rw0_addr_in[1]
@@ -2476,7 +2476,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 266.805 0.210 266.875 ;
     END
   END rw0_addr_in[2]
@@ -2485,7 +2485,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 273.805 0.210 273.875 ;
     END
   END rw0_addr_in[3]
@@ -2494,7 +2494,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 280.805 0.210 280.875 ;
     END
   END rw0_addr_in[4]
@@ -2503,7 +2503,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 287.805 0.210 287.875 ;
     END
   END rw0_addr_in[5]
@@ -2512,7 +2512,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 252.805 418.760 252.875 ;
     END
   END rw0_addr_in[6]
@@ -2521,7 +2521,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 259.805 418.760 259.875 ;
     END
   END rw0_addr_in[7]
@@ -2530,7 +2530,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 266.805 418.760 266.875 ;
     END
   END rw0_addr_in[8]
@@ -2539,7 +2539,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 273.805 418.760 273.875 ;
     END
   END rw0_addr_in[9]
@@ -2548,7 +2548,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 418.550 280.805 418.760 280.875 ;
     END
   END rw0_addr_in[10]
@@ -2557,7 +2557,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 219.985 499.590 220.055 499.800 ;
     END
   END rw0_we_in
@@ -2566,7 +2566,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 223.025 499.590 223.095 499.800 ;
     END
   END rw0_ce_in
@@ -2575,7 +2575,7 @@ MACRO fakeram_2048x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 226.065 499.590 226.135 499.800 ;
     END
   END rw0_clk
@@ -2584,229 +2584,193 @@ MACRO fakeram_2048x128_1rw
     USE GROUND ;
     PORT
       LAYER metal4 ;
-      RECT 1.140 0.700 417.620 0.980 ;
-      RECT 1.140 2.940 417.620 3.220 ;
-      RECT 1.140 5.180 417.620 5.460 ;
-      RECT 1.140 7.420 417.620 7.700 ;
-      RECT 1.140 9.660 417.620 9.940 ;
-      RECT 1.140 11.900 417.620 12.180 ;
-      RECT 1.140 14.140 417.620 14.420 ;
-      RECT 1.140 16.380 417.620 16.660 ;
-      RECT 1.140 18.620 417.620 18.900 ;
-      RECT 1.140 20.860 417.620 21.140 ;
-      RECT 1.140 23.100 417.620 23.380 ;
-      RECT 1.140 25.340 417.620 25.620 ;
-      RECT 1.140 27.580 417.620 27.860 ;
-      RECT 1.140 29.820 417.620 30.100 ;
-      RECT 1.140 32.060 417.620 32.340 ;
-      RECT 1.140 34.300 417.620 34.580 ;
-      RECT 1.140 36.540 417.620 36.820 ;
-      RECT 1.140 38.780 417.620 39.060 ;
-      RECT 1.140 41.020 417.620 41.300 ;
-      RECT 1.140 43.260 417.620 43.540 ;
-      RECT 1.140 45.500 417.620 45.780 ;
-      RECT 1.140 47.740 417.620 48.020 ;
-      RECT 1.140 49.980 417.620 50.260 ;
-      RECT 1.140 52.220 417.620 52.500 ;
-      RECT 1.140 54.460 417.620 54.740 ;
-      RECT 1.140 56.700 417.620 56.980 ;
-      RECT 1.140 58.940 417.620 59.220 ;
-      RECT 1.140 61.180 417.620 61.460 ;
-      RECT 1.140 63.420 417.620 63.700 ;
-      RECT 1.140 65.660 417.620 65.940 ;
-      RECT 1.140 67.900 417.620 68.180 ;
-      RECT 1.140 70.140 417.620 70.420 ;
-      RECT 1.140 72.380 417.620 72.660 ;
-      RECT 1.140 74.620 417.620 74.900 ;
-      RECT 1.140 76.860 417.620 77.140 ;
-      RECT 1.140 79.100 417.620 79.380 ;
-      RECT 1.140 81.340 417.620 81.620 ;
-      RECT 1.140 83.580 417.620 83.860 ;
-      RECT 1.140 85.820 417.620 86.100 ;
-      RECT 1.140 88.060 417.620 88.340 ;
-      RECT 1.140 90.300 417.620 90.580 ;
-      RECT 1.140 92.540 417.620 92.820 ;
-      RECT 1.140 94.780 417.620 95.060 ;
-      RECT 1.140 97.020 417.620 97.300 ;
-      RECT 1.140 99.260 417.620 99.540 ;
-      RECT 1.140 101.500 417.620 101.780 ;
-      RECT 1.140 103.740 417.620 104.020 ;
-      RECT 1.140 105.980 417.620 106.260 ;
-      RECT 1.140 108.220 417.620 108.500 ;
-      RECT 1.140 110.460 417.620 110.740 ;
-      RECT 1.140 112.700 417.620 112.980 ;
-      RECT 1.140 114.940 417.620 115.220 ;
-      RECT 1.140 117.180 417.620 117.460 ;
-      RECT 1.140 119.420 417.620 119.700 ;
-      RECT 1.140 121.660 417.620 121.940 ;
-      RECT 1.140 123.900 417.620 124.180 ;
-      RECT 1.140 126.140 417.620 126.420 ;
-      RECT 1.140 128.380 417.620 128.660 ;
-      RECT 1.140 130.620 417.620 130.900 ;
-      RECT 1.140 132.860 417.620 133.140 ;
-      RECT 1.140 135.100 417.620 135.380 ;
-      RECT 1.140 137.340 417.620 137.620 ;
-      RECT 1.140 139.580 417.620 139.860 ;
-      RECT 1.140 141.820 417.620 142.100 ;
-      RECT 1.140 144.060 417.620 144.340 ;
-      RECT 1.140 146.300 417.620 146.580 ;
-      RECT 1.140 148.540 417.620 148.820 ;
-      RECT 1.140 150.780 417.620 151.060 ;
-      RECT 1.140 153.020 417.620 153.300 ;
-      RECT 1.140 155.260 417.620 155.540 ;
-      RECT 1.140 157.500 417.620 157.780 ;
-      RECT 1.140 159.740 417.620 160.020 ;
-      RECT 1.140 161.980 417.620 162.260 ;
-      RECT 1.140 164.220 417.620 164.500 ;
-      RECT 1.140 166.460 417.620 166.740 ;
-      RECT 1.140 168.700 417.620 168.980 ;
-      RECT 1.140 170.940 417.620 171.220 ;
-      RECT 1.140 173.180 417.620 173.460 ;
-      RECT 1.140 175.420 417.620 175.700 ;
-      RECT 1.140 177.660 417.620 177.940 ;
-      RECT 1.140 179.900 417.620 180.180 ;
-      RECT 1.140 182.140 417.620 182.420 ;
-      RECT 1.140 184.380 417.620 184.660 ;
-      RECT 1.140 186.620 417.620 186.900 ;
-      RECT 1.140 188.860 417.620 189.140 ;
-      RECT 1.140 191.100 417.620 191.380 ;
-      RECT 1.140 193.340 417.620 193.620 ;
-      RECT 1.140 195.580 417.620 195.860 ;
-      RECT 1.140 197.820 417.620 198.100 ;
-      RECT 1.140 200.060 417.620 200.340 ;
-      RECT 1.140 202.300 417.620 202.580 ;
-      RECT 1.140 204.540 417.620 204.820 ;
-      RECT 1.140 206.780 417.620 207.060 ;
-      RECT 1.140 209.020 417.620 209.300 ;
-      RECT 1.140 211.260 417.620 211.540 ;
-      RECT 1.140 213.500 417.620 213.780 ;
-      RECT 1.140 215.740 417.620 216.020 ;
-      RECT 1.140 217.980 417.620 218.260 ;
-      RECT 1.140 220.220 417.620 220.500 ;
-      RECT 1.140 222.460 417.620 222.740 ;
-      RECT 1.140 224.700 417.620 224.980 ;
-      RECT 1.140 226.940 417.620 227.220 ;
-      RECT 1.140 229.180 417.620 229.460 ;
-      RECT 1.140 231.420 417.620 231.700 ;
-      RECT 1.140 233.660 417.620 233.940 ;
-      RECT 1.140 235.900 417.620 236.180 ;
-      RECT 1.140 238.140 417.620 238.420 ;
-      RECT 1.140 240.380 417.620 240.660 ;
-      RECT 1.140 242.620 417.620 242.900 ;
-      RECT 1.140 244.860 417.620 245.140 ;
-      RECT 1.140 247.100 417.620 247.380 ;
-      RECT 1.140 249.340 417.620 249.620 ;
-      RECT 1.140 251.580 417.620 251.860 ;
-      RECT 1.140 253.820 417.620 254.100 ;
-      RECT 1.140 256.060 417.620 256.340 ;
-      RECT 1.140 258.300 417.620 258.580 ;
-      RECT 1.140 260.540 417.620 260.820 ;
-      RECT 1.140 262.780 417.620 263.060 ;
-      RECT 1.140 265.020 417.620 265.300 ;
-      RECT 1.140 267.260 417.620 267.540 ;
-      RECT 1.140 269.500 417.620 269.780 ;
-      RECT 1.140 271.740 417.620 272.020 ;
-      RECT 1.140 273.980 417.620 274.260 ;
-      RECT 1.140 276.220 417.620 276.500 ;
-      RECT 1.140 278.460 417.620 278.740 ;
-      RECT 1.140 280.700 417.620 280.980 ;
-      RECT 1.140 282.940 417.620 283.220 ;
-      RECT 1.140 285.180 417.620 285.460 ;
-      RECT 1.140 287.420 417.620 287.700 ;
-      RECT 1.140 289.660 417.620 289.940 ;
-      RECT 1.140 291.900 417.620 292.180 ;
-      RECT 1.140 294.140 417.620 294.420 ;
-      RECT 1.140 296.380 417.620 296.660 ;
-      RECT 1.140 298.620 417.620 298.900 ;
-      RECT 1.140 300.860 417.620 301.140 ;
-      RECT 1.140 303.100 417.620 303.380 ;
-      RECT 1.140 305.340 417.620 305.620 ;
-      RECT 1.140 307.580 417.620 307.860 ;
-      RECT 1.140 309.820 417.620 310.100 ;
-      RECT 1.140 312.060 417.620 312.340 ;
-      RECT 1.140 314.300 417.620 314.580 ;
-      RECT 1.140 316.540 417.620 316.820 ;
-      RECT 1.140 318.780 417.620 319.060 ;
-      RECT 1.140 321.020 417.620 321.300 ;
-      RECT 1.140 323.260 417.620 323.540 ;
-      RECT 1.140 325.500 417.620 325.780 ;
-      RECT 1.140 327.740 417.620 328.020 ;
-      RECT 1.140 329.980 417.620 330.260 ;
-      RECT 1.140 332.220 417.620 332.500 ;
-      RECT 1.140 334.460 417.620 334.740 ;
-      RECT 1.140 336.700 417.620 336.980 ;
-      RECT 1.140 338.940 417.620 339.220 ;
-      RECT 1.140 341.180 417.620 341.460 ;
-      RECT 1.140 343.420 417.620 343.700 ;
-      RECT 1.140 345.660 417.620 345.940 ;
-      RECT 1.140 347.900 417.620 348.180 ;
-      RECT 1.140 350.140 417.620 350.420 ;
-      RECT 1.140 352.380 417.620 352.660 ;
-      RECT 1.140 354.620 417.620 354.900 ;
-      RECT 1.140 356.860 417.620 357.140 ;
-      RECT 1.140 359.100 417.620 359.380 ;
-      RECT 1.140 361.340 417.620 361.620 ;
-      RECT 1.140 363.580 417.620 363.860 ;
-      RECT 1.140 365.820 417.620 366.100 ;
-      RECT 1.140 368.060 417.620 368.340 ;
-      RECT 1.140 370.300 417.620 370.580 ;
-      RECT 1.140 372.540 417.620 372.820 ;
-      RECT 1.140 374.780 417.620 375.060 ;
-      RECT 1.140 377.020 417.620 377.300 ;
-      RECT 1.140 379.260 417.620 379.540 ;
-      RECT 1.140 381.500 417.620 381.780 ;
-      RECT 1.140 383.740 417.620 384.020 ;
-      RECT 1.140 385.980 417.620 386.260 ;
-      RECT 1.140 388.220 417.620 388.500 ;
-      RECT 1.140 390.460 417.620 390.740 ;
-      RECT 1.140 392.700 417.620 392.980 ;
-      RECT 1.140 394.940 417.620 395.220 ;
-      RECT 1.140 397.180 417.620 397.460 ;
-      RECT 1.140 399.420 417.620 399.700 ;
-      RECT 1.140 401.660 417.620 401.940 ;
-      RECT 1.140 403.900 417.620 404.180 ;
-      RECT 1.140 406.140 417.620 406.420 ;
-      RECT 1.140 408.380 417.620 408.660 ;
-      RECT 1.140 410.620 417.620 410.900 ;
-      RECT 1.140 412.860 417.620 413.140 ;
-      RECT 1.140 415.100 417.620 415.380 ;
-      RECT 1.140 417.340 417.620 417.620 ;
-      RECT 1.140 419.580 417.620 419.860 ;
-      RECT 1.140 421.820 417.620 422.100 ;
-      RECT 1.140 424.060 417.620 424.340 ;
-      RECT 1.140 426.300 417.620 426.580 ;
-      RECT 1.140 428.540 417.620 428.820 ;
-      RECT 1.140 430.780 417.620 431.060 ;
-      RECT 1.140 433.020 417.620 433.300 ;
-      RECT 1.140 435.260 417.620 435.540 ;
-      RECT 1.140 437.500 417.620 437.780 ;
-      RECT 1.140 439.740 417.620 440.020 ;
-      RECT 1.140 441.980 417.620 442.260 ;
-      RECT 1.140 444.220 417.620 444.500 ;
-      RECT 1.140 446.460 417.620 446.740 ;
-      RECT 1.140 448.700 417.620 448.980 ;
-      RECT 1.140 450.940 417.620 451.220 ;
-      RECT 1.140 453.180 417.620 453.460 ;
-      RECT 1.140 455.420 417.620 455.700 ;
-      RECT 1.140 457.660 417.620 457.940 ;
-      RECT 1.140 459.900 417.620 460.180 ;
-      RECT 1.140 462.140 417.620 462.420 ;
-      RECT 1.140 464.380 417.620 464.660 ;
-      RECT 1.140 466.620 417.620 466.900 ;
-      RECT 1.140 468.860 417.620 469.140 ;
-      RECT 1.140 471.100 417.620 471.380 ;
-      RECT 1.140 473.340 417.620 473.620 ;
-      RECT 1.140 475.580 417.620 475.860 ;
-      RECT 1.140 477.820 417.620 478.100 ;
-      RECT 1.140 480.060 417.620 480.340 ;
-      RECT 1.140 482.300 417.620 482.580 ;
-      RECT 1.140 484.540 417.620 484.820 ;
-      RECT 1.140 486.780 417.620 487.060 ;
-      RECT 1.140 489.020 417.620 489.300 ;
-      RECT 1.140 491.260 417.620 491.540 ;
-      RECT 1.140 493.500 417.620 493.780 ;
-      RECT 1.140 495.740 417.620 496.020 ;
-      RECT 1.140 497.980 417.620 498.260 ;
+      RECT 1.000 0.840 1.280 498.960 ;
+      RECT 3.240 0.840 3.520 498.960 ;
+      RECT 5.480 0.840 5.760 498.960 ;
+      RECT 7.720 0.840 8.000 498.960 ;
+      RECT 9.960 0.840 10.240 498.960 ;
+      RECT 12.200 0.840 12.480 498.960 ;
+      RECT 14.440 0.840 14.720 498.960 ;
+      RECT 16.680 0.840 16.960 498.960 ;
+      RECT 18.920 0.840 19.200 498.960 ;
+      RECT 21.160 0.840 21.440 498.960 ;
+      RECT 23.400 0.840 23.680 498.960 ;
+      RECT 25.640 0.840 25.920 498.960 ;
+      RECT 27.880 0.840 28.160 498.960 ;
+      RECT 30.120 0.840 30.400 498.960 ;
+      RECT 32.360 0.840 32.640 498.960 ;
+      RECT 34.600 0.840 34.880 498.960 ;
+      RECT 36.840 0.840 37.120 498.960 ;
+      RECT 39.080 0.840 39.360 498.960 ;
+      RECT 41.320 0.840 41.600 498.960 ;
+      RECT 43.560 0.840 43.840 498.960 ;
+      RECT 45.800 0.840 46.080 498.960 ;
+      RECT 48.040 0.840 48.320 498.960 ;
+      RECT 50.280 0.840 50.560 498.960 ;
+      RECT 52.520 0.840 52.800 498.960 ;
+      RECT 54.760 0.840 55.040 498.960 ;
+      RECT 57.000 0.840 57.280 498.960 ;
+      RECT 59.240 0.840 59.520 498.960 ;
+      RECT 61.480 0.840 61.760 498.960 ;
+      RECT 63.720 0.840 64.000 498.960 ;
+      RECT 65.960 0.840 66.240 498.960 ;
+      RECT 68.200 0.840 68.480 498.960 ;
+      RECT 70.440 0.840 70.720 498.960 ;
+      RECT 72.680 0.840 72.960 498.960 ;
+      RECT 74.920 0.840 75.200 498.960 ;
+      RECT 77.160 0.840 77.440 498.960 ;
+      RECT 79.400 0.840 79.680 498.960 ;
+      RECT 81.640 0.840 81.920 498.960 ;
+      RECT 83.880 0.840 84.160 498.960 ;
+      RECT 86.120 0.840 86.400 498.960 ;
+      RECT 88.360 0.840 88.640 498.960 ;
+      RECT 90.600 0.840 90.880 498.960 ;
+      RECT 92.840 0.840 93.120 498.960 ;
+      RECT 95.080 0.840 95.360 498.960 ;
+      RECT 97.320 0.840 97.600 498.960 ;
+      RECT 99.560 0.840 99.840 498.960 ;
+      RECT 101.800 0.840 102.080 498.960 ;
+      RECT 104.040 0.840 104.320 498.960 ;
+      RECT 106.280 0.840 106.560 498.960 ;
+      RECT 108.520 0.840 108.800 498.960 ;
+      RECT 110.760 0.840 111.040 498.960 ;
+      RECT 113.000 0.840 113.280 498.960 ;
+      RECT 115.240 0.840 115.520 498.960 ;
+      RECT 117.480 0.840 117.760 498.960 ;
+      RECT 119.720 0.840 120.000 498.960 ;
+      RECT 121.960 0.840 122.240 498.960 ;
+      RECT 124.200 0.840 124.480 498.960 ;
+      RECT 126.440 0.840 126.720 498.960 ;
+      RECT 128.680 0.840 128.960 498.960 ;
+      RECT 130.920 0.840 131.200 498.960 ;
+      RECT 133.160 0.840 133.440 498.960 ;
+      RECT 135.400 0.840 135.680 498.960 ;
+      RECT 137.640 0.840 137.920 498.960 ;
+      RECT 139.880 0.840 140.160 498.960 ;
+      RECT 142.120 0.840 142.400 498.960 ;
+      RECT 144.360 0.840 144.640 498.960 ;
+      RECT 146.600 0.840 146.880 498.960 ;
+      RECT 148.840 0.840 149.120 498.960 ;
+      RECT 151.080 0.840 151.360 498.960 ;
+      RECT 153.320 0.840 153.600 498.960 ;
+      RECT 155.560 0.840 155.840 498.960 ;
+      RECT 157.800 0.840 158.080 498.960 ;
+      RECT 160.040 0.840 160.320 498.960 ;
+      RECT 162.280 0.840 162.560 498.960 ;
+      RECT 164.520 0.840 164.800 498.960 ;
+      RECT 166.760 0.840 167.040 498.960 ;
+      RECT 169.000 0.840 169.280 498.960 ;
+      RECT 171.240 0.840 171.520 498.960 ;
+      RECT 173.480 0.840 173.760 498.960 ;
+      RECT 175.720 0.840 176.000 498.960 ;
+      RECT 177.960 0.840 178.240 498.960 ;
+      RECT 180.200 0.840 180.480 498.960 ;
+      RECT 182.440 0.840 182.720 498.960 ;
+      RECT 184.680 0.840 184.960 498.960 ;
+      RECT 186.920 0.840 187.200 498.960 ;
+      RECT 189.160 0.840 189.440 498.960 ;
+      RECT 191.400 0.840 191.680 498.960 ;
+      RECT 193.640 0.840 193.920 498.960 ;
+      RECT 195.880 0.840 196.160 498.960 ;
+      RECT 198.120 0.840 198.400 498.960 ;
+      RECT 200.360 0.840 200.640 498.960 ;
+      RECT 202.600 0.840 202.880 498.960 ;
+      RECT 204.840 0.840 205.120 498.960 ;
+      RECT 207.080 0.840 207.360 498.960 ;
+      RECT 209.320 0.840 209.600 498.960 ;
+      RECT 211.560 0.840 211.840 498.960 ;
+      RECT 213.800 0.840 214.080 498.960 ;
+      RECT 216.040 0.840 216.320 498.960 ;
+      RECT 218.280 0.840 218.560 498.960 ;
+      RECT 220.520 0.840 220.800 498.960 ;
+      RECT 222.760 0.840 223.040 498.960 ;
+      RECT 225.000 0.840 225.280 498.960 ;
+      RECT 227.240 0.840 227.520 498.960 ;
+      RECT 229.480 0.840 229.760 498.960 ;
+      RECT 231.720 0.840 232.000 498.960 ;
+      RECT 233.960 0.840 234.240 498.960 ;
+      RECT 236.200 0.840 236.480 498.960 ;
+      RECT 238.440 0.840 238.720 498.960 ;
+      RECT 240.680 0.840 240.960 498.960 ;
+      RECT 242.920 0.840 243.200 498.960 ;
+      RECT 245.160 0.840 245.440 498.960 ;
+      RECT 247.400 0.840 247.680 498.960 ;
+      RECT 249.640 0.840 249.920 498.960 ;
+      RECT 251.880 0.840 252.160 498.960 ;
+      RECT 254.120 0.840 254.400 498.960 ;
+      RECT 256.360 0.840 256.640 498.960 ;
+      RECT 258.600 0.840 258.880 498.960 ;
+      RECT 260.840 0.840 261.120 498.960 ;
+      RECT 263.080 0.840 263.360 498.960 ;
+      RECT 265.320 0.840 265.600 498.960 ;
+      RECT 267.560 0.840 267.840 498.960 ;
+      RECT 269.800 0.840 270.080 498.960 ;
+      RECT 272.040 0.840 272.320 498.960 ;
+      RECT 274.280 0.840 274.560 498.960 ;
+      RECT 276.520 0.840 276.800 498.960 ;
+      RECT 278.760 0.840 279.040 498.960 ;
+      RECT 281.000 0.840 281.280 498.960 ;
+      RECT 283.240 0.840 283.520 498.960 ;
+      RECT 285.480 0.840 285.760 498.960 ;
+      RECT 287.720 0.840 288.000 498.960 ;
+      RECT 289.960 0.840 290.240 498.960 ;
+      RECT 292.200 0.840 292.480 498.960 ;
+      RECT 294.440 0.840 294.720 498.960 ;
+      RECT 296.680 0.840 296.960 498.960 ;
+      RECT 298.920 0.840 299.200 498.960 ;
+      RECT 301.160 0.840 301.440 498.960 ;
+      RECT 303.400 0.840 303.680 498.960 ;
+      RECT 305.640 0.840 305.920 498.960 ;
+      RECT 307.880 0.840 308.160 498.960 ;
+      RECT 310.120 0.840 310.400 498.960 ;
+      RECT 312.360 0.840 312.640 498.960 ;
+      RECT 314.600 0.840 314.880 498.960 ;
+      RECT 316.840 0.840 317.120 498.960 ;
+      RECT 319.080 0.840 319.360 498.960 ;
+      RECT 321.320 0.840 321.600 498.960 ;
+      RECT 323.560 0.840 323.840 498.960 ;
+      RECT 325.800 0.840 326.080 498.960 ;
+      RECT 328.040 0.840 328.320 498.960 ;
+      RECT 330.280 0.840 330.560 498.960 ;
+      RECT 332.520 0.840 332.800 498.960 ;
+      RECT 334.760 0.840 335.040 498.960 ;
+      RECT 337.000 0.840 337.280 498.960 ;
+      RECT 339.240 0.840 339.520 498.960 ;
+      RECT 341.480 0.840 341.760 498.960 ;
+      RECT 343.720 0.840 344.000 498.960 ;
+      RECT 345.960 0.840 346.240 498.960 ;
+      RECT 348.200 0.840 348.480 498.960 ;
+      RECT 350.440 0.840 350.720 498.960 ;
+      RECT 352.680 0.840 352.960 498.960 ;
+      RECT 354.920 0.840 355.200 498.960 ;
+      RECT 357.160 0.840 357.440 498.960 ;
+      RECT 359.400 0.840 359.680 498.960 ;
+      RECT 361.640 0.840 361.920 498.960 ;
+      RECT 363.880 0.840 364.160 498.960 ;
+      RECT 366.120 0.840 366.400 498.960 ;
+      RECT 368.360 0.840 368.640 498.960 ;
+      RECT 370.600 0.840 370.880 498.960 ;
+      RECT 372.840 0.840 373.120 498.960 ;
+      RECT 375.080 0.840 375.360 498.960 ;
+      RECT 377.320 0.840 377.600 498.960 ;
+      RECT 379.560 0.840 379.840 498.960 ;
+      RECT 381.800 0.840 382.080 498.960 ;
+      RECT 384.040 0.840 384.320 498.960 ;
+      RECT 386.280 0.840 386.560 498.960 ;
+      RECT 388.520 0.840 388.800 498.960 ;
+      RECT 390.760 0.840 391.040 498.960 ;
+      RECT 393.000 0.840 393.280 498.960 ;
+      RECT 395.240 0.840 395.520 498.960 ;
+      RECT 397.480 0.840 397.760 498.960 ;
+      RECT 399.720 0.840 400.000 498.960 ;
+      RECT 401.960 0.840 402.240 498.960 ;
+      RECT 404.200 0.840 404.480 498.960 ;
+      RECT 406.440 0.840 406.720 498.960 ;
+      RECT 408.680 0.840 408.960 498.960 ;
+      RECT 410.920 0.840 411.200 498.960 ;
+      RECT 413.160 0.840 413.440 498.960 ;
+      RECT 415.400 0.840 415.680 498.960 ;
+      RECT 417.640 0.840 417.920 498.960 ;
     END
   END VSS
   PIN VDD
@@ -2814,229 +2778,193 @@ MACRO fakeram_2048x128_1rw
     USE POWER ;
     PORT
       LAYER metal4 ;
-      RECT 1.140 0.700 417.620 0.980 ;
-      RECT 1.140 2.940 417.620 3.220 ;
-      RECT 1.140 5.180 417.620 5.460 ;
-      RECT 1.140 7.420 417.620 7.700 ;
-      RECT 1.140 9.660 417.620 9.940 ;
-      RECT 1.140 11.900 417.620 12.180 ;
-      RECT 1.140 14.140 417.620 14.420 ;
-      RECT 1.140 16.380 417.620 16.660 ;
-      RECT 1.140 18.620 417.620 18.900 ;
-      RECT 1.140 20.860 417.620 21.140 ;
-      RECT 1.140 23.100 417.620 23.380 ;
-      RECT 1.140 25.340 417.620 25.620 ;
-      RECT 1.140 27.580 417.620 27.860 ;
-      RECT 1.140 29.820 417.620 30.100 ;
-      RECT 1.140 32.060 417.620 32.340 ;
-      RECT 1.140 34.300 417.620 34.580 ;
-      RECT 1.140 36.540 417.620 36.820 ;
-      RECT 1.140 38.780 417.620 39.060 ;
-      RECT 1.140 41.020 417.620 41.300 ;
-      RECT 1.140 43.260 417.620 43.540 ;
-      RECT 1.140 45.500 417.620 45.780 ;
-      RECT 1.140 47.740 417.620 48.020 ;
-      RECT 1.140 49.980 417.620 50.260 ;
-      RECT 1.140 52.220 417.620 52.500 ;
-      RECT 1.140 54.460 417.620 54.740 ;
-      RECT 1.140 56.700 417.620 56.980 ;
-      RECT 1.140 58.940 417.620 59.220 ;
-      RECT 1.140 61.180 417.620 61.460 ;
-      RECT 1.140 63.420 417.620 63.700 ;
-      RECT 1.140 65.660 417.620 65.940 ;
-      RECT 1.140 67.900 417.620 68.180 ;
-      RECT 1.140 70.140 417.620 70.420 ;
-      RECT 1.140 72.380 417.620 72.660 ;
-      RECT 1.140 74.620 417.620 74.900 ;
-      RECT 1.140 76.860 417.620 77.140 ;
-      RECT 1.140 79.100 417.620 79.380 ;
-      RECT 1.140 81.340 417.620 81.620 ;
-      RECT 1.140 83.580 417.620 83.860 ;
-      RECT 1.140 85.820 417.620 86.100 ;
-      RECT 1.140 88.060 417.620 88.340 ;
-      RECT 1.140 90.300 417.620 90.580 ;
-      RECT 1.140 92.540 417.620 92.820 ;
-      RECT 1.140 94.780 417.620 95.060 ;
-      RECT 1.140 97.020 417.620 97.300 ;
-      RECT 1.140 99.260 417.620 99.540 ;
-      RECT 1.140 101.500 417.620 101.780 ;
-      RECT 1.140 103.740 417.620 104.020 ;
-      RECT 1.140 105.980 417.620 106.260 ;
-      RECT 1.140 108.220 417.620 108.500 ;
-      RECT 1.140 110.460 417.620 110.740 ;
-      RECT 1.140 112.700 417.620 112.980 ;
-      RECT 1.140 114.940 417.620 115.220 ;
-      RECT 1.140 117.180 417.620 117.460 ;
-      RECT 1.140 119.420 417.620 119.700 ;
-      RECT 1.140 121.660 417.620 121.940 ;
-      RECT 1.140 123.900 417.620 124.180 ;
-      RECT 1.140 126.140 417.620 126.420 ;
-      RECT 1.140 128.380 417.620 128.660 ;
-      RECT 1.140 130.620 417.620 130.900 ;
-      RECT 1.140 132.860 417.620 133.140 ;
-      RECT 1.140 135.100 417.620 135.380 ;
-      RECT 1.140 137.340 417.620 137.620 ;
-      RECT 1.140 139.580 417.620 139.860 ;
-      RECT 1.140 141.820 417.620 142.100 ;
-      RECT 1.140 144.060 417.620 144.340 ;
-      RECT 1.140 146.300 417.620 146.580 ;
-      RECT 1.140 148.540 417.620 148.820 ;
-      RECT 1.140 150.780 417.620 151.060 ;
-      RECT 1.140 153.020 417.620 153.300 ;
-      RECT 1.140 155.260 417.620 155.540 ;
-      RECT 1.140 157.500 417.620 157.780 ;
-      RECT 1.140 159.740 417.620 160.020 ;
-      RECT 1.140 161.980 417.620 162.260 ;
-      RECT 1.140 164.220 417.620 164.500 ;
-      RECT 1.140 166.460 417.620 166.740 ;
-      RECT 1.140 168.700 417.620 168.980 ;
-      RECT 1.140 170.940 417.620 171.220 ;
-      RECT 1.140 173.180 417.620 173.460 ;
-      RECT 1.140 175.420 417.620 175.700 ;
-      RECT 1.140 177.660 417.620 177.940 ;
-      RECT 1.140 179.900 417.620 180.180 ;
-      RECT 1.140 182.140 417.620 182.420 ;
-      RECT 1.140 184.380 417.620 184.660 ;
-      RECT 1.140 186.620 417.620 186.900 ;
-      RECT 1.140 188.860 417.620 189.140 ;
-      RECT 1.140 191.100 417.620 191.380 ;
-      RECT 1.140 193.340 417.620 193.620 ;
-      RECT 1.140 195.580 417.620 195.860 ;
-      RECT 1.140 197.820 417.620 198.100 ;
-      RECT 1.140 200.060 417.620 200.340 ;
-      RECT 1.140 202.300 417.620 202.580 ;
-      RECT 1.140 204.540 417.620 204.820 ;
-      RECT 1.140 206.780 417.620 207.060 ;
-      RECT 1.140 209.020 417.620 209.300 ;
-      RECT 1.140 211.260 417.620 211.540 ;
-      RECT 1.140 213.500 417.620 213.780 ;
-      RECT 1.140 215.740 417.620 216.020 ;
-      RECT 1.140 217.980 417.620 218.260 ;
-      RECT 1.140 220.220 417.620 220.500 ;
-      RECT 1.140 222.460 417.620 222.740 ;
-      RECT 1.140 224.700 417.620 224.980 ;
-      RECT 1.140 226.940 417.620 227.220 ;
-      RECT 1.140 229.180 417.620 229.460 ;
-      RECT 1.140 231.420 417.620 231.700 ;
-      RECT 1.140 233.660 417.620 233.940 ;
-      RECT 1.140 235.900 417.620 236.180 ;
-      RECT 1.140 238.140 417.620 238.420 ;
-      RECT 1.140 240.380 417.620 240.660 ;
-      RECT 1.140 242.620 417.620 242.900 ;
-      RECT 1.140 244.860 417.620 245.140 ;
-      RECT 1.140 247.100 417.620 247.380 ;
-      RECT 1.140 249.340 417.620 249.620 ;
-      RECT 1.140 251.580 417.620 251.860 ;
-      RECT 1.140 253.820 417.620 254.100 ;
-      RECT 1.140 256.060 417.620 256.340 ;
-      RECT 1.140 258.300 417.620 258.580 ;
-      RECT 1.140 260.540 417.620 260.820 ;
-      RECT 1.140 262.780 417.620 263.060 ;
-      RECT 1.140 265.020 417.620 265.300 ;
-      RECT 1.140 267.260 417.620 267.540 ;
-      RECT 1.140 269.500 417.620 269.780 ;
-      RECT 1.140 271.740 417.620 272.020 ;
-      RECT 1.140 273.980 417.620 274.260 ;
-      RECT 1.140 276.220 417.620 276.500 ;
-      RECT 1.140 278.460 417.620 278.740 ;
-      RECT 1.140 280.700 417.620 280.980 ;
-      RECT 1.140 282.940 417.620 283.220 ;
-      RECT 1.140 285.180 417.620 285.460 ;
-      RECT 1.140 287.420 417.620 287.700 ;
-      RECT 1.140 289.660 417.620 289.940 ;
-      RECT 1.140 291.900 417.620 292.180 ;
-      RECT 1.140 294.140 417.620 294.420 ;
-      RECT 1.140 296.380 417.620 296.660 ;
-      RECT 1.140 298.620 417.620 298.900 ;
-      RECT 1.140 300.860 417.620 301.140 ;
-      RECT 1.140 303.100 417.620 303.380 ;
-      RECT 1.140 305.340 417.620 305.620 ;
-      RECT 1.140 307.580 417.620 307.860 ;
-      RECT 1.140 309.820 417.620 310.100 ;
-      RECT 1.140 312.060 417.620 312.340 ;
-      RECT 1.140 314.300 417.620 314.580 ;
-      RECT 1.140 316.540 417.620 316.820 ;
-      RECT 1.140 318.780 417.620 319.060 ;
-      RECT 1.140 321.020 417.620 321.300 ;
-      RECT 1.140 323.260 417.620 323.540 ;
-      RECT 1.140 325.500 417.620 325.780 ;
-      RECT 1.140 327.740 417.620 328.020 ;
-      RECT 1.140 329.980 417.620 330.260 ;
-      RECT 1.140 332.220 417.620 332.500 ;
-      RECT 1.140 334.460 417.620 334.740 ;
-      RECT 1.140 336.700 417.620 336.980 ;
-      RECT 1.140 338.940 417.620 339.220 ;
-      RECT 1.140 341.180 417.620 341.460 ;
-      RECT 1.140 343.420 417.620 343.700 ;
-      RECT 1.140 345.660 417.620 345.940 ;
-      RECT 1.140 347.900 417.620 348.180 ;
-      RECT 1.140 350.140 417.620 350.420 ;
-      RECT 1.140 352.380 417.620 352.660 ;
-      RECT 1.140 354.620 417.620 354.900 ;
-      RECT 1.140 356.860 417.620 357.140 ;
-      RECT 1.140 359.100 417.620 359.380 ;
-      RECT 1.140 361.340 417.620 361.620 ;
-      RECT 1.140 363.580 417.620 363.860 ;
-      RECT 1.140 365.820 417.620 366.100 ;
-      RECT 1.140 368.060 417.620 368.340 ;
-      RECT 1.140 370.300 417.620 370.580 ;
-      RECT 1.140 372.540 417.620 372.820 ;
-      RECT 1.140 374.780 417.620 375.060 ;
-      RECT 1.140 377.020 417.620 377.300 ;
-      RECT 1.140 379.260 417.620 379.540 ;
-      RECT 1.140 381.500 417.620 381.780 ;
-      RECT 1.140 383.740 417.620 384.020 ;
-      RECT 1.140 385.980 417.620 386.260 ;
-      RECT 1.140 388.220 417.620 388.500 ;
-      RECT 1.140 390.460 417.620 390.740 ;
-      RECT 1.140 392.700 417.620 392.980 ;
-      RECT 1.140 394.940 417.620 395.220 ;
-      RECT 1.140 397.180 417.620 397.460 ;
-      RECT 1.140 399.420 417.620 399.700 ;
-      RECT 1.140 401.660 417.620 401.940 ;
-      RECT 1.140 403.900 417.620 404.180 ;
-      RECT 1.140 406.140 417.620 406.420 ;
-      RECT 1.140 408.380 417.620 408.660 ;
-      RECT 1.140 410.620 417.620 410.900 ;
-      RECT 1.140 412.860 417.620 413.140 ;
-      RECT 1.140 415.100 417.620 415.380 ;
-      RECT 1.140 417.340 417.620 417.620 ;
-      RECT 1.140 419.580 417.620 419.860 ;
-      RECT 1.140 421.820 417.620 422.100 ;
-      RECT 1.140 424.060 417.620 424.340 ;
-      RECT 1.140 426.300 417.620 426.580 ;
-      RECT 1.140 428.540 417.620 428.820 ;
-      RECT 1.140 430.780 417.620 431.060 ;
-      RECT 1.140 433.020 417.620 433.300 ;
-      RECT 1.140 435.260 417.620 435.540 ;
-      RECT 1.140 437.500 417.620 437.780 ;
-      RECT 1.140 439.740 417.620 440.020 ;
-      RECT 1.140 441.980 417.620 442.260 ;
-      RECT 1.140 444.220 417.620 444.500 ;
-      RECT 1.140 446.460 417.620 446.740 ;
-      RECT 1.140 448.700 417.620 448.980 ;
-      RECT 1.140 450.940 417.620 451.220 ;
-      RECT 1.140 453.180 417.620 453.460 ;
-      RECT 1.140 455.420 417.620 455.700 ;
-      RECT 1.140 457.660 417.620 457.940 ;
-      RECT 1.140 459.900 417.620 460.180 ;
-      RECT 1.140 462.140 417.620 462.420 ;
-      RECT 1.140 464.380 417.620 464.660 ;
-      RECT 1.140 466.620 417.620 466.900 ;
-      RECT 1.140 468.860 417.620 469.140 ;
-      RECT 1.140 471.100 417.620 471.380 ;
-      RECT 1.140 473.340 417.620 473.620 ;
-      RECT 1.140 475.580 417.620 475.860 ;
-      RECT 1.140 477.820 417.620 478.100 ;
-      RECT 1.140 480.060 417.620 480.340 ;
-      RECT 1.140 482.300 417.620 482.580 ;
-      RECT 1.140 484.540 417.620 484.820 ;
-      RECT 1.140 486.780 417.620 487.060 ;
-      RECT 1.140 489.020 417.620 489.300 ;
-      RECT 1.140 491.260 417.620 491.540 ;
-      RECT 1.140 493.500 417.620 493.780 ;
-      RECT 1.140 495.740 417.620 496.020 ;
-      RECT 1.140 497.980 417.620 498.260 ;
+      RECT 1.000 0.840 1.280 498.960 ;
+      RECT 3.240 0.840 3.520 498.960 ;
+      RECT 5.480 0.840 5.760 498.960 ;
+      RECT 7.720 0.840 8.000 498.960 ;
+      RECT 9.960 0.840 10.240 498.960 ;
+      RECT 12.200 0.840 12.480 498.960 ;
+      RECT 14.440 0.840 14.720 498.960 ;
+      RECT 16.680 0.840 16.960 498.960 ;
+      RECT 18.920 0.840 19.200 498.960 ;
+      RECT 21.160 0.840 21.440 498.960 ;
+      RECT 23.400 0.840 23.680 498.960 ;
+      RECT 25.640 0.840 25.920 498.960 ;
+      RECT 27.880 0.840 28.160 498.960 ;
+      RECT 30.120 0.840 30.400 498.960 ;
+      RECT 32.360 0.840 32.640 498.960 ;
+      RECT 34.600 0.840 34.880 498.960 ;
+      RECT 36.840 0.840 37.120 498.960 ;
+      RECT 39.080 0.840 39.360 498.960 ;
+      RECT 41.320 0.840 41.600 498.960 ;
+      RECT 43.560 0.840 43.840 498.960 ;
+      RECT 45.800 0.840 46.080 498.960 ;
+      RECT 48.040 0.840 48.320 498.960 ;
+      RECT 50.280 0.840 50.560 498.960 ;
+      RECT 52.520 0.840 52.800 498.960 ;
+      RECT 54.760 0.840 55.040 498.960 ;
+      RECT 57.000 0.840 57.280 498.960 ;
+      RECT 59.240 0.840 59.520 498.960 ;
+      RECT 61.480 0.840 61.760 498.960 ;
+      RECT 63.720 0.840 64.000 498.960 ;
+      RECT 65.960 0.840 66.240 498.960 ;
+      RECT 68.200 0.840 68.480 498.960 ;
+      RECT 70.440 0.840 70.720 498.960 ;
+      RECT 72.680 0.840 72.960 498.960 ;
+      RECT 74.920 0.840 75.200 498.960 ;
+      RECT 77.160 0.840 77.440 498.960 ;
+      RECT 79.400 0.840 79.680 498.960 ;
+      RECT 81.640 0.840 81.920 498.960 ;
+      RECT 83.880 0.840 84.160 498.960 ;
+      RECT 86.120 0.840 86.400 498.960 ;
+      RECT 88.360 0.840 88.640 498.960 ;
+      RECT 90.600 0.840 90.880 498.960 ;
+      RECT 92.840 0.840 93.120 498.960 ;
+      RECT 95.080 0.840 95.360 498.960 ;
+      RECT 97.320 0.840 97.600 498.960 ;
+      RECT 99.560 0.840 99.840 498.960 ;
+      RECT 101.800 0.840 102.080 498.960 ;
+      RECT 104.040 0.840 104.320 498.960 ;
+      RECT 106.280 0.840 106.560 498.960 ;
+      RECT 108.520 0.840 108.800 498.960 ;
+      RECT 110.760 0.840 111.040 498.960 ;
+      RECT 113.000 0.840 113.280 498.960 ;
+      RECT 115.240 0.840 115.520 498.960 ;
+      RECT 117.480 0.840 117.760 498.960 ;
+      RECT 119.720 0.840 120.000 498.960 ;
+      RECT 121.960 0.840 122.240 498.960 ;
+      RECT 124.200 0.840 124.480 498.960 ;
+      RECT 126.440 0.840 126.720 498.960 ;
+      RECT 128.680 0.840 128.960 498.960 ;
+      RECT 130.920 0.840 131.200 498.960 ;
+      RECT 133.160 0.840 133.440 498.960 ;
+      RECT 135.400 0.840 135.680 498.960 ;
+      RECT 137.640 0.840 137.920 498.960 ;
+      RECT 139.880 0.840 140.160 498.960 ;
+      RECT 142.120 0.840 142.400 498.960 ;
+      RECT 144.360 0.840 144.640 498.960 ;
+      RECT 146.600 0.840 146.880 498.960 ;
+      RECT 148.840 0.840 149.120 498.960 ;
+      RECT 151.080 0.840 151.360 498.960 ;
+      RECT 153.320 0.840 153.600 498.960 ;
+      RECT 155.560 0.840 155.840 498.960 ;
+      RECT 157.800 0.840 158.080 498.960 ;
+      RECT 160.040 0.840 160.320 498.960 ;
+      RECT 162.280 0.840 162.560 498.960 ;
+      RECT 164.520 0.840 164.800 498.960 ;
+      RECT 166.760 0.840 167.040 498.960 ;
+      RECT 169.000 0.840 169.280 498.960 ;
+      RECT 171.240 0.840 171.520 498.960 ;
+      RECT 173.480 0.840 173.760 498.960 ;
+      RECT 175.720 0.840 176.000 498.960 ;
+      RECT 177.960 0.840 178.240 498.960 ;
+      RECT 180.200 0.840 180.480 498.960 ;
+      RECT 182.440 0.840 182.720 498.960 ;
+      RECT 184.680 0.840 184.960 498.960 ;
+      RECT 186.920 0.840 187.200 498.960 ;
+      RECT 189.160 0.840 189.440 498.960 ;
+      RECT 191.400 0.840 191.680 498.960 ;
+      RECT 193.640 0.840 193.920 498.960 ;
+      RECT 195.880 0.840 196.160 498.960 ;
+      RECT 198.120 0.840 198.400 498.960 ;
+      RECT 200.360 0.840 200.640 498.960 ;
+      RECT 202.600 0.840 202.880 498.960 ;
+      RECT 204.840 0.840 205.120 498.960 ;
+      RECT 207.080 0.840 207.360 498.960 ;
+      RECT 209.320 0.840 209.600 498.960 ;
+      RECT 211.560 0.840 211.840 498.960 ;
+      RECT 213.800 0.840 214.080 498.960 ;
+      RECT 216.040 0.840 216.320 498.960 ;
+      RECT 218.280 0.840 218.560 498.960 ;
+      RECT 220.520 0.840 220.800 498.960 ;
+      RECT 222.760 0.840 223.040 498.960 ;
+      RECT 225.000 0.840 225.280 498.960 ;
+      RECT 227.240 0.840 227.520 498.960 ;
+      RECT 229.480 0.840 229.760 498.960 ;
+      RECT 231.720 0.840 232.000 498.960 ;
+      RECT 233.960 0.840 234.240 498.960 ;
+      RECT 236.200 0.840 236.480 498.960 ;
+      RECT 238.440 0.840 238.720 498.960 ;
+      RECT 240.680 0.840 240.960 498.960 ;
+      RECT 242.920 0.840 243.200 498.960 ;
+      RECT 245.160 0.840 245.440 498.960 ;
+      RECT 247.400 0.840 247.680 498.960 ;
+      RECT 249.640 0.840 249.920 498.960 ;
+      RECT 251.880 0.840 252.160 498.960 ;
+      RECT 254.120 0.840 254.400 498.960 ;
+      RECT 256.360 0.840 256.640 498.960 ;
+      RECT 258.600 0.840 258.880 498.960 ;
+      RECT 260.840 0.840 261.120 498.960 ;
+      RECT 263.080 0.840 263.360 498.960 ;
+      RECT 265.320 0.840 265.600 498.960 ;
+      RECT 267.560 0.840 267.840 498.960 ;
+      RECT 269.800 0.840 270.080 498.960 ;
+      RECT 272.040 0.840 272.320 498.960 ;
+      RECT 274.280 0.840 274.560 498.960 ;
+      RECT 276.520 0.840 276.800 498.960 ;
+      RECT 278.760 0.840 279.040 498.960 ;
+      RECT 281.000 0.840 281.280 498.960 ;
+      RECT 283.240 0.840 283.520 498.960 ;
+      RECT 285.480 0.840 285.760 498.960 ;
+      RECT 287.720 0.840 288.000 498.960 ;
+      RECT 289.960 0.840 290.240 498.960 ;
+      RECT 292.200 0.840 292.480 498.960 ;
+      RECT 294.440 0.840 294.720 498.960 ;
+      RECT 296.680 0.840 296.960 498.960 ;
+      RECT 298.920 0.840 299.200 498.960 ;
+      RECT 301.160 0.840 301.440 498.960 ;
+      RECT 303.400 0.840 303.680 498.960 ;
+      RECT 305.640 0.840 305.920 498.960 ;
+      RECT 307.880 0.840 308.160 498.960 ;
+      RECT 310.120 0.840 310.400 498.960 ;
+      RECT 312.360 0.840 312.640 498.960 ;
+      RECT 314.600 0.840 314.880 498.960 ;
+      RECT 316.840 0.840 317.120 498.960 ;
+      RECT 319.080 0.840 319.360 498.960 ;
+      RECT 321.320 0.840 321.600 498.960 ;
+      RECT 323.560 0.840 323.840 498.960 ;
+      RECT 325.800 0.840 326.080 498.960 ;
+      RECT 328.040 0.840 328.320 498.960 ;
+      RECT 330.280 0.840 330.560 498.960 ;
+      RECT 332.520 0.840 332.800 498.960 ;
+      RECT 334.760 0.840 335.040 498.960 ;
+      RECT 337.000 0.840 337.280 498.960 ;
+      RECT 339.240 0.840 339.520 498.960 ;
+      RECT 341.480 0.840 341.760 498.960 ;
+      RECT 343.720 0.840 344.000 498.960 ;
+      RECT 345.960 0.840 346.240 498.960 ;
+      RECT 348.200 0.840 348.480 498.960 ;
+      RECT 350.440 0.840 350.720 498.960 ;
+      RECT 352.680 0.840 352.960 498.960 ;
+      RECT 354.920 0.840 355.200 498.960 ;
+      RECT 357.160 0.840 357.440 498.960 ;
+      RECT 359.400 0.840 359.680 498.960 ;
+      RECT 361.640 0.840 361.920 498.960 ;
+      RECT 363.880 0.840 364.160 498.960 ;
+      RECT 366.120 0.840 366.400 498.960 ;
+      RECT 368.360 0.840 368.640 498.960 ;
+      RECT 370.600 0.840 370.880 498.960 ;
+      RECT 372.840 0.840 373.120 498.960 ;
+      RECT 375.080 0.840 375.360 498.960 ;
+      RECT 377.320 0.840 377.600 498.960 ;
+      RECT 379.560 0.840 379.840 498.960 ;
+      RECT 381.800 0.840 382.080 498.960 ;
+      RECT 384.040 0.840 384.320 498.960 ;
+      RECT 386.280 0.840 386.560 498.960 ;
+      RECT 388.520 0.840 388.800 498.960 ;
+      RECT 390.760 0.840 391.040 498.960 ;
+      RECT 393.000 0.840 393.280 498.960 ;
+      RECT 395.240 0.840 395.520 498.960 ;
+      RECT 397.480 0.840 397.760 498.960 ;
+      RECT 399.720 0.840 400.000 498.960 ;
+      RECT 401.960 0.840 402.240 498.960 ;
+      RECT 404.200 0.840 404.480 498.960 ;
+      RECT 406.440 0.840 406.720 498.960 ;
+      RECT 408.680 0.840 408.960 498.960 ;
+      RECT 410.920 0.840 411.200 498.960 ;
+      RECT 413.160 0.840 413.440 498.960 ;
+      RECT 415.400 0.840 415.680 498.960 ;
+      RECT 417.640 0.840 417.920 498.960 ;
     END
   END VDD
   OBS

--- a/designs/nangate45/coralnpu/sram/lef/fakeram_512x128_1rw.lef
+++ b/designs/nangate45/coralnpu/sram/lef/fakeram_512x128_1rw.lef
@@ -1,0 +1,2802 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_512x128_1rw
+  FOREIGN fakeram_512x128_1rw 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 210.140 BY 235.200 ;
+  CLASS BLOCK ;
+  PIN rw0_wmask_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 0.805 0.210 0.875 ;
+    END
+  END rw0_wmask_in[0]
+  PIN rw0_wmask_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 4.165 0.210 4.235 ;
+    END
+  END rw0_wmask_in[1]
+  PIN rw0_wmask_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 7.525 0.210 7.595 ;
+    END
+  END rw0_wmask_in[2]
+  PIN rw0_wmask_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 10.885 0.210 10.955 ;
+    END
+  END rw0_wmask_in[3]
+  PIN rw0_wmask_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 0.805 210.140 0.875 ;
+    END
+  END rw0_wmask_in[4]
+  PIN rw0_wmask_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 4.165 210.140 4.235 ;
+    END
+  END rw0_wmask_in[5]
+  PIN rw0_wmask_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 7.525 210.140 7.595 ;
+    END
+  END rw0_wmask_in[6]
+  PIN rw0_wmask_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 10.885 210.140 10.955 ;
+    END
+  END rw0_wmask_in[7]
+  PIN rw0_wmask_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 1.105 234.990 1.175 235.200 ;
+    END
+  END rw0_wmask_in[8]
+  PIN rw0_wmask_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 2.625 234.990 2.695 235.200 ;
+    END
+  END rw0_wmask_in[9]
+  PIN rw0_wmask_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 4.145 234.990 4.215 235.200 ;
+    END
+  END rw0_wmask_in[10]
+  PIN rw0_wmask_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 5.665 234.990 5.735 235.200 ;
+    END
+  END rw0_wmask_in[11]
+  PIN rw0_wmask_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 7.185 234.990 7.255 235.200 ;
+    END
+  END rw0_wmask_in[12]
+  PIN rw0_wmask_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 8.705 234.990 8.775 235.200 ;
+    END
+  END rw0_wmask_in[13]
+  PIN rw0_wmask_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 10.225 234.990 10.295 235.200 ;
+    END
+  END rw0_wmask_in[14]
+  PIN rw0_wmask_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 11.745 234.990 11.815 235.200 ;
+    END
+  END rw0_wmask_in[15]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 14.245 0.210 14.315 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 17.605 0.210 17.675 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 20.965 0.210 21.035 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 24.325 0.210 24.395 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 27.685 0.210 27.755 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 31.045 0.210 31.115 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 34.405 0.210 34.475 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 37.765 0.210 37.835 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 41.125 0.210 41.195 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 44.485 0.210 44.555 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 47.845 0.210 47.915 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 51.205 0.210 51.275 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 54.565 0.210 54.635 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 57.925 0.210 57.995 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 61.285 0.210 61.355 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 64.645 0.210 64.715 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 68.005 0.210 68.075 ;
+    END
+  END rw0_wd_in[16]
+  PIN rw0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 71.365 0.210 71.435 ;
+    END
+  END rw0_wd_in[17]
+  PIN rw0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 74.725 0.210 74.795 ;
+    END
+  END rw0_wd_in[18]
+  PIN rw0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 78.085 0.210 78.155 ;
+    END
+  END rw0_wd_in[19]
+  PIN rw0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 81.445 0.210 81.515 ;
+    END
+  END rw0_wd_in[20]
+  PIN rw0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 84.805 0.210 84.875 ;
+    END
+  END rw0_wd_in[21]
+  PIN rw0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 88.165 0.210 88.235 ;
+    END
+  END rw0_wd_in[22]
+  PIN rw0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 91.525 0.210 91.595 ;
+    END
+  END rw0_wd_in[23]
+  PIN rw0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 94.885 0.210 94.955 ;
+    END
+  END rw0_wd_in[24]
+  PIN rw0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 98.245 0.210 98.315 ;
+    END
+  END rw0_wd_in[25]
+  PIN rw0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 101.605 0.210 101.675 ;
+    END
+  END rw0_wd_in[26]
+  PIN rw0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 104.965 0.210 105.035 ;
+    END
+  END rw0_wd_in[27]
+  PIN rw0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 108.325 0.210 108.395 ;
+    END
+  END rw0_wd_in[28]
+  PIN rw0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 111.685 0.210 111.755 ;
+    END
+  END rw0_wd_in[29]
+  PIN rw0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 115.045 0.210 115.115 ;
+    END
+  END rw0_wd_in[30]
+  PIN rw0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 118.405 0.210 118.475 ;
+    END
+  END rw0_wd_in[31]
+  PIN rw0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 14.245 210.140 14.315 ;
+    END
+  END rw0_wd_in[32]
+  PIN rw0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 17.605 210.140 17.675 ;
+    END
+  END rw0_wd_in[33]
+  PIN rw0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 20.965 210.140 21.035 ;
+    END
+  END rw0_wd_in[34]
+  PIN rw0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 24.325 210.140 24.395 ;
+    END
+  END rw0_wd_in[35]
+  PIN rw0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 27.685 210.140 27.755 ;
+    END
+  END rw0_wd_in[36]
+  PIN rw0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 31.045 210.140 31.115 ;
+    END
+  END rw0_wd_in[37]
+  PIN rw0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 34.405 210.140 34.475 ;
+    END
+  END rw0_wd_in[38]
+  PIN rw0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 37.765 210.140 37.835 ;
+    END
+  END rw0_wd_in[39]
+  PIN rw0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 41.125 210.140 41.195 ;
+    END
+  END rw0_wd_in[40]
+  PIN rw0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 44.485 210.140 44.555 ;
+    END
+  END rw0_wd_in[41]
+  PIN rw0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 47.845 210.140 47.915 ;
+    END
+  END rw0_wd_in[42]
+  PIN rw0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 51.205 210.140 51.275 ;
+    END
+  END rw0_wd_in[43]
+  PIN rw0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 54.565 210.140 54.635 ;
+    END
+  END rw0_wd_in[44]
+  PIN rw0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 57.925 210.140 57.995 ;
+    END
+  END rw0_wd_in[45]
+  PIN rw0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 61.285 210.140 61.355 ;
+    END
+  END rw0_wd_in[46]
+  PIN rw0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 64.645 210.140 64.715 ;
+    END
+  END rw0_wd_in[47]
+  PIN rw0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 68.005 210.140 68.075 ;
+    END
+  END rw0_wd_in[48]
+  PIN rw0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 71.365 210.140 71.435 ;
+    END
+  END rw0_wd_in[49]
+  PIN rw0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 74.725 210.140 74.795 ;
+    END
+  END rw0_wd_in[50]
+  PIN rw0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 78.085 210.140 78.155 ;
+    END
+  END rw0_wd_in[51]
+  PIN rw0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 81.445 210.140 81.515 ;
+    END
+  END rw0_wd_in[52]
+  PIN rw0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 84.805 210.140 84.875 ;
+    END
+  END rw0_wd_in[53]
+  PIN rw0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 88.165 210.140 88.235 ;
+    END
+  END rw0_wd_in[54]
+  PIN rw0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 91.525 210.140 91.595 ;
+    END
+  END rw0_wd_in[55]
+  PIN rw0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 94.885 210.140 94.955 ;
+    END
+  END rw0_wd_in[56]
+  PIN rw0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 98.245 210.140 98.315 ;
+    END
+  END rw0_wd_in[57]
+  PIN rw0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 101.605 210.140 101.675 ;
+    END
+  END rw0_wd_in[58]
+  PIN rw0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 104.965 210.140 105.035 ;
+    END
+  END rw0_wd_in[59]
+  PIN rw0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 108.325 210.140 108.395 ;
+    END
+  END rw0_wd_in[60]
+  PIN rw0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 111.685 210.140 111.755 ;
+    END
+  END rw0_wd_in[61]
+  PIN rw0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 115.045 210.140 115.115 ;
+    END
+  END rw0_wd_in[62]
+  PIN rw0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 118.405 210.140 118.475 ;
+    END
+  END rw0_wd_in[63]
+  PIN rw0_wd_in[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 1.105 0.000 1.175 0.210 ;
+    END
+  END rw0_wd_in[64]
+  PIN rw0_wd_in[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 2.625 0.000 2.695 0.210 ;
+    END
+  END rw0_wd_in[65]
+  PIN rw0_wd_in[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 4.145 0.000 4.215 0.210 ;
+    END
+  END rw0_wd_in[66]
+  PIN rw0_wd_in[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 5.665 0.000 5.735 0.210 ;
+    END
+  END rw0_wd_in[67]
+  PIN rw0_wd_in[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 7.185 0.000 7.255 0.210 ;
+    END
+  END rw0_wd_in[68]
+  PIN rw0_wd_in[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 8.705 0.000 8.775 0.210 ;
+    END
+  END rw0_wd_in[69]
+  PIN rw0_wd_in[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 10.225 0.000 10.295 0.210 ;
+    END
+  END rw0_wd_in[70]
+  PIN rw0_wd_in[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 11.745 0.000 11.815 0.210 ;
+    END
+  END rw0_wd_in[71]
+  PIN rw0_wd_in[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 13.265 0.000 13.335 0.210 ;
+    END
+  END rw0_wd_in[72]
+  PIN rw0_wd_in[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 14.785 0.000 14.855 0.210 ;
+    END
+  END rw0_wd_in[73]
+  PIN rw0_wd_in[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 16.305 0.000 16.375 0.210 ;
+    END
+  END rw0_wd_in[74]
+  PIN rw0_wd_in[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 17.825 0.000 17.895 0.210 ;
+    END
+  END rw0_wd_in[75]
+  PIN rw0_wd_in[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 19.345 0.000 19.415 0.210 ;
+    END
+  END rw0_wd_in[76]
+  PIN rw0_wd_in[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 20.865 0.000 20.935 0.210 ;
+    END
+  END rw0_wd_in[77]
+  PIN rw0_wd_in[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 22.385 0.000 22.455 0.210 ;
+    END
+  END rw0_wd_in[78]
+  PIN rw0_wd_in[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 23.905 0.000 23.975 0.210 ;
+    END
+  END rw0_wd_in[79]
+  PIN rw0_wd_in[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 25.425 0.000 25.495 0.210 ;
+    END
+  END rw0_wd_in[80]
+  PIN rw0_wd_in[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 26.945 0.000 27.015 0.210 ;
+    END
+  END rw0_wd_in[81]
+  PIN rw0_wd_in[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 28.465 0.000 28.535 0.210 ;
+    END
+  END rw0_wd_in[82]
+  PIN rw0_wd_in[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 29.985 0.000 30.055 0.210 ;
+    END
+  END rw0_wd_in[83]
+  PIN rw0_wd_in[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 31.505 0.000 31.575 0.210 ;
+    END
+  END rw0_wd_in[84]
+  PIN rw0_wd_in[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 33.025 0.000 33.095 0.210 ;
+    END
+  END rw0_wd_in[85]
+  PIN rw0_wd_in[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 34.545 0.000 34.615 0.210 ;
+    END
+  END rw0_wd_in[86]
+  PIN rw0_wd_in[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 36.065 0.000 36.135 0.210 ;
+    END
+  END rw0_wd_in[87]
+  PIN rw0_wd_in[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 37.585 0.000 37.655 0.210 ;
+    END
+  END rw0_wd_in[88]
+  PIN rw0_wd_in[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 39.105 0.000 39.175 0.210 ;
+    END
+  END rw0_wd_in[89]
+  PIN rw0_wd_in[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 40.625 0.000 40.695 0.210 ;
+    END
+  END rw0_wd_in[90]
+  PIN rw0_wd_in[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 42.145 0.000 42.215 0.210 ;
+    END
+  END rw0_wd_in[91]
+  PIN rw0_wd_in[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 43.665 0.000 43.735 0.210 ;
+    END
+  END rw0_wd_in[92]
+  PIN rw0_wd_in[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 45.185 0.000 45.255 0.210 ;
+    END
+  END rw0_wd_in[93]
+  PIN rw0_wd_in[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 46.705 0.000 46.775 0.210 ;
+    END
+  END rw0_wd_in[94]
+  PIN rw0_wd_in[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 48.225 0.000 48.295 0.210 ;
+    END
+  END rw0_wd_in[95]
+  PIN rw0_wd_in[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 49.745 0.000 49.815 0.210 ;
+    END
+  END rw0_wd_in[96]
+  PIN rw0_wd_in[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 51.265 0.000 51.335 0.210 ;
+    END
+  END rw0_wd_in[97]
+  PIN rw0_wd_in[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 52.785 0.000 52.855 0.210 ;
+    END
+  END rw0_wd_in[98]
+  PIN rw0_wd_in[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 54.305 0.000 54.375 0.210 ;
+    END
+  END rw0_wd_in[99]
+  PIN rw0_wd_in[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 55.825 0.000 55.895 0.210 ;
+    END
+  END rw0_wd_in[100]
+  PIN rw0_wd_in[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 57.345 0.000 57.415 0.210 ;
+    END
+  END rw0_wd_in[101]
+  PIN rw0_wd_in[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 58.865 0.000 58.935 0.210 ;
+    END
+  END rw0_wd_in[102]
+  PIN rw0_wd_in[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 60.385 0.000 60.455 0.210 ;
+    END
+  END rw0_wd_in[103]
+  PIN rw0_wd_in[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 61.905 0.000 61.975 0.210 ;
+    END
+  END rw0_wd_in[104]
+  PIN rw0_wd_in[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 63.425 0.000 63.495 0.210 ;
+    END
+  END rw0_wd_in[105]
+  PIN rw0_wd_in[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 64.945 0.000 65.015 0.210 ;
+    END
+  END rw0_wd_in[106]
+  PIN rw0_wd_in[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 66.465 0.000 66.535 0.210 ;
+    END
+  END rw0_wd_in[107]
+  PIN rw0_wd_in[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 67.985 0.000 68.055 0.210 ;
+    END
+  END rw0_wd_in[108]
+  PIN rw0_wd_in[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 69.505 0.000 69.575 0.210 ;
+    END
+  END rw0_wd_in[109]
+  PIN rw0_wd_in[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 71.025 0.000 71.095 0.210 ;
+    END
+  END rw0_wd_in[110]
+  PIN rw0_wd_in[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 72.545 0.000 72.615 0.210 ;
+    END
+  END rw0_wd_in[111]
+  PIN rw0_wd_in[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 74.065 0.000 74.135 0.210 ;
+    END
+  END rw0_wd_in[112]
+  PIN rw0_wd_in[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 75.585 0.000 75.655 0.210 ;
+    END
+  END rw0_wd_in[113]
+  PIN rw0_wd_in[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 77.105 0.000 77.175 0.210 ;
+    END
+  END rw0_wd_in[114]
+  PIN rw0_wd_in[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 78.625 0.000 78.695 0.210 ;
+    END
+  END rw0_wd_in[115]
+  PIN rw0_wd_in[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 80.145 0.000 80.215 0.210 ;
+    END
+  END rw0_wd_in[116]
+  PIN rw0_wd_in[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 81.665 0.000 81.735 0.210 ;
+    END
+  END rw0_wd_in[117]
+  PIN rw0_wd_in[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 83.185 0.000 83.255 0.210 ;
+    END
+  END rw0_wd_in[118]
+  PIN rw0_wd_in[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 84.705 0.000 84.775 0.210 ;
+    END
+  END rw0_wd_in[119]
+  PIN rw0_wd_in[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 86.225 0.000 86.295 0.210 ;
+    END
+  END rw0_wd_in[120]
+  PIN rw0_wd_in[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 87.745 0.000 87.815 0.210 ;
+    END
+  END rw0_wd_in[121]
+  PIN rw0_wd_in[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 89.265 0.000 89.335 0.210 ;
+    END
+  END rw0_wd_in[122]
+  PIN rw0_wd_in[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 90.785 0.000 90.855 0.210 ;
+    END
+  END rw0_wd_in[123]
+  PIN rw0_wd_in[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 92.305 0.000 92.375 0.210 ;
+    END
+  END rw0_wd_in[124]
+  PIN rw0_wd_in[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 93.825 0.000 93.895 0.210 ;
+    END
+  END rw0_wd_in[125]
+  PIN rw0_wd_in[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 95.345 0.000 95.415 0.210 ;
+    END
+  END rw0_wd_in[126]
+  PIN rw0_wd_in[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 96.865 0.000 96.935 0.210 ;
+    END
+  END rw0_wd_in[127]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 98.385 0.000 98.455 0.210 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.905 0.000 99.975 0.210 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 101.425 0.000 101.495 0.210 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 102.945 0.000 103.015 0.210 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 104.465 0.000 104.535 0.210 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 105.985 0.000 106.055 0.210 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 107.505 0.000 107.575 0.210 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 109.025 0.000 109.095 0.210 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 110.545 0.000 110.615 0.210 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 112.065 0.000 112.135 0.210 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 113.585 0.000 113.655 0.210 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 115.105 0.000 115.175 0.210 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 116.625 0.000 116.695 0.210 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 118.145 0.000 118.215 0.210 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 119.665 0.000 119.735 0.210 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 121.185 0.000 121.255 0.210 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 122.705 0.000 122.775 0.210 ;
+    END
+  END rw0_rd_out[16]
+  PIN rw0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 124.225 0.000 124.295 0.210 ;
+    END
+  END rw0_rd_out[17]
+  PIN rw0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 125.745 0.000 125.815 0.210 ;
+    END
+  END rw0_rd_out[18]
+  PIN rw0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 127.265 0.000 127.335 0.210 ;
+    END
+  END rw0_rd_out[19]
+  PIN rw0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 128.785 0.000 128.855 0.210 ;
+    END
+  END rw0_rd_out[20]
+  PIN rw0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 130.305 0.000 130.375 0.210 ;
+    END
+  END rw0_rd_out[21]
+  PIN rw0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 131.825 0.000 131.895 0.210 ;
+    END
+  END rw0_rd_out[22]
+  PIN rw0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 133.345 0.000 133.415 0.210 ;
+    END
+  END rw0_rd_out[23]
+  PIN rw0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 134.865 0.000 134.935 0.210 ;
+    END
+  END rw0_rd_out[24]
+  PIN rw0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 136.385 0.000 136.455 0.210 ;
+    END
+  END rw0_rd_out[25]
+  PIN rw0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 137.905 0.000 137.975 0.210 ;
+    END
+  END rw0_rd_out[26]
+  PIN rw0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 139.425 0.000 139.495 0.210 ;
+    END
+  END rw0_rd_out[27]
+  PIN rw0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 140.945 0.000 141.015 0.210 ;
+    END
+  END rw0_rd_out[28]
+  PIN rw0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 142.465 0.000 142.535 0.210 ;
+    END
+  END rw0_rd_out[29]
+  PIN rw0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 143.985 0.000 144.055 0.210 ;
+    END
+  END rw0_rd_out[30]
+  PIN rw0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 145.505 0.000 145.575 0.210 ;
+    END
+  END rw0_rd_out[31]
+  PIN rw0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 147.025 0.000 147.095 0.210 ;
+    END
+  END rw0_rd_out[32]
+  PIN rw0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 148.545 0.000 148.615 0.210 ;
+    END
+  END rw0_rd_out[33]
+  PIN rw0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 150.065 0.000 150.135 0.210 ;
+    END
+  END rw0_rd_out[34]
+  PIN rw0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 151.585 0.000 151.655 0.210 ;
+    END
+  END rw0_rd_out[35]
+  PIN rw0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 153.105 0.000 153.175 0.210 ;
+    END
+  END rw0_rd_out[36]
+  PIN rw0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 154.625 0.000 154.695 0.210 ;
+    END
+  END rw0_rd_out[37]
+  PIN rw0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 156.145 0.000 156.215 0.210 ;
+    END
+  END rw0_rd_out[38]
+  PIN rw0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 157.665 0.000 157.735 0.210 ;
+    END
+  END rw0_rd_out[39]
+  PIN rw0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 159.185 0.000 159.255 0.210 ;
+    END
+  END rw0_rd_out[40]
+  PIN rw0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 160.705 0.000 160.775 0.210 ;
+    END
+  END rw0_rd_out[41]
+  PIN rw0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 162.225 0.000 162.295 0.210 ;
+    END
+  END rw0_rd_out[42]
+  PIN rw0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 163.745 0.000 163.815 0.210 ;
+    END
+  END rw0_rd_out[43]
+  PIN rw0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 165.265 0.000 165.335 0.210 ;
+    END
+  END rw0_rd_out[44]
+  PIN rw0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 166.785 0.000 166.855 0.210 ;
+    END
+  END rw0_rd_out[45]
+  PIN rw0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 168.305 0.000 168.375 0.210 ;
+    END
+  END rw0_rd_out[46]
+  PIN rw0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 169.825 0.000 169.895 0.210 ;
+    END
+  END rw0_rd_out[47]
+  PIN rw0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 171.345 0.000 171.415 0.210 ;
+    END
+  END rw0_rd_out[48]
+  PIN rw0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 172.865 0.000 172.935 0.210 ;
+    END
+  END rw0_rd_out[49]
+  PIN rw0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 174.385 0.000 174.455 0.210 ;
+    END
+  END rw0_rd_out[50]
+  PIN rw0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 175.905 0.000 175.975 0.210 ;
+    END
+  END rw0_rd_out[51]
+  PIN rw0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 177.425 0.000 177.495 0.210 ;
+    END
+  END rw0_rd_out[52]
+  PIN rw0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 178.945 0.000 179.015 0.210 ;
+    END
+  END rw0_rd_out[53]
+  PIN rw0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 180.465 0.000 180.535 0.210 ;
+    END
+  END rw0_rd_out[54]
+  PIN rw0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 181.985 0.000 182.055 0.210 ;
+    END
+  END rw0_rd_out[55]
+  PIN rw0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 183.505 0.000 183.575 0.210 ;
+    END
+  END rw0_rd_out[56]
+  PIN rw0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 185.025 0.000 185.095 0.210 ;
+    END
+  END rw0_rd_out[57]
+  PIN rw0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 186.545 0.000 186.615 0.210 ;
+    END
+  END rw0_rd_out[58]
+  PIN rw0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 188.065 0.000 188.135 0.210 ;
+    END
+  END rw0_rd_out[59]
+  PIN rw0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 189.585 0.000 189.655 0.210 ;
+    END
+  END rw0_rd_out[60]
+  PIN rw0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 191.105 0.000 191.175 0.210 ;
+    END
+  END rw0_rd_out[61]
+  PIN rw0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 192.625 0.000 192.695 0.210 ;
+    END
+  END rw0_rd_out[62]
+  PIN rw0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 194.145 0.000 194.215 0.210 ;
+    END
+  END rw0_rd_out[63]
+  PIN rw0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 13.265 234.990 13.335 235.200 ;
+    END
+  END rw0_rd_out[64]
+  PIN rw0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 14.785 234.990 14.855 235.200 ;
+    END
+  END rw0_rd_out[65]
+  PIN rw0_rd_out[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 16.305 234.990 16.375 235.200 ;
+    END
+  END rw0_rd_out[66]
+  PIN rw0_rd_out[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 17.825 234.990 17.895 235.200 ;
+    END
+  END rw0_rd_out[67]
+  PIN rw0_rd_out[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 19.345 234.990 19.415 235.200 ;
+    END
+  END rw0_rd_out[68]
+  PIN rw0_rd_out[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 20.865 234.990 20.935 235.200 ;
+    END
+  END rw0_rd_out[69]
+  PIN rw0_rd_out[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 22.385 234.990 22.455 235.200 ;
+    END
+  END rw0_rd_out[70]
+  PIN rw0_rd_out[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 23.905 234.990 23.975 235.200 ;
+    END
+  END rw0_rd_out[71]
+  PIN rw0_rd_out[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 25.425 234.990 25.495 235.200 ;
+    END
+  END rw0_rd_out[72]
+  PIN rw0_rd_out[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 26.945 234.990 27.015 235.200 ;
+    END
+  END rw0_rd_out[73]
+  PIN rw0_rd_out[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 28.465 234.990 28.535 235.200 ;
+    END
+  END rw0_rd_out[74]
+  PIN rw0_rd_out[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 29.985 234.990 30.055 235.200 ;
+    END
+  END rw0_rd_out[75]
+  PIN rw0_rd_out[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 31.505 234.990 31.575 235.200 ;
+    END
+  END rw0_rd_out[76]
+  PIN rw0_rd_out[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 33.025 234.990 33.095 235.200 ;
+    END
+  END rw0_rd_out[77]
+  PIN rw0_rd_out[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 34.545 234.990 34.615 235.200 ;
+    END
+  END rw0_rd_out[78]
+  PIN rw0_rd_out[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 36.065 234.990 36.135 235.200 ;
+    END
+  END rw0_rd_out[79]
+  PIN rw0_rd_out[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 37.585 234.990 37.655 235.200 ;
+    END
+  END rw0_rd_out[80]
+  PIN rw0_rd_out[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 39.105 234.990 39.175 235.200 ;
+    END
+  END rw0_rd_out[81]
+  PIN rw0_rd_out[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 40.625 234.990 40.695 235.200 ;
+    END
+  END rw0_rd_out[82]
+  PIN rw0_rd_out[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 42.145 234.990 42.215 235.200 ;
+    END
+  END rw0_rd_out[83]
+  PIN rw0_rd_out[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 43.665 234.990 43.735 235.200 ;
+    END
+  END rw0_rd_out[84]
+  PIN rw0_rd_out[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 45.185 234.990 45.255 235.200 ;
+    END
+  END rw0_rd_out[85]
+  PIN rw0_rd_out[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 46.705 234.990 46.775 235.200 ;
+    END
+  END rw0_rd_out[86]
+  PIN rw0_rd_out[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 48.225 234.990 48.295 235.200 ;
+    END
+  END rw0_rd_out[87]
+  PIN rw0_rd_out[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 49.745 234.990 49.815 235.200 ;
+    END
+  END rw0_rd_out[88]
+  PIN rw0_rd_out[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 51.265 234.990 51.335 235.200 ;
+    END
+  END rw0_rd_out[89]
+  PIN rw0_rd_out[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 52.785 234.990 52.855 235.200 ;
+    END
+  END rw0_rd_out[90]
+  PIN rw0_rd_out[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 54.305 234.990 54.375 235.200 ;
+    END
+  END rw0_rd_out[91]
+  PIN rw0_rd_out[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 55.825 234.990 55.895 235.200 ;
+    END
+  END rw0_rd_out[92]
+  PIN rw0_rd_out[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 57.345 234.990 57.415 235.200 ;
+    END
+  END rw0_rd_out[93]
+  PIN rw0_rd_out[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 58.865 234.990 58.935 235.200 ;
+    END
+  END rw0_rd_out[94]
+  PIN rw0_rd_out[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 60.385 234.990 60.455 235.200 ;
+    END
+  END rw0_rd_out[95]
+  PIN rw0_rd_out[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 61.905 234.990 61.975 235.200 ;
+    END
+  END rw0_rd_out[96]
+  PIN rw0_rd_out[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 63.425 234.990 63.495 235.200 ;
+    END
+  END rw0_rd_out[97]
+  PIN rw0_rd_out[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 64.945 234.990 65.015 235.200 ;
+    END
+  END rw0_rd_out[98]
+  PIN rw0_rd_out[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 66.465 234.990 66.535 235.200 ;
+    END
+  END rw0_rd_out[99]
+  PIN rw0_rd_out[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 67.985 234.990 68.055 235.200 ;
+    END
+  END rw0_rd_out[100]
+  PIN rw0_rd_out[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 69.505 234.990 69.575 235.200 ;
+    END
+  END rw0_rd_out[101]
+  PIN rw0_rd_out[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 71.025 234.990 71.095 235.200 ;
+    END
+  END rw0_rd_out[102]
+  PIN rw0_rd_out[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 72.545 234.990 72.615 235.200 ;
+    END
+  END rw0_rd_out[103]
+  PIN rw0_rd_out[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 74.065 234.990 74.135 235.200 ;
+    END
+  END rw0_rd_out[104]
+  PIN rw0_rd_out[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 75.585 234.990 75.655 235.200 ;
+    END
+  END rw0_rd_out[105]
+  PIN rw0_rd_out[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 77.105 234.990 77.175 235.200 ;
+    END
+  END rw0_rd_out[106]
+  PIN rw0_rd_out[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 78.625 234.990 78.695 235.200 ;
+    END
+  END rw0_rd_out[107]
+  PIN rw0_rd_out[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 80.145 234.990 80.215 235.200 ;
+    END
+  END rw0_rd_out[108]
+  PIN rw0_rd_out[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 81.665 234.990 81.735 235.200 ;
+    END
+  END rw0_rd_out[109]
+  PIN rw0_rd_out[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 83.185 234.990 83.255 235.200 ;
+    END
+  END rw0_rd_out[110]
+  PIN rw0_rd_out[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 84.705 234.990 84.775 235.200 ;
+    END
+  END rw0_rd_out[111]
+  PIN rw0_rd_out[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 86.225 234.990 86.295 235.200 ;
+    END
+  END rw0_rd_out[112]
+  PIN rw0_rd_out[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 87.745 234.990 87.815 235.200 ;
+    END
+  END rw0_rd_out[113]
+  PIN rw0_rd_out[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 89.265 234.990 89.335 235.200 ;
+    END
+  END rw0_rd_out[114]
+  PIN rw0_rd_out[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 90.785 234.990 90.855 235.200 ;
+    END
+  END rw0_rd_out[115]
+  PIN rw0_rd_out[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 92.305 234.990 92.375 235.200 ;
+    END
+  END rw0_rd_out[116]
+  PIN rw0_rd_out[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 93.825 234.990 93.895 235.200 ;
+    END
+  END rw0_rd_out[117]
+  PIN rw0_rd_out[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 95.345 234.990 95.415 235.200 ;
+    END
+  END rw0_rd_out[118]
+  PIN rw0_rd_out[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 96.865 234.990 96.935 235.200 ;
+    END
+  END rw0_rd_out[119]
+  PIN rw0_rd_out[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 98.385 234.990 98.455 235.200 ;
+    END
+  END rw0_rd_out[120]
+  PIN rw0_rd_out[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.905 234.990 99.975 235.200 ;
+    END
+  END rw0_rd_out[121]
+  PIN rw0_rd_out[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 101.425 234.990 101.495 235.200 ;
+    END
+  END rw0_rd_out[122]
+  PIN rw0_rd_out[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 102.945 234.990 103.015 235.200 ;
+    END
+  END rw0_rd_out[123]
+  PIN rw0_rd_out[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 104.465 234.990 104.535 235.200 ;
+    END
+  END rw0_rd_out[124]
+  PIN rw0_rd_out[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 105.985 234.990 106.055 235.200 ;
+    END
+  END rw0_rd_out[125]
+  PIN rw0_rd_out[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 107.505 234.990 107.575 235.200 ;
+    END
+  END rw0_rd_out[126]
+  PIN rw0_rd_out[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 109.025 234.990 109.095 235.200 ;
+    END
+  END rw0_rd_out[127]
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 121.765 0.210 121.835 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 125.125 0.210 125.195 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 128.485 0.210 128.555 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 131.845 0.210 131.915 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 0.000 135.205 0.210 135.275 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 121.765 210.140 121.835 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 125.125 210.140 125.195 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 128.485 210.140 128.555 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal4 ;
+      RECT 209.930 131.845 210.140 131.915 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 110.545 234.990 110.615 235.200 ;
+    END
+  END rw0_we_in
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 112.065 234.990 112.135 235.200 ;
+    END
+  END rw0_ce_in
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 113.585 234.990 113.655 235.200 ;
+    END
+  END rw0_clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER metal4 ;
+      RECT 1.140 0.700 209.000 0.980 ;
+      RECT 1.140 2.940 209.000 3.220 ;
+      RECT 1.140 5.180 209.000 5.460 ;
+      RECT 1.140 7.420 209.000 7.700 ;
+      RECT 1.140 9.660 209.000 9.940 ;
+      RECT 1.140 11.900 209.000 12.180 ;
+      RECT 1.140 14.140 209.000 14.420 ;
+      RECT 1.140 16.380 209.000 16.660 ;
+      RECT 1.140 18.620 209.000 18.900 ;
+      RECT 1.140 20.860 209.000 21.140 ;
+      RECT 1.140 23.100 209.000 23.380 ;
+      RECT 1.140 25.340 209.000 25.620 ;
+      RECT 1.140 27.580 209.000 27.860 ;
+      RECT 1.140 29.820 209.000 30.100 ;
+      RECT 1.140 32.060 209.000 32.340 ;
+      RECT 1.140 34.300 209.000 34.580 ;
+      RECT 1.140 36.540 209.000 36.820 ;
+      RECT 1.140 38.780 209.000 39.060 ;
+      RECT 1.140 41.020 209.000 41.300 ;
+      RECT 1.140 43.260 209.000 43.540 ;
+      RECT 1.140 45.500 209.000 45.780 ;
+      RECT 1.140 47.740 209.000 48.020 ;
+      RECT 1.140 49.980 209.000 50.260 ;
+      RECT 1.140 52.220 209.000 52.500 ;
+      RECT 1.140 54.460 209.000 54.740 ;
+      RECT 1.140 56.700 209.000 56.980 ;
+      RECT 1.140 58.940 209.000 59.220 ;
+      RECT 1.140 61.180 209.000 61.460 ;
+      RECT 1.140 63.420 209.000 63.700 ;
+      RECT 1.140 65.660 209.000 65.940 ;
+      RECT 1.140 67.900 209.000 68.180 ;
+      RECT 1.140 70.140 209.000 70.420 ;
+      RECT 1.140 72.380 209.000 72.660 ;
+      RECT 1.140 74.620 209.000 74.900 ;
+      RECT 1.140 76.860 209.000 77.140 ;
+      RECT 1.140 79.100 209.000 79.380 ;
+      RECT 1.140 81.340 209.000 81.620 ;
+      RECT 1.140 83.580 209.000 83.860 ;
+      RECT 1.140 85.820 209.000 86.100 ;
+      RECT 1.140 88.060 209.000 88.340 ;
+      RECT 1.140 90.300 209.000 90.580 ;
+      RECT 1.140 92.540 209.000 92.820 ;
+      RECT 1.140 94.780 209.000 95.060 ;
+      RECT 1.140 97.020 209.000 97.300 ;
+      RECT 1.140 99.260 209.000 99.540 ;
+      RECT 1.140 101.500 209.000 101.780 ;
+      RECT 1.140 103.740 209.000 104.020 ;
+      RECT 1.140 105.980 209.000 106.260 ;
+      RECT 1.140 108.220 209.000 108.500 ;
+      RECT 1.140 110.460 209.000 110.740 ;
+      RECT 1.140 112.700 209.000 112.980 ;
+      RECT 1.140 114.940 209.000 115.220 ;
+      RECT 1.140 117.180 209.000 117.460 ;
+      RECT 1.140 119.420 209.000 119.700 ;
+      RECT 1.140 121.660 209.000 121.940 ;
+      RECT 1.140 123.900 209.000 124.180 ;
+      RECT 1.140 126.140 209.000 126.420 ;
+      RECT 1.140 128.380 209.000 128.660 ;
+      RECT 1.140 130.620 209.000 130.900 ;
+      RECT 1.140 132.860 209.000 133.140 ;
+      RECT 1.140 135.100 209.000 135.380 ;
+      RECT 1.140 137.340 209.000 137.620 ;
+      RECT 1.140 139.580 209.000 139.860 ;
+      RECT 1.140 141.820 209.000 142.100 ;
+      RECT 1.140 144.060 209.000 144.340 ;
+      RECT 1.140 146.300 209.000 146.580 ;
+      RECT 1.140 148.540 209.000 148.820 ;
+      RECT 1.140 150.780 209.000 151.060 ;
+      RECT 1.140 153.020 209.000 153.300 ;
+      RECT 1.140 155.260 209.000 155.540 ;
+      RECT 1.140 157.500 209.000 157.780 ;
+      RECT 1.140 159.740 209.000 160.020 ;
+      RECT 1.140 161.980 209.000 162.260 ;
+      RECT 1.140 164.220 209.000 164.500 ;
+      RECT 1.140 166.460 209.000 166.740 ;
+      RECT 1.140 168.700 209.000 168.980 ;
+      RECT 1.140 170.940 209.000 171.220 ;
+      RECT 1.140 173.180 209.000 173.460 ;
+      RECT 1.140 175.420 209.000 175.700 ;
+      RECT 1.140 177.660 209.000 177.940 ;
+      RECT 1.140 179.900 209.000 180.180 ;
+      RECT 1.140 182.140 209.000 182.420 ;
+      RECT 1.140 184.380 209.000 184.660 ;
+      RECT 1.140 186.620 209.000 186.900 ;
+      RECT 1.140 188.860 209.000 189.140 ;
+      RECT 1.140 191.100 209.000 191.380 ;
+      RECT 1.140 193.340 209.000 193.620 ;
+      RECT 1.140 195.580 209.000 195.860 ;
+      RECT 1.140 197.820 209.000 198.100 ;
+      RECT 1.140 200.060 209.000 200.340 ;
+      RECT 1.140 202.300 209.000 202.580 ;
+      RECT 1.140 204.540 209.000 204.820 ;
+      RECT 1.140 206.780 209.000 207.060 ;
+      RECT 1.140 209.020 209.000 209.300 ;
+      RECT 1.140 211.260 209.000 211.540 ;
+      RECT 1.140 213.500 209.000 213.780 ;
+      RECT 1.140 215.740 209.000 216.020 ;
+      RECT 1.140 217.980 209.000 218.260 ;
+      RECT 1.140 220.220 209.000 220.500 ;
+      RECT 1.140 222.460 209.000 222.740 ;
+      RECT 1.140 224.700 209.000 224.980 ;
+      RECT 1.140 226.940 209.000 227.220 ;
+      RECT 1.140 229.180 209.000 229.460 ;
+      RECT 1.140 231.420 209.000 231.700 ;
+      RECT 1.140 233.660 209.000 233.940 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER metal4 ;
+      RECT 1.140 0.700 209.000 0.980 ;
+      RECT 1.140 2.940 209.000 3.220 ;
+      RECT 1.140 5.180 209.000 5.460 ;
+      RECT 1.140 7.420 209.000 7.700 ;
+      RECT 1.140 9.660 209.000 9.940 ;
+      RECT 1.140 11.900 209.000 12.180 ;
+      RECT 1.140 14.140 209.000 14.420 ;
+      RECT 1.140 16.380 209.000 16.660 ;
+      RECT 1.140 18.620 209.000 18.900 ;
+      RECT 1.140 20.860 209.000 21.140 ;
+      RECT 1.140 23.100 209.000 23.380 ;
+      RECT 1.140 25.340 209.000 25.620 ;
+      RECT 1.140 27.580 209.000 27.860 ;
+      RECT 1.140 29.820 209.000 30.100 ;
+      RECT 1.140 32.060 209.000 32.340 ;
+      RECT 1.140 34.300 209.000 34.580 ;
+      RECT 1.140 36.540 209.000 36.820 ;
+      RECT 1.140 38.780 209.000 39.060 ;
+      RECT 1.140 41.020 209.000 41.300 ;
+      RECT 1.140 43.260 209.000 43.540 ;
+      RECT 1.140 45.500 209.000 45.780 ;
+      RECT 1.140 47.740 209.000 48.020 ;
+      RECT 1.140 49.980 209.000 50.260 ;
+      RECT 1.140 52.220 209.000 52.500 ;
+      RECT 1.140 54.460 209.000 54.740 ;
+      RECT 1.140 56.700 209.000 56.980 ;
+      RECT 1.140 58.940 209.000 59.220 ;
+      RECT 1.140 61.180 209.000 61.460 ;
+      RECT 1.140 63.420 209.000 63.700 ;
+      RECT 1.140 65.660 209.000 65.940 ;
+      RECT 1.140 67.900 209.000 68.180 ;
+      RECT 1.140 70.140 209.000 70.420 ;
+      RECT 1.140 72.380 209.000 72.660 ;
+      RECT 1.140 74.620 209.000 74.900 ;
+      RECT 1.140 76.860 209.000 77.140 ;
+      RECT 1.140 79.100 209.000 79.380 ;
+      RECT 1.140 81.340 209.000 81.620 ;
+      RECT 1.140 83.580 209.000 83.860 ;
+      RECT 1.140 85.820 209.000 86.100 ;
+      RECT 1.140 88.060 209.000 88.340 ;
+      RECT 1.140 90.300 209.000 90.580 ;
+      RECT 1.140 92.540 209.000 92.820 ;
+      RECT 1.140 94.780 209.000 95.060 ;
+      RECT 1.140 97.020 209.000 97.300 ;
+      RECT 1.140 99.260 209.000 99.540 ;
+      RECT 1.140 101.500 209.000 101.780 ;
+      RECT 1.140 103.740 209.000 104.020 ;
+      RECT 1.140 105.980 209.000 106.260 ;
+      RECT 1.140 108.220 209.000 108.500 ;
+      RECT 1.140 110.460 209.000 110.740 ;
+      RECT 1.140 112.700 209.000 112.980 ;
+      RECT 1.140 114.940 209.000 115.220 ;
+      RECT 1.140 117.180 209.000 117.460 ;
+      RECT 1.140 119.420 209.000 119.700 ;
+      RECT 1.140 121.660 209.000 121.940 ;
+      RECT 1.140 123.900 209.000 124.180 ;
+      RECT 1.140 126.140 209.000 126.420 ;
+      RECT 1.140 128.380 209.000 128.660 ;
+      RECT 1.140 130.620 209.000 130.900 ;
+      RECT 1.140 132.860 209.000 133.140 ;
+      RECT 1.140 135.100 209.000 135.380 ;
+      RECT 1.140 137.340 209.000 137.620 ;
+      RECT 1.140 139.580 209.000 139.860 ;
+      RECT 1.140 141.820 209.000 142.100 ;
+      RECT 1.140 144.060 209.000 144.340 ;
+      RECT 1.140 146.300 209.000 146.580 ;
+      RECT 1.140 148.540 209.000 148.820 ;
+      RECT 1.140 150.780 209.000 151.060 ;
+      RECT 1.140 153.020 209.000 153.300 ;
+      RECT 1.140 155.260 209.000 155.540 ;
+      RECT 1.140 157.500 209.000 157.780 ;
+      RECT 1.140 159.740 209.000 160.020 ;
+      RECT 1.140 161.980 209.000 162.260 ;
+      RECT 1.140 164.220 209.000 164.500 ;
+      RECT 1.140 166.460 209.000 166.740 ;
+      RECT 1.140 168.700 209.000 168.980 ;
+      RECT 1.140 170.940 209.000 171.220 ;
+      RECT 1.140 173.180 209.000 173.460 ;
+      RECT 1.140 175.420 209.000 175.700 ;
+      RECT 1.140 177.660 209.000 177.940 ;
+      RECT 1.140 179.900 209.000 180.180 ;
+      RECT 1.140 182.140 209.000 182.420 ;
+      RECT 1.140 184.380 209.000 184.660 ;
+      RECT 1.140 186.620 209.000 186.900 ;
+      RECT 1.140 188.860 209.000 189.140 ;
+      RECT 1.140 191.100 209.000 191.380 ;
+      RECT 1.140 193.340 209.000 193.620 ;
+      RECT 1.140 195.580 209.000 195.860 ;
+      RECT 1.140 197.820 209.000 198.100 ;
+      RECT 1.140 200.060 209.000 200.340 ;
+      RECT 1.140 202.300 209.000 202.580 ;
+      RECT 1.140 204.540 209.000 204.820 ;
+      RECT 1.140 206.780 209.000 207.060 ;
+      RECT 1.140 209.020 209.000 209.300 ;
+      RECT 1.140 211.260 209.000 211.540 ;
+      RECT 1.140 213.500 209.000 213.780 ;
+      RECT 1.140 215.740 209.000 216.020 ;
+      RECT 1.140 217.980 209.000 218.260 ;
+      RECT 1.140 220.220 209.000 220.500 ;
+      RECT 1.140 222.460 209.000 222.740 ;
+      RECT 1.140 224.700 209.000 224.980 ;
+      RECT 1.140 226.940 209.000 227.220 ;
+      RECT 1.140 229.180 209.000 229.460 ;
+      RECT 1.140 231.420 209.000 231.700 ;
+      RECT 1.140 233.660 209.000 233.940 ;
+    END
+  END VDD
+  OBS
+    LAYER metal1 ;
+    RECT 0 0 210.140 235.200 ;
+    LAYER metal2 ;
+    RECT 0 0 210.140 235.200 ;
+    LAYER metal3 ;
+    RECT 0 0 210.140 235.200 ;
+    LAYER metal4 ;
+    RECT 0 0 210.140 235.200 ;
+    LAYER OVERLAP ;
+    RECT 0 0 210.140 235.200 ;
+  END
+END fakeram_512x128_1rw
+
+END LIBRARY

--- a/designs/nangate45/coralnpu/sram/lef/fakeram_512x128_1rw.lef
+++ b/designs/nangate45/coralnpu/sram/lef/fakeram_512x128_1rw.lef
@@ -10,7 +10,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 0.805 0.210 0.875 ;
     END
   END rw0_wmask_in[0]
@@ -19,7 +19,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 4.165 0.210 4.235 ;
     END
   END rw0_wmask_in[1]
@@ -28,7 +28,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 7.525 0.210 7.595 ;
     END
   END rw0_wmask_in[2]
@@ -37,7 +37,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 10.885 0.210 10.955 ;
     END
   END rw0_wmask_in[3]
@@ -46,7 +46,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 0.805 210.140 0.875 ;
     END
   END rw0_wmask_in[4]
@@ -55,7 +55,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 4.165 210.140 4.235 ;
     END
   END rw0_wmask_in[5]
@@ -64,7 +64,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 7.525 210.140 7.595 ;
     END
   END rw0_wmask_in[6]
@@ -73,7 +73,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 10.885 210.140 10.955 ;
     END
   END rw0_wmask_in[7]
@@ -82,7 +82,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 1.105 234.990 1.175 235.200 ;
     END
   END rw0_wmask_in[8]
@@ -91,7 +91,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 2.625 234.990 2.695 235.200 ;
     END
   END rw0_wmask_in[9]
@@ -100,7 +100,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 4.145 234.990 4.215 235.200 ;
     END
   END rw0_wmask_in[10]
@@ -109,7 +109,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 5.665 234.990 5.735 235.200 ;
     END
   END rw0_wmask_in[11]
@@ -118,7 +118,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 7.185 234.990 7.255 235.200 ;
     END
   END rw0_wmask_in[12]
@@ -127,7 +127,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 8.705 234.990 8.775 235.200 ;
     END
   END rw0_wmask_in[13]
@@ -136,7 +136,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 10.225 234.990 10.295 235.200 ;
     END
   END rw0_wmask_in[14]
@@ -145,7 +145,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 11.745 234.990 11.815 235.200 ;
     END
   END rw0_wmask_in[15]
@@ -154,7 +154,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 14.245 0.210 14.315 ;
     END
   END rw0_wd_in[0]
@@ -163,7 +163,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 17.605 0.210 17.675 ;
     END
   END rw0_wd_in[1]
@@ -172,7 +172,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 20.965 0.210 21.035 ;
     END
   END rw0_wd_in[2]
@@ -181,7 +181,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 24.325 0.210 24.395 ;
     END
   END rw0_wd_in[3]
@@ -190,7 +190,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 27.685 0.210 27.755 ;
     END
   END rw0_wd_in[4]
@@ -199,7 +199,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 31.045 0.210 31.115 ;
     END
   END rw0_wd_in[5]
@@ -208,7 +208,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 34.405 0.210 34.475 ;
     END
   END rw0_wd_in[6]
@@ -217,7 +217,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 37.765 0.210 37.835 ;
     END
   END rw0_wd_in[7]
@@ -226,7 +226,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 41.125 0.210 41.195 ;
     END
   END rw0_wd_in[8]
@@ -235,7 +235,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 44.485 0.210 44.555 ;
     END
   END rw0_wd_in[9]
@@ -244,7 +244,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 47.845 0.210 47.915 ;
     END
   END rw0_wd_in[10]
@@ -253,7 +253,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 51.205 0.210 51.275 ;
     END
   END rw0_wd_in[11]
@@ -262,7 +262,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 54.565 0.210 54.635 ;
     END
   END rw0_wd_in[12]
@@ -271,7 +271,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 57.925 0.210 57.995 ;
     END
   END rw0_wd_in[13]
@@ -280,7 +280,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 61.285 0.210 61.355 ;
     END
   END rw0_wd_in[14]
@@ -289,7 +289,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 64.645 0.210 64.715 ;
     END
   END rw0_wd_in[15]
@@ -298,7 +298,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 68.005 0.210 68.075 ;
     END
   END rw0_wd_in[16]
@@ -307,7 +307,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 71.365 0.210 71.435 ;
     END
   END rw0_wd_in[17]
@@ -316,7 +316,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 74.725 0.210 74.795 ;
     END
   END rw0_wd_in[18]
@@ -325,7 +325,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 78.085 0.210 78.155 ;
     END
   END rw0_wd_in[19]
@@ -334,7 +334,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 81.445 0.210 81.515 ;
     END
   END rw0_wd_in[20]
@@ -343,7 +343,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 84.805 0.210 84.875 ;
     END
   END rw0_wd_in[21]
@@ -352,7 +352,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 88.165 0.210 88.235 ;
     END
   END rw0_wd_in[22]
@@ -361,7 +361,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 91.525 0.210 91.595 ;
     END
   END rw0_wd_in[23]
@@ -370,7 +370,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 94.885 0.210 94.955 ;
     END
   END rw0_wd_in[24]
@@ -379,7 +379,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 98.245 0.210 98.315 ;
     END
   END rw0_wd_in[25]
@@ -388,7 +388,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 101.605 0.210 101.675 ;
     END
   END rw0_wd_in[26]
@@ -397,7 +397,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 104.965 0.210 105.035 ;
     END
   END rw0_wd_in[27]
@@ -406,7 +406,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 108.325 0.210 108.395 ;
     END
   END rw0_wd_in[28]
@@ -415,7 +415,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 111.685 0.210 111.755 ;
     END
   END rw0_wd_in[29]
@@ -424,7 +424,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 115.045 0.210 115.115 ;
     END
   END rw0_wd_in[30]
@@ -433,7 +433,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 118.405 0.210 118.475 ;
     END
   END rw0_wd_in[31]
@@ -442,7 +442,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 14.245 210.140 14.315 ;
     END
   END rw0_wd_in[32]
@@ -451,7 +451,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 17.605 210.140 17.675 ;
     END
   END rw0_wd_in[33]
@@ -460,7 +460,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 20.965 210.140 21.035 ;
     END
   END rw0_wd_in[34]
@@ -469,7 +469,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 24.325 210.140 24.395 ;
     END
   END rw0_wd_in[35]
@@ -478,7 +478,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 27.685 210.140 27.755 ;
     END
   END rw0_wd_in[36]
@@ -487,7 +487,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 31.045 210.140 31.115 ;
     END
   END rw0_wd_in[37]
@@ -496,7 +496,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 34.405 210.140 34.475 ;
     END
   END rw0_wd_in[38]
@@ -505,7 +505,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 37.765 210.140 37.835 ;
     END
   END rw0_wd_in[39]
@@ -514,7 +514,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 41.125 210.140 41.195 ;
     END
   END rw0_wd_in[40]
@@ -523,7 +523,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 44.485 210.140 44.555 ;
     END
   END rw0_wd_in[41]
@@ -532,7 +532,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 47.845 210.140 47.915 ;
     END
   END rw0_wd_in[42]
@@ -541,7 +541,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 51.205 210.140 51.275 ;
     END
   END rw0_wd_in[43]
@@ -550,7 +550,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 54.565 210.140 54.635 ;
     END
   END rw0_wd_in[44]
@@ -559,7 +559,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 57.925 210.140 57.995 ;
     END
   END rw0_wd_in[45]
@@ -568,7 +568,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 61.285 210.140 61.355 ;
     END
   END rw0_wd_in[46]
@@ -577,7 +577,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 64.645 210.140 64.715 ;
     END
   END rw0_wd_in[47]
@@ -586,7 +586,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 68.005 210.140 68.075 ;
     END
   END rw0_wd_in[48]
@@ -595,7 +595,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 71.365 210.140 71.435 ;
     END
   END rw0_wd_in[49]
@@ -604,7 +604,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 74.725 210.140 74.795 ;
     END
   END rw0_wd_in[50]
@@ -613,7 +613,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 78.085 210.140 78.155 ;
     END
   END rw0_wd_in[51]
@@ -622,7 +622,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 81.445 210.140 81.515 ;
     END
   END rw0_wd_in[52]
@@ -631,7 +631,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 84.805 210.140 84.875 ;
     END
   END rw0_wd_in[53]
@@ -640,7 +640,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 88.165 210.140 88.235 ;
     END
   END rw0_wd_in[54]
@@ -649,7 +649,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 91.525 210.140 91.595 ;
     END
   END rw0_wd_in[55]
@@ -658,7 +658,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 94.885 210.140 94.955 ;
     END
   END rw0_wd_in[56]
@@ -667,7 +667,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 98.245 210.140 98.315 ;
     END
   END rw0_wd_in[57]
@@ -676,7 +676,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 101.605 210.140 101.675 ;
     END
   END rw0_wd_in[58]
@@ -685,7 +685,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 104.965 210.140 105.035 ;
     END
   END rw0_wd_in[59]
@@ -694,7 +694,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 108.325 210.140 108.395 ;
     END
   END rw0_wd_in[60]
@@ -703,7 +703,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 111.685 210.140 111.755 ;
     END
   END rw0_wd_in[61]
@@ -712,7 +712,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 115.045 210.140 115.115 ;
     END
   END rw0_wd_in[62]
@@ -721,7 +721,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 118.405 210.140 118.475 ;
     END
   END rw0_wd_in[63]
@@ -730,7 +730,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 1.105 0.000 1.175 0.210 ;
     END
   END rw0_wd_in[64]
@@ -739,7 +739,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 2.625 0.000 2.695 0.210 ;
     END
   END rw0_wd_in[65]
@@ -748,7 +748,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 4.145 0.000 4.215 0.210 ;
     END
   END rw0_wd_in[66]
@@ -757,7 +757,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 5.665 0.000 5.735 0.210 ;
     END
   END rw0_wd_in[67]
@@ -766,7 +766,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 7.185 0.000 7.255 0.210 ;
     END
   END rw0_wd_in[68]
@@ -775,7 +775,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 8.705 0.000 8.775 0.210 ;
     END
   END rw0_wd_in[69]
@@ -784,7 +784,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 10.225 0.000 10.295 0.210 ;
     END
   END rw0_wd_in[70]
@@ -793,7 +793,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 11.745 0.000 11.815 0.210 ;
     END
   END rw0_wd_in[71]
@@ -802,7 +802,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 13.265 0.000 13.335 0.210 ;
     END
   END rw0_wd_in[72]
@@ -811,7 +811,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 14.785 0.000 14.855 0.210 ;
     END
   END rw0_wd_in[73]
@@ -820,7 +820,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 16.305 0.000 16.375 0.210 ;
     END
   END rw0_wd_in[74]
@@ -829,7 +829,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 17.825 0.000 17.895 0.210 ;
     END
   END rw0_wd_in[75]
@@ -838,7 +838,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 19.345 0.000 19.415 0.210 ;
     END
   END rw0_wd_in[76]
@@ -847,7 +847,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 20.865 0.000 20.935 0.210 ;
     END
   END rw0_wd_in[77]
@@ -856,7 +856,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 22.385 0.000 22.455 0.210 ;
     END
   END rw0_wd_in[78]
@@ -865,7 +865,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 23.905 0.000 23.975 0.210 ;
     END
   END rw0_wd_in[79]
@@ -874,7 +874,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 25.425 0.000 25.495 0.210 ;
     END
   END rw0_wd_in[80]
@@ -883,7 +883,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 26.945 0.000 27.015 0.210 ;
     END
   END rw0_wd_in[81]
@@ -892,7 +892,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 28.465 0.000 28.535 0.210 ;
     END
   END rw0_wd_in[82]
@@ -901,7 +901,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 29.985 0.000 30.055 0.210 ;
     END
   END rw0_wd_in[83]
@@ -910,7 +910,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 31.505 0.000 31.575 0.210 ;
     END
   END rw0_wd_in[84]
@@ -919,7 +919,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 33.025 0.000 33.095 0.210 ;
     END
   END rw0_wd_in[85]
@@ -928,7 +928,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 34.545 0.000 34.615 0.210 ;
     END
   END rw0_wd_in[86]
@@ -937,7 +937,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 36.065 0.000 36.135 0.210 ;
     END
   END rw0_wd_in[87]
@@ -946,7 +946,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 37.585 0.000 37.655 0.210 ;
     END
   END rw0_wd_in[88]
@@ -955,7 +955,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 39.105 0.000 39.175 0.210 ;
     END
   END rw0_wd_in[89]
@@ -964,7 +964,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 40.625 0.000 40.695 0.210 ;
     END
   END rw0_wd_in[90]
@@ -973,7 +973,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 42.145 0.000 42.215 0.210 ;
     END
   END rw0_wd_in[91]
@@ -982,7 +982,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 43.665 0.000 43.735 0.210 ;
     END
   END rw0_wd_in[92]
@@ -991,7 +991,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 45.185 0.000 45.255 0.210 ;
     END
   END rw0_wd_in[93]
@@ -1000,7 +1000,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 46.705 0.000 46.775 0.210 ;
     END
   END rw0_wd_in[94]
@@ -1009,7 +1009,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 48.225 0.000 48.295 0.210 ;
     END
   END rw0_wd_in[95]
@@ -1018,7 +1018,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 49.745 0.000 49.815 0.210 ;
     END
   END rw0_wd_in[96]
@@ -1027,7 +1027,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 51.265 0.000 51.335 0.210 ;
     END
   END rw0_wd_in[97]
@@ -1036,7 +1036,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 52.785 0.000 52.855 0.210 ;
     END
   END rw0_wd_in[98]
@@ -1045,7 +1045,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 54.305 0.000 54.375 0.210 ;
     END
   END rw0_wd_in[99]
@@ -1054,7 +1054,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 55.825 0.000 55.895 0.210 ;
     END
   END rw0_wd_in[100]
@@ -1063,7 +1063,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 57.345 0.000 57.415 0.210 ;
     END
   END rw0_wd_in[101]
@@ -1072,7 +1072,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 58.865 0.000 58.935 0.210 ;
     END
   END rw0_wd_in[102]
@@ -1081,7 +1081,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 60.385 0.000 60.455 0.210 ;
     END
   END rw0_wd_in[103]
@@ -1090,7 +1090,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 61.905 0.000 61.975 0.210 ;
     END
   END rw0_wd_in[104]
@@ -1099,7 +1099,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 63.425 0.000 63.495 0.210 ;
     END
   END rw0_wd_in[105]
@@ -1108,7 +1108,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 64.945 0.000 65.015 0.210 ;
     END
   END rw0_wd_in[106]
@@ -1117,7 +1117,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 66.465 0.000 66.535 0.210 ;
     END
   END rw0_wd_in[107]
@@ -1126,7 +1126,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 67.985 0.000 68.055 0.210 ;
     END
   END rw0_wd_in[108]
@@ -1135,7 +1135,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 69.505 0.000 69.575 0.210 ;
     END
   END rw0_wd_in[109]
@@ -1144,7 +1144,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 71.025 0.000 71.095 0.210 ;
     END
   END rw0_wd_in[110]
@@ -1153,7 +1153,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 72.545 0.000 72.615 0.210 ;
     END
   END rw0_wd_in[111]
@@ -1162,7 +1162,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 74.065 0.000 74.135 0.210 ;
     END
   END rw0_wd_in[112]
@@ -1171,7 +1171,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 75.585 0.000 75.655 0.210 ;
     END
   END rw0_wd_in[113]
@@ -1180,7 +1180,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 77.105 0.000 77.175 0.210 ;
     END
   END rw0_wd_in[114]
@@ -1189,7 +1189,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 78.625 0.000 78.695 0.210 ;
     END
   END rw0_wd_in[115]
@@ -1198,7 +1198,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 80.145 0.000 80.215 0.210 ;
     END
   END rw0_wd_in[116]
@@ -1207,7 +1207,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 81.665 0.000 81.735 0.210 ;
     END
   END rw0_wd_in[117]
@@ -1216,7 +1216,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 83.185 0.000 83.255 0.210 ;
     END
   END rw0_wd_in[118]
@@ -1225,7 +1225,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 84.705 0.000 84.775 0.210 ;
     END
   END rw0_wd_in[119]
@@ -1234,7 +1234,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 86.225 0.000 86.295 0.210 ;
     END
   END rw0_wd_in[120]
@@ -1243,7 +1243,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 87.745 0.000 87.815 0.210 ;
     END
   END rw0_wd_in[121]
@@ -1252,7 +1252,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 89.265 0.000 89.335 0.210 ;
     END
   END rw0_wd_in[122]
@@ -1261,7 +1261,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 90.785 0.000 90.855 0.210 ;
     END
   END rw0_wd_in[123]
@@ -1270,7 +1270,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 92.305 0.000 92.375 0.210 ;
     END
   END rw0_wd_in[124]
@@ -1279,7 +1279,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 93.825 0.000 93.895 0.210 ;
     END
   END rw0_wd_in[125]
@@ -1288,7 +1288,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 95.345 0.000 95.415 0.210 ;
     END
   END rw0_wd_in[126]
@@ -1297,7 +1297,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 96.865 0.000 96.935 0.210 ;
     END
   END rw0_wd_in[127]
@@ -1306,7 +1306,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 98.385 0.000 98.455 0.210 ;
     END
   END rw0_rd_out[0]
@@ -1315,7 +1315,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 99.905 0.000 99.975 0.210 ;
     END
   END rw0_rd_out[1]
@@ -1324,7 +1324,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 101.425 0.000 101.495 0.210 ;
     END
   END rw0_rd_out[2]
@@ -1333,7 +1333,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 102.945 0.000 103.015 0.210 ;
     END
   END rw0_rd_out[3]
@@ -1342,7 +1342,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 104.465 0.000 104.535 0.210 ;
     END
   END rw0_rd_out[4]
@@ -1351,7 +1351,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 105.985 0.000 106.055 0.210 ;
     END
   END rw0_rd_out[5]
@@ -1360,7 +1360,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 107.505 0.000 107.575 0.210 ;
     END
   END rw0_rd_out[6]
@@ -1369,7 +1369,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 109.025 0.000 109.095 0.210 ;
     END
   END rw0_rd_out[7]
@@ -1378,7 +1378,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 110.545 0.000 110.615 0.210 ;
     END
   END rw0_rd_out[8]
@@ -1387,7 +1387,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 112.065 0.000 112.135 0.210 ;
     END
   END rw0_rd_out[9]
@@ -1396,7 +1396,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 113.585 0.000 113.655 0.210 ;
     END
   END rw0_rd_out[10]
@@ -1405,7 +1405,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 115.105 0.000 115.175 0.210 ;
     END
   END rw0_rd_out[11]
@@ -1414,7 +1414,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 116.625 0.000 116.695 0.210 ;
     END
   END rw0_rd_out[12]
@@ -1423,7 +1423,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 118.145 0.000 118.215 0.210 ;
     END
   END rw0_rd_out[13]
@@ -1432,7 +1432,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 119.665 0.000 119.735 0.210 ;
     END
   END rw0_rd_out[14]
@@ -1441,7 +1441,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 121.185 0.000 121.255 0.210 ;
     END
   END rw0_rd_out[15]
@@ -1450,7 +1450,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 122.705 0.000 122.775 0.210 ;
     END
   END rw0_rd_out[16]
@@ -1459,7 +1459,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 124.225 0.000 124.295 0.210 ;
     END
   END rw0_rd_out[17]
@@ -1468,7 +1468,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 125.745 0.000 125.815 0.210 ;
     END
   END rw0_rd_out[18]
@@ -1477,7 +1477,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 127.265 0.000 127.335 0.210 ;
     END
   END rw0_rd_out[19]
@@ -1486,7 +1486,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 128.785 0.000 128.855 0.210 ;
     END
   END rw0_rd_out[20]
@@ -1495,7 +1495,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 130.305 0.000 130.375 0.210 ;
     END
   END rw0_rd_out[21]
@@ -1504,7 +1504,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 131.825 0.000 131.895 0.210 ;
     END
   END rw0_rd_out[22]
@@ -1513,7 +1513,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 133.345 0.000 133.415 0.210 ;
     END
   END rw0_rd_out[23]
@@ -1522,7 +1522,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 134.865 0.000 134.935 0.210 ;
     END
   END rw0_rd_out[24]
@@ -1531,7 +1531,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 136.385 0.000 136.455 0.210 ;
     END
   END rw0_rd_out[25]
@@ -1540,7 +1540,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 137.905 0.000 137.975 0.210 ;
     END
   END rw0_rd_out[26]
@@ -1549,7 +1549,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 139.425 0.000 139.495 0.210 ;
     END
   END rw0_rd_out[27]
@@ -1558,7 +1558,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 140.945 0.000 141.015 0.210 ;
     END
   END rw0_rd_out[28]
@@ -1567,7 +1567,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 142.465 0.000 142.535 0.210 ;
     END
   END rw0_rd_out[29]
@@ -1576,7 +1576,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 143.985 0.000 144.055 0.210 ;
     END
   END rw0_rd_out[30]
@@ -1585,7 +1585,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 145.505 0.000 145.575 0.210 ;
     END
   END rw0_rd_out[31]
@@ -1594,7 +1594,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 147.025 0.000 147.095 0.210 ;
     END
   END rw0_rd_out[32]
@@ -1603,7 +1603,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 148.545 0.000 148.615 0.210 ;
     END
   END rw0_rd_out[33]
@@ -1612,7 +1612,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 150.065 0.000 150.135 0.210 ;
     END
   END rw0_rd_out[34]
@@ -1621,7 +1621,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 151.585 0.000 151.655 0.210 ;
     END
   END rw0_rd_out[35]
@@ -1630,7 +1630,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 153.105 0.000 153.175 0.210 ;
     END
   END rw0_rd_out[36]
@@ -1639,7 +1639,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 154.625 0.000 154.695 0.210 ;
     END
   END rw0_rd_out[37]
@@ -1648,7 +1648,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 156.145 0.000 156.215 0.210 ;
     END
   END rw0_rd_out[38]
@@ -1657,7 +1657,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 157.665 0.000 157.735 0.210 ;
     END
   END rw0_rd_out[39]
@@ -1666,7 +1666,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 159.185 0.000 159.255 0.210 ;
     END
   END rw0_rd_out[40]
@@ -1675,7 +1675,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 160.705 0.000 160.775 0.210 ;
     END
   END rw0_rd_out[41]
@@ -1684,7 +1684,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 162.225 0.000 162.295 0.210 ;
     END
   END rw0_rd_out[42]
@@ -1693,7 +1693,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 163.745 0.000 163.815 0.210 ;
     END
   END rw0_rd_out[43]
@@ -1702,7 +1702,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 165.265 0.000 165.335 0.210 ;
     END
   END rw0_rd_out[44]
@@ -1711,7 +1711,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 166.785 0.000 166.855 0.210 ;
     END
   END rw0_rd_out[45]
@@ -1720,7 +1720,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 168.305 0.000 168.375 0.210 ;
     END
   END rw0_rd_out[46]
@@ -1729,7 +1729,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 169.825 0.000 169.895 0.210 ;
     END
   END rw0_rd_out[47]
@@ -1738,7 +1738,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 171.345 0.000 171.415 0.210 ;
     END
   END rw0_rd_out[48]
@@ -1747,7 +1747,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 172.865 0.000 172.935 0.210 ;
     END
   END rw0_rd_out[49]
@@ -1756,7 +1756,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 174.385 0.000 174.455 0.210 ;
     END
   END rw0_rd_out[50]
@@ -1765,7 +1765,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 175.905 0.000 175.975 0.210 ;
     END
   END rw0_rd_out[51]
@@ -1774,7 +1774,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 177.425 0.000 177.495 0.210 ;
     END
   END rw0_rd_out[52]
@@ -1783,7 +1783,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 178.945 0.000 179.015 0.210 ;
     END
   END rw0_rd_out[53]
@@ -1792,7 +1792,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 180.465 0.000 180.535 0.210 ;
     END
   END rw0_rd_out[54]
@@ -1801,7 +1801,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 181.985 0.000 182.055 0.210 ;
     END
   END rw0_rd_out[55]
@@ -1810,7 +1810,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 183.505 0.000 183.575 0.210 ;
     END
   END rw0_rd_out[56]
@@ -1819,7 +1819,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 185.025 0.000 185.095 0.210 ;
     END
   END rw0_rd_out[57]
@@ -1828,7 +1828,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 186.545 0.000 186.615 0.210 ;
     END
   END rw0_rd_out[58]
@@ -1837,7 +1837,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 188.065 0.000 188.135 0.210 ;
     END
   END rw0_rd_out[59]
@@ -1846,7 +1846,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 189.585 0.000 189.655 0.210 ;
     END
   END rw0_rd_out[60]
@@ -1855,7 +1855,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 191.105 0.000 191.175 0.210 ;
     END
   END rw0_rd_out[61]
@@ -1864,7 +1864,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 192.625 0.000 192.695 0.210 ;
     END
   END rw0_rd_out[62]
@@ -1873,7 +1873,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 194.145 0.000 194.215 0.210 ;
     END
   END rw0_rd_out[63]
@@ -1882,7 +1882,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 13.265 234.990 13.335 235.200 ;
     END
   END rw0_rd_out[64]
@@ -1891,7 +1891,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 14.785 234.990 14.855 235.200 ;
     END
   END rw0_rd_out[65]
@@ -1900,7 +1900,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 16.305 234.990 16.375 235.200 ;
     END
   END rw0_rd_out[66]
@@ -1909,7 +1909,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 17.825 234.990 17.895 235.200 ;
     END
   END rw0_rd_out[67]
@@ -1918,7 +1918,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 19.345 234.990 19.415 235.200 ;
     END
   END rw0_rd_out[68]
@@ -1927,7 +1927,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 20.865 234.990 20.935 235.200 ;
     END
   END rw0_rd_out[69]
@@ -1936,7 +1936,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 22.385 234.990 22.455 235.200 ;
     END
   END rw0_rd_out[70]
@@ -1945,7 +1945,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 23.905 234.990 23.975 235.200 ;
     END
   END rw0_rd_out[71]
@@ -1954,7 +1954,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 25.425 234.990 25.495 235.200 ;
     END
   END rw0_rd_out[72]
@@ -1963,7 +1963,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 26.945 234.990 27.015 235.200 ;
     END
   END rw0_rd_out[73]
@@ -1972,7 +1972,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 28.465 234.990 28.535 235.200 ;
     END
   END rw0_rd_out[74]
@@ -1981,7 +1981,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 29.985 234.990 30.055 235.200 ;
     END
   END rw0_rd_out[75]
@@ -1990,7 +1990,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 31.505 234.990 31.575 235.200 ;
     END
   END rw0_rd_out[76]
@@ -1999,7 +1999,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 33.025 234.990 33.095 235.200 ;
     END
   END rw0_rd_out[77]
@@ -2008,7 +2008,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 34.545 234.990 34.615 235.200 ;
     END
   END rw0_rd_out[78]
@@ -2017,7 +2017,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 36.065 234.990 36.135 235.200 ;
     END
   END rw0_rd_out[79]
@@ -2026,7 +2026,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 37.585 234.990 37.655 235.200 ;
     END
   END rw0_rd_out[80]
@@ -2035,7 +2035,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 39.105 234.990 39.175 235.200 ;
     END
   END rw0_rd_out[81]
@@ -2044,7 +2044,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 40.625 234.990 40.695 235.200 ;
     END
   END rw0_rd_out[82]
@@ -2053,7 +2053,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 42.145 234.990 42.215 235.200 ;
     END
   END rw0_rd_out[83]
@@ -2062,7 +2062,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 43.665 234.990 43.735 235.200 ;
     END
   END rw0_rd_out[84]
@@ -2071,7 +2071,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 45.185 234.990 45.255 235.200 ;
     END
   END rw0_rd_out[85]
@@ -2080,7 +2080,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 46.705 234.990 46.775 235.200 ;
     END
   END rw0_rd_out[86]
@@ -2089,7 +2089,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 48.225 234.990 48.295 235.200 ;
     END
   END rw0_rd_out[87]
@@ -2098,7 +2098,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 49.745 234.990 49.815 235.200 ;
     END
   END rw0_rd_out[88]
@@ -2107,7 +2107,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 51.265 234.990 51.335 235.200 ;
     END
   END rw0_rd_out[89]
@@ -2116,7 +2116,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 52.785 234.990 52.855 235.200 ;
     END
   END rw0_rd_out[90]
@@ -2125,7 +2125,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 54.305 234.990 54.375 235.200 ;
     END
   END rw0_rd_out[91]
@@ -2134,7 +2134,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 55.825 234.990 55.895 235.200 ;
     END
   END rw0_rd_out[92]
@@ -2143,7 +2143,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 57.345 234.990 57.415 235.200 ;
     END
   END rw0_rd_out[93]
@@ -2152,7 +2152,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 58.865 234.990 58.935 235.200 ;
     END
   END rw0_rd_out[94]
@@ -2161,7 +2161,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 60.385 234.990 60.455 235.200 ;
     END
   END rw0_rd_out[95]
@@ -2170,7 +2170,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 61.905 234.990 61.975 235.200 ;
     END
   END rw0_rd_out[96]
@@ -2179,7 +2179,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 63.425 234.990 63.495 235.200 ;
     END
   END rw0_rd_out[97]
@@ -2188,7 +2188,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 64.945 234.990 65.015 235.200 ;
     END
   END rw0_rd_out[98]
@@ -2197,7 +2197,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 66.465 234.990 66.535 235.200 ;
     END
   END rw0_rd_out[99]
@@ -2206,7 +2206,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 67.985 234.990 68.055 235.200 ;
     END
   END rw0_rd_out[100]
@@ -2215,7 +2215,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 69.505 234.990 69.575 235.200 ;
     END
   END rw0_rd_out[101]
@@ -2224,7 +2224,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 71.025 234.990 71.095 235.200 ;
     END
   END rw0_rd_out[102]
@@ -2233,7 +2233,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 72.545 234.990 72.615 235.200 ;
     END
   END rw0_rd_out[103]
@@ -2242,7 +2242,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 74.065 234.990 74.135 235.200 ;
     END
   END rw0_rd_out[104]
@@ -2251,7 +2251,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 75.585 234.990 75.655 235.200 ;
     END
   END rw0_rd_out[105]
@@ -2260,7 +2260,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 77.105 234.990 77.175 235.200 ;
     END
   END rw0_rd_out[106]
@@ -2269,7 +2269,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 78.625 234.990 78.695 235.200 ;
     END
   END rw0_rd_out[107]
@@ -2278,7 +2278,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 80.145 234.990 80.215 235.200 ;
     END
   END rw0_rd_out[108]
@@ -2287,7 +2287,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 81.665 234.990 81.735 235.200 ;
     END
   END rw0_rd_out[109]
@@ -2296,7 +2296,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 83.185 234.990 83.255 235.200 ;
     END
   END rw0_rd_out[110]
@@ -2305,7 +2305,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 84.705 234.990 84.775 235.200 ;
     END
   END rw0_rd_out[111]
@@ -2314,7 +2314,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 86.225 234.990 86.295 235.200 ;
     END
   END rw0_rd_out[112]
@@ -2323,7 +2323,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 87.745 234.990 87.815 235.200 ;
     END
   END rw0_rd_out[113]
@@ -2332,7 +2332,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 89.265 234.990 89.335 235.200 ;
     END
   END rw0_rd_out[114]
@@ -2341,7 +2341,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 90.785 234.990 90.855 235.200 ;
     END
   END rw0_rd_out[115]
@@ -2350,7 +2350,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 92.305 234.990 92.375 235.200 ;
     END
   END rw0_rd_out[116]
@@ -2359,7 +2359,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 93.825 234.990 93.895 235.200 ;
     END
   END rw0_rd_out[117]
@@ -2368,7 +2368,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 95.345 234.990 95.415 235.200 ;
     END
   END rw0_rd_out[118]
@@ -2377,7 +2377,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 96.865 234.990 96.935 235.200 ;
     END
   END rw0_rd_out[119]
@@ -2386,7 +2386,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 98.385 234.990 98.455 235.200 ;
     END
   END rw0_rd_out[120]
@@ -2395,7 +2395,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 99.905 234.990 99.975 235.200 ;
     END
   END rw0_rd_out[121]
@@ -2404,7 +2404,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 101.425 234.990 101.495 235.200 ;
     END
   END rw0_rd_out[122]
@@ -2413,7 +2413,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 102.945 234.990 103.015 235.200 ;
     END
   END rw0_rd_out[123]
@@ -2422,7 +2422,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 104.465 234.990 104.535 235.200 ;
     END
   END rw0_rd_out[124]
@@ -2431,7 +2431,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 105.985 234.990 106.055 235.200 ;
     END
   END rw0_rd_out[125]
@@ -2440,7 +2440,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 107.505 234.990 107.575 235.200 ;
     END
   END rw0_rd_out[126]
@@ -2449,7 +2449,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 109.025 234.990 109.095 235.200 ;
     END
   END rw0_rd_out[127]
@@ -2458,7 +2458,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 121.765 0.210 121.835 ;
     END
   END rw0_addr_in[0]
@@ -2467,7 +2467,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 125.125 0.210 125.195 ;
     END
   END rw0_addr_in[1]
@@ -2476,7 +2476,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 128.485 0.210 128.555 ;
     END
   END rw0_addr_in[2]
@@ -2485,7 +2485,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 131.845 0.210 131.915 ;
     END
   END rw0_addr_in[3]
@@ -2494,7 +2494,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 0.000 135.205 0.210 135.275 ;
     END
   END rw0_addr_in[4]
@@ -2503,7 +2503,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 121.765 210.140 121.835 ;
     END
   END rw0_addr_in[5]
@@ -2512,7 +2512,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 125.125 210.140 125.195 ;
     END
   END rw0_addr_in[6]
@@ -2521,7 +2521,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 128.485 210.140 128.555 ;
     END
   END rw0_addr_in[7]
@@ -2530,7 +2530,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal4 ;
+      LAYER metal3 ;
       RECT 209.930 131.845 210.140 131.915 ;
     END
   END rw0_addr_in[8]
@@ -2539,7 +2539,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 110.545 234.990 110.615 235.200 ;
     END
   END rw0_we_in
@@ -2548,7 +2548,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 112.065 234.990 112.135 235.200 ;
     END
   END rw0_ce_in
@@ -2557,7 +2557,7 @@ MACRO fakeram_512x128_1rw
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
-      LAYER metal3 ;
+      LAYER metal2 ;
       RECT 113.585 234.990 113.655 235.200 ;
     END
   END rw0_clk
@@ -2566,111 +2566,100 @@ MACRO fakeram_512x128_1rw
     USE GROUND ;
     PORT
       LAYER metal4 ;
-      RECT 1.140 0.700 209.000 0.980 ;
-      RECT 1.140 2.940 209.000 3.220 ;
-      RECT 1.140 5.180 209.000 5.460 ;
-      RECT 1.140 7.420 209.000 7.700 ;
-      RECT 1.140 9.660 209.000 9.940 ;
-      RECT 1.140 11.900 209.000 12.180 ;
-      RECT 1.140 14.140 209.000 14.420 ;
-      RECT 1.140 16.380 209.000 16.660 ;
-      RECT 1.140 18.620 209.000 18.900 ;
-      RECT 1.140 20.860 209.000 21.140 ;
-      RECT 1.140 23.100 209.000 23.380 ;
-      RECT 1.140 25.340 209.000 25.620 ;
-      RECT 1.140 27.580 209.000 27.860 ;
-      RECT 1.140 29.820 209.000 30.100 ;
-      RECT 1.140 32.060 209.000 32.340 ;
-      RECT 1.140 34.300 209.000 34.580 ;
-      RECT 1.140 36.540 209.000 36.820 ;
-      RECT 1.140 38.780 209.000 39.060 ;
-      RECT 1.140 41.020 209.000 41.300 ;
-      RECT 1.140 43.260 209.000 43.540 ;
-      RECT 1.140 45.500 209.000 45.780 ;
-      RECT 1.140 47.740 209.000 48.020 ;
-      RECT 1.140 49.980 209.000 50.260 ;
-      RECT 1.140 52.220 209.000 52.500 ;
-      RECT 1.140 54.460 209.000 54.740 ;
-      RECT 1.140 56.700 209.000 56.980 ;
-      RECT 1.140 58.940 209.000 59.220 ;
-      RECT 1.140 61.180 209.000 61.460 ;
-      RECT 1.140 63.420 209.000 63.700 ;
-      RECT 1.140 65.660 209.000 65.940 ;
-      RECT 1.140 67.900 209.000 68.180 ;
-      RECT 1.140 70.140 209.000 70.420 ;
-      RECT 1.140 72.380 209.000 72.660 ;
-      RECT 1.140 74.620 209.000 74.900 ;
-      RECT 1.140 76.860 209.000 77.140 ;
-      RECT 1.140 79.100 209.000 79.380 ;
-      RECT 1.140 81.340 209.000 81.620 ;
-      RECT 1.140 83.580 209.000 83.860 ;
-      RECT 1.140 85.820 209.000 86.100 ;
-      RECT 1.140 88.060 209.000 88.340 ;
-      RECT 1.140 90.300 209.000 90.580 ;
-      RECT 1.140 92.540 209.000 92.820 ;
-      RECT 1.140 94.780 209.000 95.060 ;
-      RECT 1.140 97.020 209.000 97.300 ;
-      RECT 1.140 99.260 209.000 99.540 ;
-      RECT 1.140 101.500 209.000 101.780 ;
-      RECT 1.140 103.740 209.000 104.020 ;
-      RECT 1.140 105.980 209.000 106.260 ;
-      RECT 1.140 108.220 209.000 108.500 ;
-      RECT 1.140 110.460 209.000 110.740 ;
-      RECT 1.140 112.700 209.000 112.980 ;
-      RECT 1.140 114.940 209.000 115.220 ;
-      RECT 1.140 117.180 209.000 117.460 ;
-      RECT 1.140 119.420 209.000 119.700 ;
-      RECT 1.140 121.660 209.000 121.940 ;
-      RECT 1.140 123.900 209.000 124.180 ;
-      RECT 1.140 126.140 209.000 126.420 ;
-      RECT 1.140 128.380 209.000 128.660 ;
-      RECT 1.140 130.620 209.000 130.900 ;
-      RECT 1.140 132.860 209.000 133.140 ;
-      RECT 1.140 135.100 209.000 135.380 ;
-      RECT 1.140 137.340 209.000 137.620 ;
-      RECT 1.140 139.580 209.000 139.860 ;
-      RECT 1.140 141.820 209.000 142.100 ;
-      RECT 1.140 144.060 209.000 144.340 ;
-      RECT 1.140 146.300 209.000 146.580 ;
-      RECT 1.140 148.540 209.000 148.820 ;
-      RECT 1.140 150.780 209.000 151.060 ;
-      RECT 1.140 153.020 209.000 153.300 ;
-      RECT 1.140 155.260 209.000 155.540 ;
-      RECT 1.140 157.500 209.000 157.780 ;
-      RECT 1.140 159.740 209.000 160.020 ;
-      RECT 1.140 161.980 209.000 162.260 ;
-      RECT 1.140 164.220 209.000 164.500 ;
-      RECT 1.140 166.460 209.000 166.740 ;
-      RECT 1.140 168.700 209.000 168.980 ;
-      RECT 1.140 170.940 209.000 171.220 ;
-      RECT 1.140 173.180 209.000 173.460 ;
-      RECT 1.140 175.420 209.000 175.700 ;
-      RECT 1.140 177.660 209.000 177.940 ;
-      RECT 1.140 179.900 209.000 180.180 ;
-      RECT 1.140 182.140 209.000 182.420 ;
-      RECT 1.140 184.380 209.000 184.660 ;
-      RECT 1.140 186.620 209.000 186.900 ;
-      RECT 1.140 188.860 209.000 189.140 ;
-      RECT 1.140 191.100 209.000 191.380 ;
-      RECT 1.140 193.340 209.000 193.620 ;
-      RECT 1.140 195.580 209.000 195.860 ;
-      RECT 1.140 197.820 209.000 198.100 ;
-      RECT 1.140 200.060 209.000 200.340 ;
-      RECT 1.140 202.300 209.000 202.580 ;
-      RECT 1.140 204.540 209.000 204.820 ;
-      RECT 1.140 206.780 209.000 207.060 ;
-      RECT 1.140 209.020 209.000 209.300 ;
-      RECT 1.140 211.260 209.000 211.540 ;
-      RECT 1.140 213.500 209.000 213.780 ;
-      RECT 1.140 215.740 209.000 216.020 ;
-      RECT 1.140 217.980 209.000 218.260 ;
-      RECT 1.140 220.220 209.000 220.500 ;
-      RECT 1.140 222.460 209.000 222.740 ;
-      RECT 1.140 224.700 209.000 224.980 ;
-      RECT 1.140 226.940 209.000 227.220 ;
-      RECT 1.140 229.180 209.000 229.460 ;
-      RECT 1.140 231.420 209.000 231.700 ;
-      RECT 1.140 233.660 209.000 233.940 ;
+      RECT 1.000 0.840 1.280 234.360 ;
+      RECT 3.240 0.840 3.520 234.360 ;
+      RECT 5.480 0.840 5.760 234.360 ;
+      RECT 7.720 0.840 8.000 234.360 ;
+      RECT 9.960 0.840 10.240 234.360 ;
+      RECT 12.200 0.840 12.480 234.360 ;
+      RECT 14.440 0.840 14.720 234.360 ;
+      RECT 16.680 0.840 16.960 234.360 ;
+      RECT 18.920 0.840 19.200 234.360 ;
+      RECT 21.160 0.840 21.440 234.360 ;
+      RECT 23.400 0.840 23.680 234.360 ;
+      RECT 25.640 0.840 25.920 234.360 ;
+      RECT 27.880 0.840 28.160 234.360 ;
+      RECT 30.120 0.840 30.400 234.360 ;
+      RECT 32.360 0.840 32.640 234.360 ;
+      RECT 34.600 0.840 34.880 234.360 ;
+      RECT 36.840 0.840 37.120 234.360 ;
+      RECT 39.080 0.840 39.360 234.360 ;
+      RECT 41.320 0.840 41.600 234.360 ;
+      RECT 43.560 0.840 43.840 234.360 ;
+      RECT 45.800 0.840 46.080 234.360 ;
+      RECT 48.040 0.840 48.320 234.360 ;
+      RECT 50.280 0.840 50.560 234.360 ;
+      RECT 52.520 0.840 52.800 234.360 ;
+      RECT 54.760 0.840 55.040 234.360 ;
+      RECT 57.000 0.840 57.280 234.360 ;
+      RECT 59.240 0.840 59.520 234.360 ;
+      RECT 61.480 0.840 61.760 234.360 ;
+      RECT 63.720 0.840 64.000 234.360 ;
+      RECT 65.960 0.840 66.240 234.360 ;
+      RECT 68.200 0.840 68.480 234.360 ;
+      RECT 70.440 0.840 70.720 234.360 ;
+      RECT 72.680 0.840 72.960 234.360 ;
+      RECT 74.920 0.840 75.200 234.360 ;
+      RECT 77.160 0.840 77.440 234.360 ;
+      RECT 79.400 0.840 79.680 234.360 ;
+      RECT 81.640 0.840 81.920 234.360 ;
+      RECT 83.880 0.840 84.160 234.360 ;
+      RECT 86.120 0.840 86.400 234.360 ;
+      RECT 88.360 0.840 88.640 234.360 ;
+      RECT 90.600 0.840 90.880 234.360 ;
+      RECT 92.840 0.840 93.120 234.360 ;
+      RECT 95.080 0.840 95.360 234.360 ;
+      RECT 97.320 0.840 97.600 234.360 ;
+      RECT 99.560 0.840 99.840 234.360 ;
+      RECT 101.800 0.840 102.080 234.360 ;
+      RECT 104.040 0.840 104.320 234.360 ;
+      RECT 106.280 0.840 106.560 234.360 ;
+      RECT 108.520 0.840 108.800 234.360 ;
+      RECT 110.760 0.840 111.040 234.360 ;
+      RECT 113.000 0.840 113.280 234.360 ;
+      RECT 115.240 0.840 115.520 234.360 ;
+      RECT 117.480 0.840 117.760 234.360 ;
+      RECT 119.720 0.840 120.000 234.360 ;
+      RECT 121.960 0.840 122.240 234.360 ;
+      RECT 124.200 0.840 124.480 234.360 ;
+      RECT 126.440 0.840 126.720 234.360 ;
+      RECT 128.680 0.840 128.960 234.360 ;
+      RECT 130.920 0.840 131.200 234.360 ;
+      RECT 133.160 0.840 133.440 234.360 ;
+      RECT 135.400 0.840 135.680 234.360 ;
+      RECT 137.640 0.840 137.920 234.360 ;
+      RECT 139.880 0.840 140.160 234.360 ;
+      RECT 142.120 0.840 142.400 234.360 ;
+      RECT 144.360 0.840 144.640 234.360 ;
+      RECT 146.600 0.840 146.880 234.360 ;
+      RECT 148.840 0.840 149.120 234.360 ;
+      RECT 151.080 0.840 151.360 234.360 ;
+      RECT 153.320 0.840 153.600 234.360 ;
+      RECT 155.560 0.840 155.840 234.360 ;
+      RECT 157.800 0.840 158.080 234.360 ;
+      RECT 160.040 0.840 160.320 234.360 ;
+      RECT 162.280 0.840 162.560 234.360 ;
+      RECT 164.520 0.840 164.800 234.360 ;
+      RECT 166.760 0.840 167.040 234.360 ;
+      RECT 169.000 0.840 169.280 234.360 ;
+      RECT 171.240 0.840 171.520 234.360 ;
+      RECT 173.480 0.840 173.760 234.360 ;
+      RECT 175.720 0.840 176.000 234.360 ;
+      RECT 177.960 0.840 178.240 234.360 ;
+      RECT 180.200 0.840 180.480 234.360 ;
+      RECT 182.440 0.840 182.720 234.360 ;
+      RECT 184.680 0.840 184.960 234.360 ;
+      RECT 186.920 0.840 187.200 234.360 ;
+      RECT 189.160 0.840 189.440 234.360 ;
+      RECT 191.400 0.840 191.680 234.360 ;
+      RECT 193.640 0.840 193.920 234.360 ;
+      RECT 195.880 0.840 196.160 234.360 ;
+      RECT 198.120 0.840 198.400 234.360 ;
+      RECT 200.360 0.840 200.640 234.360 ;
+      RECT 202.600 0.840 202.880 234.360 ;
+      RECT 204.840 0.840 205.120 234.360 ;
+      RECT 207.080 0.840 207.360 234.360 ;
+      RECT 209.320 0.840 209.600 234.360 ;
     END
   END VSS
   PIN VDD
@@ -2678,111 +2667,100 @@ MACRO fakeram_512x128_1rw
     USE POWER ;
     PORT
       LAYER metal4 ;
-      RECT 1.140 0.700 209.000 0.980 ;
-      RECT 1.140 2.940 209.000 3.220 ;
-      RECT 1.140 5.180 209.000 5.460 ;
-      RECT 1.140 7.420 209.000 7.700 ;
-      RECT 1.140 9.660 209.000 9.940 ;
-      RECT 1.140 11.900 209.000 12.180 ;
-      RECT 1.140 14.140 209.000 14.420 ;
-      RECT 1.140 16.380 209.000 16.660 ;
-      RECT 1.140 18.620 209.000 18.900 ;
-      RECT 1.140 20.860 209.000 21.140 ;
-      RECT 1.140 23.100 209.000 23.380 ;
-      RECT 1.140 25.340 209.000 25.620 ;
-      RECT 1.140 27.580 209.000 27.860 ;
-      RECT 1.140 29.820 209.000 30.100 ;
-      RECT 1.140 32.060 209.000 32.340 ;
-      RECT 1.140 34.300 209.000 34.580 ;
-      RECT 1.140 36.540 209.000 36.820 ;
-      RECT 1.140 38.780 209.000 39.060 ;
-      RECT 1.140 41.020 209.000 41.300 ;
-      RECT 1.140 43.260 209.000 43.540 ;
-      RECT 1.140 45.500 209.000 45.780 ;
-      RECT 1.140 47.740 209.000 48.020 ;
-      RECT 1.140 49.980 209.000 50.260 ;
-      RECT 1.140 52.220 209.000 52.500 ;
-      RECT 1.140 54.460 209.000 54.740 ;
-      RECT 1.140 56.700 209.000 56.980 ;
-      RECT 1.140 58.940 209.000 59.220 ;
-      RECT 1.140 61.180 209.000 61.460 ;
-      RECT 1.140 63.420 209.000 63.700 ;
-      RECT 1.140 65.660 209.000 65.940 ;
-      RECT 1.140 67.900 209.000 68.180 ;
-      RECT 1.140 70.140 209.000 70.420 ;
-      RECT 1.140 72.380 209.000 72.660 ;
-      RECT 1.140 74.620 209.000 74.900 ;
-      RECT 1.140 76.860 209.000 77.140 ;
-      RECT 1.140 79.100 209.000 79.380 ;
-      RECT 1.140 81.340 209.000 81.620 ;
-      RECT 1.140 83.580 209.000 83.860 ;
-      RECT 1.140 85.820 209.000 86.100 ;
-      RECT 1.140 88.060 209.000 88.340 ;
-      RECT 1.140 90.300 209.000 90.580 ;
-      RECT 1.140 92.540 209.000 92.820 ;
-      RECT 1.140 94.780 209.000 95.060 ;
-      RECT 1.140 97.020 209.000 97.300 ;
-      RECT 1.140 99.260 209.000 99.540 ;
-      RECT 1.140 101.500 209.000 101.780 ;
-      RECT 1.140 103.740 209.000 104.020 ;
-      RECT 1.140 105.980 209.000 106.260 ;
-      RECT 1.140 108.220 209.000 108.500 ;
-      RECT 1.140 110.460 209.000 110.740 ;
-      RECT 1.140 112.700 209.000 112.980 ;
-      RECT 1.140 114.940 209.000 115.220 ;
-      RECT 1.140 117.180 209.000 117.460 ;
-      RECT 1.140 119.420 209.000 119.700 ;
-      RECT 1.140 121.660 209.000 121.940 ;
-      RECT 1.140 123.900 209.000 124.180 ;
-      RECT 1.140 126.140 209.000 126.420 ;
-      RECT 1.140 128.380 209.000 128.660 ;
-      RECT 1.140 130.620 209.000 130.900 ;
-      RECT 1.140 132.860 209.000 133.140 ;
-      RECT 1.140 135.100 209.000 135.380 ;
-      RECT 1.140 137.340 209.000 137.620 ;
-      RECT 1.140 139.580 209.000 139.860 ;
-      RECT 1.140 141.820 209.000 142.100 ;
-      RECT 1.140 144.060 209.000 144.340 ;
-      RECT 1.140 146.300 209.000 146.580 ;
-      RECT 1.140 148.540 209.000 148.820 ;
-      RECT 1.140 150.780 209.000 151.060 ;
-      RECT 1.140 153.020 209.000 153.300 ;
-      RECT 1.140 155.260 209.000 155.540 ;
-      RECT 1.140 157.500 209.000 157.780 ;
-      RECT 1.140 159.740 209.000 160.020 ;
-      RECT 1.140 161.980 209.000 162.260 ;
-      RECT 1.140 164.220 209.000 164.500 ;
-      RECT 1.140 166.460 209.000 166.740 ;
-      RECT 1.140 168.700 209.000 168.980 ;
-      RECT 1.140 170.940 209.000 171.220 ;
-      RECT 1.140 173.180 209.000 173.460 ;
-      RECT 1.140 175.420 209.000 175.700 ;
-      RECT 1.140 177.660 209.000 177.940 ;
-      RECT 1.140 179.900 209.000 180.180 ;
-      RECT 1.140 182.140 209.000 182.420 ;
-      RECT 1.140 184.380 209.000 184.660 ;
-      RECT 1.140 186.620 209.000 186.900 ;
-      RECT 1.140 188.860 209.000 189.140 ;
-      RECT 1.140 191.100 209.000 191.380 ;
-      RECT 1.140 193.340 209.000 193.620 ;
-      RECT 1.140 195.580 209.000 195.860 ;
-      RECT 1.140 197.820 209.000 198.100 ;
-      RECT 1.140 200.060 209.000 200.340 ;
-      RECT 1.140 202.300 209.000 202.580 ;
-      RECT 1.140 204.540 209.000 204.820 ;
-      RECT 1.140 206.780 209.000 207.060 ;
-      RECT 1.140 209.020 209.000 209.300 ;
-      RECT 1.140 211.260 209.000 211.540 ;
-      RECT 1.140 213.500 209.000 213.780 ;
-      RECT 1.140 215.740 209.000 216.020 ;
-      RECT 1.140 217.980 209.000 218.260 ;
-      RECT 1.140 220.220 209.000 220.500 ;
-      RECT 1.140 222.460 209.000 222.740 ;
-      RECT 1.140 224.700 209.000 224.980 ;
-      RECT 1.140 226.940 209.000 227.220 ;
-      RECT 1.140 229.180 209.000 229.460 ;
-      RECT 1.140 231.420 209.000 231.700 ;
-      RECT 1.140 233.660 209.000 233.940 ;
+      RECT 1.000 0.840 1.280 234.360 ;
+      RECT 3.240 0.840 3.520 234.360 ;
+      RECT 5.480 0.840 5.760 234.360 ;
+      RECT 7.720 0.840 8.000 234.360 ;
+      RECT 9.960 0.840 10.240 234.360 ;
+      RECT 12.200 0.840 12.480 234.360 ;
+      RECT 14.440 0.840 14.720 234.360 ;
+      RECT 16.680 0.840 16.960 234.360 ;
+      RECT 18.920 0.840 19.200 234.360 ;
+      RECT 21.160 0.840 21.440 234.360 ;
+      RECT 23.400 0.840 23.680 234.360 ;
+      RECT 25.640 0.840 25.920 234.360 ;
+      RECT 27.880 0.840 28.160 234.360 ;
+      RECT 30.120 0.840 30.400 234.360 ;
+      RECT 32.360 0.840 32.640 234.360 ;
+      RECT 34.600 0.840 34.880 234.360 ;
+      RECT 36.840 0.840 37.120 234.360 ;
+      RECT 39.080 0.840 39.360 234.360 ;
+      RECT 41.320 0.840 41.600 234.360 ;
+      RECT 43.560 0.840 43.840 234.360 ;
+      RECT 45.800 0.840 46.080 234.360 ;
+      RECT 48.040 0.840 48.320 234.360 ;
+      RECT 50.280 0.840 50.560 234.360 ;
+      RECT 52.520 0.840 52.800 234.360 ;
+      RECT 54.760 0.840 55.040 234.360 ;
+      RECT 57.000 0.840 57.280 234.360 ;
+      RECT 59.240 0.840 59.520 234.360 ;
+      RECT 61.480 0.840 61.760 234.360 ;
+      RECT 63.720 0.840 64.000 234.360 ;
+      RECT 65.960 0.840 66.240 234.360 ;
+      RECT 68.200 0.840 68.480 234.360 ;
+      RECT 70.440 0.840 70.720 234.360 ;
+      RECT 72.680 0.840 72.960 234.360 ;
+      RECT 74.920 0.840 75.200 234.360 ;
+      RECT 77.160 0.840 77.440 234.360 ;
+      RECT 79.400 0.840 79.680 234.360 ;
+      RECT 81.640 0.840 81.920 234.360 ;
+      RECT 83.880 0.840 84.160 234.360 ;
+      RECT 86.120 0.840 86.400 234.360 ;
+      RECT 88.360 0.840 88.640 234.360 ;
+      RECT 90.600 0.840 90.880 234.360 ;
+      RECT 92.840 0.840 93.120 234.360 ;
+      RECT 95.080 0.840 95.360 234.360 ;
+      RECT 97.320 0.840 97.600 234.360 ;
+      RECT 99.560 0.840 99.840 234.360 ;
+      RECT 101.800 0.840 102.080 234.360 ;
+      RECT 104.040 0.840 104.320 234.360 ;
+      RECT 106.280 0.840 106.560 234.360 ;
+      RECT 108.520 0.840 108.800 234.360 ;
+      RECT 110.760 0.840 111.040 234.360 ;
+      RECT 113.000 0.840 113.280 234.360 ;
+      RECT 115.240 0.840 115.520 234.360 ;
+      RECT 117.480 0.840 117.760 234.360 ;
+      RECT 119.720 0.840 120.000 234.360 ;
+      RECT 121.960 0.840 122.240 234.360 ;
+      RECT 124.200 0.840 124.480 234.360 ;
+      RECT 126.440 0.840 126.720 234.360 ;
+      RECT 128.680 0.840 128.960 234.360 ;
+      RECT 130.920 0.840 131.200 234.360 ;
+      RECT 133.160 0.840 133.440 234.360 ;
+      RECT 135.400 0.840 135.680 234.360 ;
+      RECT 137.640 0.840 137.920 234.360 ;
+      RECT 139.880 0.840 140.160 234.360 ;
+      RECT 142.120 0.840 142.400 234.360 ;
+      RECT 144.360 0.840 144.640 234.360 ;
+      RECT 146.600 0.840 146.880 234.360 ;
+      RECT 148.840 0.840 149.120 234.360 ;
+      RECT 151.080 0.840 151.360 234.360 ;
+      RECT 153.320 0.840 153.600 234.360 ;
+      RECT 155.560 0.840 155.840 234.360 ;
+      RECT 157.800 0.840 158.080 234.360 ;
+      RECT 160.040 0.840 160.320 234.360 ;
+      RECT 162.280 0.840 162.560 234.360 ;
+      RECT 164.520 0.840 164.800 234.360 ;
+      RECT 166.760 0.840 167.040 234.360 ;
+      RECT 169.000 0.840 169.280 234.360 ;
+      RECT 171.240 0.840 171.520 234.360 ;
+      RECT 173.480 0.840 173.760 234.360 ;
+      RECT 175.720 0.840 176.000 234.360 ;
+      RECT 177.960 0.840 178.240 234.360 ;
+      RECT 180.200 0.840 180.480 234.360 ;
+      RECT 182.440 0.840 182.720 234.360 ;
+      RECT 184.680 0.840 184.960 234.360 ;
+      RECT 186.920 0.840 187.200 234.360 ;
+      RECT 189.160 0.840 189.440 234.360 ;
+      RECT 191.400 0.840 191.680 234.360 ;
+      RECT 193.640 0.840 193.920 234.360 ;
+      RECT 195.880 0.840 196.160 234.360 ;
+      RECT 198.120 0.840 198.400 234.360 ;
+      RECT 200.360 0.840 200.640 234.360 ;
+      RECT 202.600 0.840 202.880 234.360 ;
+      RECT 204.840 0.840 205.120 234.360 ;
+      RECT 207.080 0.840 207.360 234.360 ;
+      RECT 209.320 0.840 209.600 234.360 ;
     END
   END VDD
   OBS

--- a/designs/nangate45/coralnpu/sram/lib/fakeram_2048x128_1rw.lib
+++ b/designs/nangate45/coralnpu/sram/lib/fakeram_2048x128_1rw.lib
@@ -1,0 +1,468 @@
+library(fakeram_2048x128_1rw) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-04-25 15:25:23Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.1;
+    capacitive_load_unit (1,pf);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.1;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 0.227;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram_2048x128_1rw_mem_out_delay_template) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_2048x128_1rw_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_2048x128_1rw_constraint_template) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    power_lut_template(fakeram_2048x128_1rw_energy_template_clkslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    power_lut_template(fakeram_2048x128_1rw_energy_template_sigslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_2048x128_1rw_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 128;
+        bit_from : 127;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram_2048x128_1rw_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 11;
+        bit_from : 10;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram_2048x128_1rw_WMASK) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 16;
+        bit_from : 15;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram_2048x128_1rw) {
+    area : 209296.248;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 11;
+        word_width : 128;
+    }
+    pin(rw0_clk)   {
+        direction : input;
+        capacitance : 0.025;
+        clock : true;
+        min_period           : 0.521 ;
+        internal_power(){
+            rise_power(fakeram_2048x128_1rw_energy_template_clkslew) {
+                index_1 ("0.009, 0.227");
+                values ("29.045, 29.045")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_clkslew) {
+                index_1 ("0.009, 0.227");
+                values ("29.045, 29.045")
+            }
+        }
+    }
+
+    bus(rw0_rd_out)   {
+        bus_type : fakeram_2048x128_1rw_DATA;
+        direction : output;
+        max_capacitance : 0.500;
+        memory_read() {
+            address : r0_addr_in;
+        }
+        timing() {
+            related_pin : "rw0_clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(fakeram_2048x128_1rw_mem_out_delay_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.598, 0.598", \
+                  "0.598, 0.598" \
+                )
+            }
+            cell_fall(fakeram_2048x128_1rw_mem_out_delay_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.598, 0.598", \
+                  "0.598, 0.598" \
+                )
+            }
+            rise_transition(fakeram_2048x128_1rw_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.009, 0.227")
+            }
+            fall_transition(fakeram_2048x128_1rw_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.009, 0.227")
+            }
+        }
+    }
+    pin(rw0_we_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+        }
+    }
+    pin(rw0_ce_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+        }
+    }
+    bus(rw0_addr_in)   {
+        bus_type : fakeram_2048x128_1rw_ADDRESS;
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+        }
+    }
+    bus(rw0_wd_in)   {
+        bus_type : fakeram_2048x128_1rw_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+        }
+    }
+    bus(rw0_wmask_in)   {
+        bus_type : fakeram_2048x128_1rw_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.290, 0.290")
+            }
+        }
+    }
+    cell_leakage_power : 6157.930;
+}
+
+}

--- a/designs/nangate45/coralnpu/sram/lib/fakeram_2048x128_1rw.lib
+++ b/designs/nangate45/coralnpu/sram/lib/fakeram_2048x128_1rw.lib
@@ -2,7 +2,7 @@ library(fakeram_2048x128_1rw) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-04-25 15:25:23Z";
+    date : "2026-04-25 01:28:03Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";

--- a/designs/nangate45/coralnpu/sram/lib/fakeram_512x128_1rw.lib
+++ b/designs/nangate45/coralnpu/sram/lib/fakeram_512x128_1rw.lib
@@ -2,7 +2,7 @@ library(fakeram_512x128_1rw) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-04-25 15:25:20Z";
+    date : "2026-04-25 01:28:01Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";

--- a/designs/nangate45/coralnpu/sram/lib/fakeram_512x128_1rw.lib
+++ b/designs/nangate45/coralnpu/sram/lib/fakeram_512x128_1rw.lib
@@ -1,0 +1,468 @@
+library(fakeram_512x128_1rw) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-04-25 15:25:20Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.1;
+    capacitive_load_unit (1,pf);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.1;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 0.227;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram_512x128_1rw_mem_out_delay_template) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_512x128_1rw_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_512x128_1rw_constraint_template) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    power_lut_template(fakeram_512x128_1rw_energy_template_clkslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    power_lut_template(fakeram_512x128_1rw_energy_template_sigslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_512x128_1rw_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 128;
+        bit_from : 127;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram_512x128_1rw_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 9;
+        bit_from : 8;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram_512x128_1rw_WMASK) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 16;
+        bit_from : 15;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram_512x128_1rw) {
+    area : 49424.928;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 9;
+        word_width : 128;
+    }
+    pin(rw0_clk)   {
+        direction : input;
+        capacitance : 0.025;
+        clock : true;
+        min_period           : 0.380 ;
+        internal_power(){
+            rise_power(fakeram_512x128_1rw_energy_template_clkslew) {
+                index_1 ("0.009, 0.227");
+                values ("12.499, 12.499")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_clkslew) {
+                index_1 ("0.009, 0.227");
+                values ("12.499, 12.499")
+            }
+        }
+    }
+
+    bus(rw0_rd_out)   {
+        bus_type : fakeram_512x128_1rw_DATA;
+        direction : output;
+        max_capacitance : 0.500;
+        memory_read() {
+            address : r0_addr_in;
+        }
+        timing() {
+            related_pin : "rw0_clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(fakeram_512x128_1rw_mem_out_delay_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.411, 0.411", \
+                  "0.411, 0.411" \
+                )
+            }
+            cell_fall(fakeram_512x128_1rw_mem_out_delay_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.411, 0.411", \
+                  "0.411, 0.411" \
+                )
+            }
+            rise_transition(fakeram_512x128_1rw_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.009, 0.227")
+            }
+            fall_transition(fakeram_512x128_1rw_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.009, 0.227")
+            }
+        }
+    }
+    pin(rw0_we_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+        }
+    }
+    pin(rw0_ce_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+        }
+    }
+    bus(rw0_addr_in)   {
+        bus_type : fakeram_512x128_1rw_ADDRESS;
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+        }
+    }
+    bus(rw0_wd_in)   {
+        bus_type : fakeram_512x128_1rw_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+        }
+    }
+    bus(rw0_wmask_in)   {
+        bus_type : fakeram_512x128_1rw_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.125, 0.125")
+            }
+        }
+    }
+    cell_leakage_power : 2071.720;
+}
+
+}

--- a/designs/src/coralnpu/dev/fakeram_nangate45.cfg
+++ b/designs/src/coralnpu/dev/fakeram_nangate45.cfg
@@ -8,7 +8,7 @@
   "TBpinPitch_nm": 190,
   "snapWidth_nm":  190,
   "snapHeight_nm": 1400,
-  "flipPins": false,
+  "flipPins": true,
   "srams": [
     {
      "name": "fakeram_512x128_1rw",

--- a/designs/src/coralnpu/dev/fakeram_nangate45.cfg
+++ b/designs/src/coralnpu/dev/fakeram_nangate45.cfg
@@ -1,0 +1,30 @@
+{
+  "tech_nm": 45,
+  "voltage": 1.1,
+  "metalPrefix": "metal",
+  "LRpinWidth_nm": 70,
+  "LRpinPitch_nm": 140,
+  "TBpinWidth_nm": 70,
+  "TBpinPitch_nm": 190,
+  "snapWidth_nm":  190,
+  "snapHeight_nm": 1400,
+  "flipPins": false,
+  "srams": [
+    {
+     "name": "fakeram_512x128_1rw",
+     "width": 128,
+     "depth": 512,
+     "banks": 1,
+     "write_granularity": 8,
+     "ports": {"r": 0, "w": 0, "rw": 1}
+    },
+    {
+     "name": "fakeram_2048x128_1rw",
+     "width": 128,
+     "depth": 2048,
+     "banks": 1,
+     "write_granularity": 8,
+     "ports": {"r": 0, "w": 0, "rw": 1}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Ports the existing asap7 coralnpu design (CoreMiniAxi) to nangate45. RTL is reused from `designs/src/coralnpu/`; only the platform-specific flow parameters and SRAM macros change.
- Regenerates the two FakeRAM macros (`fakeram_512x128_1rw`, `fakeram_2048x128_1rw`) for nangate45 via `bsg_fakeram` with `flipPins=true` (signal pins on metal3, leaving metal4 obstructed) — matching the convention of the existing nangate45 NyuziProcessor LEFs. The cfg used to regenerate is checked in at `designs/src/coralnpu/dev/fakeram_nangate45.cfg`.
- Clock period scaled from 3 ns (asap7 ps) to 9 ns based on the 1.6→4.5 ns NyuziProcessor scaling ratio (~2.8×).
- `MACRO_PLACE_HALO=40 40` matches nangate45 NyuziProcessor; `CORE_UTILIZATION=40` (same as the recent asap7 fix in #77).

## Debugging notes
- Initial generation used `flipPins=false`, putting signal pins on metal4 — same layer as the macro's all-layer OBS — causing DRT-0073 (`No access point for ...rw0_wmask_in[0]`) at global routing. Fixed in `77e98909`.

## Test plan
- [x] `bazel build //designs/nangate45/coralnpu:coralnpu_final` on Nautilus (mrg-hightide-nangate45-coralnpu) completes through 6_final
- [x] `VSS.rpt` and `VDD.rpt` are empty (no PSM connectivity violations)
- [x] `5_route_drc.rpt` is empty (no DRC violations)
- [x] Timing closes: tns=0, wns=0, fmax=126.05 MHz (target 111 MHz @ 9 ns)