### PR TITLE
Add sky130hd cnn port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,8 @@ Dev mode requires: `git submodule update --init designs/src/<design>/dev/repo` b
 | Platform | Node | Designs |
 |----------|------|---------|
 | asap7 | 7nm academic | gemmini, minimax, cnn, sha3, lfsr, NyuziProcessor, bp_processor/bp_uno/bp_quad, liteeth (6 variants), snitch_cluster, floonoc |
-| nangate45 | 45nm | minimax, lfsr, NyuziProcessor, liteeth (6 variants) |
-| sky130hd | 130nm open | minimax, lfsr, sha3, liteeth (6 variants) |
+| nangate45 | 45nm | minimax, lfsr, NyuziProcessor, cnn, liteeth (6 variants) |
+| sky130hd | 130nm open | minimax, lfsr, sha3, cnn, liteeth (6 variants) |
 
 ### Output Directories
 
@@ -151,7 +151,8 @@ SRAM LEF/LIB files are organized per-platform:
 - `designs/<platform>/NyuziProcessor/sram/{lef,lib}/` — NyuziProcessor memories
 - `designs/<platform>/liteeth/sram/{lef,lib}/` — liteeth variant memories (shared across variants)
 - `designs/asap7/bp_processor/sram/{lef,lib}/` — bp_processor memories
-- `designs/src/cnn/fakeram_*.{lef,lib}` — CNN memories (in source directory)
+- `designs/src/cnn/fakeram_*.{lef,lib}` — CNN asap7 memories (shared with src dir)
+- `designs/{nangate45,sky130hd}/cnn/sram/{lef,lib}/` — CNN per-platform synthetic FakeRAMs (regenerable via `designs/src/cnn/dev/gen_fakeram_{nangate45,sky130hd}.py`)
 
 ## Shared Machine
 

--- a/designs/sky130hd/cnn/BUILD.bazel
+++ b/designs/sky130hd/cnn/BUILD.bazel
@@ -1,0 +1,29 @@
+load("//:defs.bzl", "hightide_design")
+
+filegroup(
+    name = "sram_lefs",
+    srcs = glob(["sram/lef/*.lef"]),
+)
+
+filegroup(
+    name = "sram_libs",
+    srcs = glob(["sram/lib/*.lib"]),
+)
+
+hightide_design(
+    name = "cnn",
+    platform = "sky130hd",
+    verilog_files = ["//designs/src/cnn:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": [":sram_lefs"],
+        "ADDITIONAL_LIBS": [":sram_libs"],
+    },
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "CORE_UTILIZATION": "30",
+        "PLACE_DENSITY_LB_ADDON": "0.10",
+        "MACRO_PLACE_HALO": "40 40",
+        "MACRO_BLOCKAGE_HALO": "0.5",
+    },
+)

--- a/designs/sky130hd/cnn/config.mk
+++ b/designs/sky130hd/cnn/config.mk
@@ -1,0 +1,19 @@
+export DESIGN_NICKNAME = cnn
+export DESIGN_NAME = cnn
+export PLATFORM    = sky130hd
+
+-include $(BENCH_DESIGN_HOME)/src/$(DESIGN_NAME)/verilog.mk
+
+export SYNTH_HIERARCHICAL = 1
+
+export ADDITIONAL_LEFS = $(wildcard $(BENCH_DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/sram/lef/fakeram_*.lef)
+export ADDITIONAL_LIBS = $(wildcard $(BENCH_DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/sram/lib/fakeram_*.lib)
+
+export SDC_FILE      = $(BENCH_DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
+
+export CORE_UTILIZATION = 30
+
+export PLACE_DENSITY_LB_ADDON = 0.10
+
+export MACRO_PLACE_HALO    = 40 40
+export MACRO_BLOCKAGE_HALO = 0.5

--- a/designs/sky130hd/cnn/constraint.sdc
+++ b/designs/sky130hd/cnn/constraint.sdc
@@ -1,0 +1,15 @@
+current_design cnn
+
+set clk_name  clk
+set clk_port_name CLK
+set clk_period 10.0
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]

--- a/designs/sky130hd/cnn/sram/lef/fakeram_w16_l32768.lef
+++ b/designs/sky130hd/cnn/sram/lef/fakeram_w16_l32768.lef
@@ -1,0 +1,921 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_w16_l32768
+  FOREIGN fakeram_w16_l32768 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 2048.380 BY 1025.440 ;
+  CLASS BLOCK ;
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.720 0.300 3.020 ;
+    END
+  END rw0_clk
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.440 0.300 5.740 ;
+    END
+  END rw0_ce_in
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.160 0.300 8.460 ;
+    END
+  END rw0_we_in
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.880 0.300 11.180 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.600 0.300 13.900 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.320 0.300 16.620 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.040 0.300 19.340 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.760 0.300 22.060 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.480 0.300 24.780 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.200 0.300 27.500 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.920 0.300 30.220 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.640 0.300 32.940 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_addr_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.360 0.300 35.660 ;
+    END
+  END rw0_addr_in[9]
+  PIN rw0_addr_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.080 0.300 38.380 ;
+    END
+  END rw0_addr_in[10]
+  PIN rw0_addr_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.800 0.300 41.100 ;
+    END
+  END rw0_addr_in[11]
+  PIN rw0_addr_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.520 0.300 43.820 ;
+    END
+  END rw0_addr_in[12]
+  PIN rw0_addr_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.240 0.300 46.540 ;
+    END
+  END rw0_addr_in[13]
+  PIN rw0_addr_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.960 0.300 49.260 ;
+    END
+  END rw0_addr_in[14]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.680 0.300 51.980 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.400 0.300 54.700 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.120 0.300 57.420 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.840 0.300 60.140 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.300 62.860 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.280 0.300 65.580 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.000 0.300 68.300 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.720 0.300 71.020 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.440 0.300 73.740 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.160 0.300 76.460 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.880 0.300 79.180 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.600 0.300 81.900 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.320 0.300 84.620 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.040 0.300 87.340 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.760 0.300 90.060 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.480 0.300 92.780 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.200 0.300 95.500 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.920 0.300 98.220 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.640 0.300 100.940 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.360 0.300 103.660 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.080 0.300 106.380 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.800 0.300 109.100 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.520 0.300 111.820 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.240 0.300 114.540 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.960 0.300 117.260 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.680 0.300 119.980 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.400 0.300 122.700 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.300 125.420 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.840 0.300 128.140 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.560 0.300 130.860 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.280 0.300 133.580 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.000 0.300 136.300 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw1_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.720 0.300 139.020 ;
+    END
+  END rw1_clk
+  PIN rw1_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 141.440 0.300 141.740 ;
+    END
+  END rw1_ce_in
+  PIN rw1_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 144.160 0.300 144.460 ;
+    END
+  END rw1_we_in
+  PIN rw1_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 146.880 0.300 147.180 ;
+    END
+  END rw1_addr_in[0]
+  PIN rw1_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 149.600 0.300 149.900 ;
+    END
+  END rw1_addr_in[1]
+  PIN rw1_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 152.320 0.300 152.620 ;
+    END
+  END rw1_addr_in[2]
+  PIN rw1_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 155.040 0.300 155.340 ;
+    END
+  END rw1_addr_in[3]
+  PIN rw1_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 157.760 0.300 158.060 ;
+    END
+  END rw1_addr_in[4]
+  PIN rw1_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 160.480 0.300 160.780 ;
+    END
+  END rw1_addr_in[5]
+  PIN rw1_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 163.200 0.300 163.500 ;
+    END
+  END rw1_addr_in[6]
+  PIN rw1_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 165.920 0.300 166.220 ;
+    END
+  END rw1_addr_in[7]
+  PIN rw1_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 168.640 0.300 168.940 ;
+    END
+  END rw1_addr_in[8]
+  PIN rw1_addr_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 171.360 0.300 171.660 ;
+    END
+  END rw1_addr_in[9]
+  PIN rw1_addr_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 174.080 0.300 174.380 ;
+    END
+  END rw1_addr_in[10]
+  PIN rw1_addr_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 176.800 0.300 177.100 ;
+    END
+  END rw1_addr_in[11]
+  PIN rw1_addr_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 179.520 0.300 179.820 ;
+    END
+  END rw1_addr_in[12]
+  PIN rw1_addr_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 182.240 0.300 182.540 ;
+    END
+  END rw1_addr_in[13]
+  PIN rw1_addr_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 184.960 0.300 185.260 ;
+    END
+  END rw1_addr_in[14]
+  PIN rw1_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 187.680 0.300 187.980 ;
+    END
+  END rw1_wd_in[0]
+  PIN rw1_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 190.400 0.300 190.700 ;
+    END
+  END rw1_wd_in[1]
+  PIN rw1_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 193.120 0.300 193.420 ;
+    END
+  END rw1_wd_in[2]
+  PIN rw1_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 195.840 0.300 196.140 ;
+    END
+  END rw1_wd_in[3]
+  PIN rw1_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 198.560 0.300 198.860 ;
+    END
+  END rw1_wd_in[4]
+  PIN rw1_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 201.280 0.300 201.580 ;
+    END
+  END rw1_wd_in[5]
+  PIN rw1_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 204.000 0.300 204.300 ;
+    END
+  END rw1_wd_in[6]
+  PIN rw1_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 206.720 0.300 207.020 ;
+    END
+  END rw1_wd_in[7]
+  PIN rw1_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 209.440 0.300 209.740 ;
+    END
+  END rw1_wd_in[8]
+  PIN rw1_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 212.160 0.300 212.460 ;
+    END
+  END rw1_wd_in[9]
+  PIN rw1_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 214.880 0.300 215.180 ;
+    END
+  END rw1_wd_in[10]
+  PIN rw1_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 217.600 0.300 217.900 ;
+    END
+  END rw1_wd_in[11]
+  PIN rw1_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 220.320 0.300 220.620 ;
+    END
+  END rw1_wd_in[12]
+  PIN rw1_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 223.040 0.300 223.340 ;
+    END
+  END rw1_wd_in[13]
+  PIN rw1_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 225.760 0.300 226.060 ;
+    END
+  END rw1_wd_in[14]
+  PIN rw1_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 228.480 0.300 228.780 ;
+    END
+  END rw1_wd_in[15]
+  PIN rw1_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 231.200 0.300 231.500 ;
+    END
+  END rw1_rd_out[0]
+  PIN rw1_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 233.920 0.300 234.220 ;
+    END
+  END rw1_rd_out[1]
+  PIN rw1_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 236.640 0.300 236.940 ;
+    END
+  END rw1_rd_out[2]
+  PIN rw1_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 239.360 0.300 239.660 ;
+    END
+  END rw1_rd_out[3]
+  PIN rw1_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 242.080 0.300 242.380 ;
+    END
+  END rw1_rd_out[4]
+  PIN rw1_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 244.800 0.300 245.100 ;
+    END
+  END rw1_rd_out[5]
+  PIN rw1_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 247.520 0.300 247.820 ;
+    END
+  END rw1_rd_out[6]
+  PIN rw1_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 250.240 0.300 250.540 ;
+    END
+  END rw1_rd_out[7]
+  PIN rw1_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 252.960 0.300 253.260 ;
+    END
+  END rw1_rd_out[8]
+  PIN rw1_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 255.680 0.300 255.980 ;
+    END
+  END rw1_rd_out[9]
+  PIN rw1_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 258.400 0.300 258.700 ;
+    END
+  END rw1_rd_out[10]
+  PIN rw1_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 261.120 0.300 261.420 ;
+    END
+  END rw1_rd_out[11]
+  PIN rw1_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 263.840 0.300 264.140 ;
+    END
+  END rw1_rd_out[12]
+  PIN rw1_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 266.560 0.300 266.860 ;
+    END
+  END rw1_rd_out[13]
+  PIN rw1_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 269.280 0.300 269.580 ;
+    END
+  END rw1_rd_out[14]
+  PIN rw1_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 272.000 0.300 272.300 ;
+    END
+  END rw1_rd_out[15]
+  OBS
+    LAYER li1 ;
+      RECT 0.000 0.000 2048.380 1025.440 ;
+    LAYER met1 ;
+      RECT 0.000 0.000 2048.380 1025.440 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 2048.380 1025.440 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 2048.380 1025.440 ;
+    LAYER met4 ;
+      RECT 0.000 0.000 2048.380 1025.440 ;
+  END
+END fakeram_w16_l32768
+END LIBRARY

--- a/designs/sky130hd/cnn/sram/lef/fakeram_w16_l512.lef
+++ b/designs/sky130hd/cnn/sram/lef/fakeram_w16_l512.lef
@@ -1,0 +1,813 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_w16_l512
+  FOREIGN fakeram_w16_l512 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 256.220 BY 250.240 ;
+  CLASS BLOCK ;
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.720 0.300 3.020 ;
+    END
+  END rw0_clk
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.440 0.300 5.740 ;
+    END
+  END rw0_ce_in
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.160 0.300 8.460 ;
+    END
+  END rw0_we_in
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.880 0.300 11.180 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.600 0.300 13.900 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.320 0.300 16.620 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.040 0.300 19.340 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.760 0.300 22.060 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.480 0.300 24.780 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.200 0.300 27.500 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.920 0.300 30.220 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.640 0.300 32.940 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.360 0.300 35.660 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.080 0.300 38.380 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.800 0.300 41.100 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.520 0.300 43.820 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.240 0.300 46.540 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.960 0.300 49.260 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.680 0.300 51.980 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.400 0.300 54.700 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.120 0.300 57.420 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.840 0.300 60.140 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.300 62.860 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.280 0.300 65.580 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.000 0.300 68.300 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.720 0.300 71.020 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.440 0.300 73.740 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.160 0.300 76.460 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.880 0.300 79.180 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.600 0.300 81.900 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.320 0.300 84.620 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.040 0.300 87.340 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.760 0.300 90.060 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.480 0.300 92.780 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.200 0.300 95.500 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.920 0.300 98.220 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.640 0.300 100.940 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.360 0.300 103.660 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.080 0.300 106.380 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.800 0.300 109.100 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.520 0.300 111.820 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.240 0.300 114.540 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.960 0.300 117.260 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.680 0.300 119.980 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw1_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.400 0.300 122.700 ;
+    END
+  END rw1_clk
+  PIN rw1_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.300 125.420 ;
+    END
+  END rw1_ce_in
+  PIN rw1_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.840 0.300 128.140 ;
+    END
+  END rw1_we_in
+  PIN rw1_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.560 0.300 130.860 ;
+    END
+  END rw1_addr_in[0]
+  PIN rw1_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.280 0.300 133.580 ;
+    END
+  END rw1_addr_in[1]
+  PIN rw1_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.000 0.300 136.300 ;
+    END
+  END rw1_addr_in[2]
+  PIN rw1_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.720 0.300 139.020 ;
+    END
+  END rw1_addr_in[3]
+  PIN rw1_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 141.440 0.300 141.740 ;
+    END
+  END rw1_addr_in[4]
+  PIN rw1_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 144.160 0.300 144.460 ;
+    END
+  END rw1_addr_in[5]
+  PIN rw1_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 146.880 0.300 147.180 ;
+    END
+  END rw1_addr_in[6]
+  PIN rw1_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 149.600 0.300 149.900 ;
+    END
+  END rw1_addr_in[7]
+  PIN rw1_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 152.320 0.300 152.620 ;
+    END
+  END rw1_addr_in[8]
+  PIN rw1_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 155.040 0.300 155.340 ;
+    END
+  END rw1_wd_in[0]
+  PIN rw1_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 157.760 0.300 158.060 ;
+    END
+  END rw1_wd_in[1]
+  PIN rw1_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 160.480 0.300 160.780 ;
+    END
+  END rw1_wd_in[2]
+  PIN rw1_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 163.200 0.300 163.500 ;
+    END
+  END rw1_wd_in[3]
+  PIN rw1_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 165.920 0.300 166.220 ;
+    END
+  END rw1_wd_in[4]
+  PIN rw1_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 168.640 0.300 168.940 ;
+    END
+  END rw1_wd_in[5]
+  PIN rw1_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 171.360 0.300 171.660 ;
+    END
+  END rw1_wd_in[6]
+  PIN rw1_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 174.080 0.300 174.380 ;
+    END
+  END rw1_wd_in[7]
+  PIN rw1_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 176.800 0.300 177.100 ;
+    END
+  END rw1_wd_in[8]
+  PIN rw1_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 179.520 0.300 179.820 ;
+    END
+  END rw1_wd_in[9]
+  PIN rw1_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 182.240 0.300 182.540 ;
+    END
+  END rw1_wd_in[10]
+  PIN rw1_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 184.960 0.300 185.260 ;
+    END
+  END rw1_wd_in[11]
+  PIN rw1_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 187.680 0.300 187.980 ;
+    END
+  END rw1_wd_in[12]
+  PIN rw1_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 190.400 0.300 190.700 ;
+    END
+  END rw1_wd_in[13]
+  PIN rw1_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 193.120 0.300 193.420 ;
+    END
+  END rw1_wd_in[14]
+  PIN rw1_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 195.840 0.300 196.140 ;
+    END
+  END rw1_wd_in[15]
+  PIN rw1_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 198.560 0.300 198.860 ;
+    END
+  END rw1_rd_out[0]
+  PIN rw1_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 201.280 0.300 201.580 ;
+    END
+  END rw1_rd_out[1]
+  PIN rw1_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 204.000 0.300 204.300 ;
+    END
+  END rw1_rd_out[2]
+  PIN rw1_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 206.720 0.300 207.020 ;
+    END
+  END rw1_rd_out[3]
+  PIN rw1_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 209.440 0.300 209.740 ;
+    END
+  END rw1_rd_out[4]
+  PIN rw1_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 212.160 0.300 212.460 ;
+    END
+  END rw1_rd_out[5]
+  PIN rw1_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 214.880 0.300 215.180 ;
+    END
+  END rw1_rd_out[6]
+  PIN rw1_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 217.600 0.300 217.900 ;
+    END
+  END rw1_rd_out[7]
+  PIN rw1_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 220.320 0.300 220.620 ;
+    END
+  END rw1_rd_out[8]
+  PIN rw1_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 223.040 0.300 223.340 ;
+    END
+  END rw1_rd_out[9]
+  PIN rw1_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 225.760 0.300 226.060 ;
+    END
+  END rw1_rd_out[10]
+  PIN rw1_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 228.480 0.300 228.780 ;
+    END
+  END rw1_rd_out[11]
+  PIN rw1_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 231.200 0.300 231.500 ;
+    END
+  END rw1_rd_out[12]
+  PIN rw1_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 233.920 0.300 234.220 ;
+    END
+  END rw1_rd_out[13]
+  PIN rw1_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 236.640 0.300 236.940 ;
+    END
+  END rw1_rd_out[14]
+  PIN rw1_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 239.360 0.300 239.660 ;
+    END
+  END rw1_rd_out[15]
+  OBS
+    LAYER li1 ;
+      RECT 0.000 0.000 256.220 250.240 ;
+    LAYER met1 ;
+      RECT 0.000 0.000 256.220 250.240 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 256.220 250.240 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 256.220 250.240 ;
+    LAYER met4 ;
+      RECT 0.000 0.000 256.220 250.240 ;
+  END
+END fakeram_w16_l512
+END LIBRARY

--- a/designs/sky130hd/cnn/sram/lef/fakeram_w16_l8192.lef
+++ b/designs/sky130hd/cnn/sram/lef/fakeram_w16_l8192.lef
@@ -1,0 +1,885 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_w16_l8192
+  FOREIGN fakeram_w16_l8192 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 1024.420 BY 514.080 ;
+  CLASS BLOCK ;
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.720 0.300 3.020 ;
+    END
+  END rw0_clk
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.440 0.300 5.740 ;
+    END
+  END rw0_ce_in
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.160 0.300 8.460 ;
+    END
+  END rw0_we_in
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.880 0.300 11.180 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.600 0.300 13.900 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.320 0.300 16.620 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.040 0.300 19.340 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.760 0.300 22.060 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.480 0.300 24.780 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.200 0.300 27.500 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.920 0.300 30.220 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.640 0.300 32.940 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_addr_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.360 0.300 35.660 ;
+    END
+  END rw0_addr_in[9]
+  PIN rw0_addr_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.080 0.300 38.380 ;
+    END
+  END rw0_addr_in[10]
+  PIN rw0_addr_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.800 0.300 41.100 ;
+    END
+  END rw0_addr_in[11]
+  PIN rw0_addr_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.520 0.300 43.820 ;
+    END
+  END rw0_addr_in[12]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.240 0.300 46.540 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.960 0.300 49.260 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.680 0.300 51.980 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.400 0.300 54.700 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.120 0.300 57.420 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.840 0.300 60.140 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.300 62.860 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.280 0.300 65.580 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.000 0.300 68.300 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.720 0.300 71.020 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.440 0.300 73.740 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.160 0.300 76.460 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.880 0.300 79.180 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.600 0.300 81.900 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.320 0.300 84.620 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.040 0.300 87.340 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.760 0.300 90.060 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.480 0.300 92.780 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.200 0.300 95.500 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.920 0.300 98.220 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.640 0.300 100.940 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.360 0.300 103.660 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.080 0.300 106.380 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.800 0.300 109.100 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.520 0.300 111.820 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.240 0.300 114.540 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.960 0.300 117.260 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.680 0.300 119.980 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.400 0.300 122.700 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.300 125.420 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.840 0.300 128.140 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.560 0.300 130.860 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw1_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.280 0.300 133.580 ;
+    END
+  END rw1_clk
+  PIN rw1_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.000 0.300 136.300 ;
+    END
+  END rw1_ce_in
+  PIN rw1_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.720 0.300 139.020 ;
+    END
+  END rw1_we_in
+  PIN rw1_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 141.440 0.300 141.740 ;
+    END
+  END rw1_addr_in[0]
+  PIN rw1_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 144.160 0.300 144.460 ;
+    END
+  END rw1_addr_in[1]
+  PIN rw1_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 146.880 0.300 147.180 ;
+    END
+  END rw1_addr_in[2]
+  PIN rw1_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 149.600 0.300 149.900 ;
+    END
+  END rw1_addr_in[3]
+  PIN rw1_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 152.320 0.300 152.620 ;
+    END
+  END rw1_addr_in[4]
+  PIN rw1_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 155.040 0.300 155.340 ;
+    END
+  END rw1_addr_in[5]
+  PIN rw1_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 157.760 0.300 158.060 ;
+    END
+  END rw1_addr_in[6]
+  PIN rw1_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 160.480 0.300 160.780 ;
+    END
+  END rw1_addr_in[7]
+  PIN rw1_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 163.200 0.300 163.500 ;
+    END
+  END rw1_addr_in[8]
+  PIN rw1_addr_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 165.920 0.300 166.220 ;
+    END
+  END rw1_addr_in[9]
+  PIN rw1_addr_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 168.640 0.300 168.940 ;
+    END
+  END rw1_addr_in[10]
+  PIN rw1_addr_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 171.360 0.300 171.660 ;
+    END
+  END rw1_addr_in[11]
+  PIN rw1_addr_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 174.080 0.300 174.380 ;
+    END
+  END rw1_addr_in[12]
+  PIN rw1_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 176.800 0.300 177.100 ;
+    END
+  END rw1_wd_in[0]
+  PIN rw1_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 179.520 0.300 179.820 ;
+    END
+  END rw1_wd_in[1]
+  PIN rw1_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 182.240 0.300 182.540 ;
+    END
+  END rw1_wd_in[2]
+  PIN rw1_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 184.960 0.300 185.260 ;
+    END
+  END rw1_wd_in[3]
+  PIN rw1_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 187.680 0.300 187.980 ;
+    END
+  END rw1_wd_in[4]
+  PIN rw1_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 190.400 0.300 190.700 ;
+    END
+  END rw1_wd_in[5]
+  PIN rw1_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 193.120 0.300 193.420 ;
+    END
+  END rw1_wd_in[6]
+  PIN rw1_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 195.840 0.300 196.140 ;
+    END
+  END rw1_wd_in[7]
+  PIN rw1_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 198.560 0.300 198.860 ;
+    END
+  END rw1_wd_in[8]
+  PIN rw1_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 201.280 0.300 201.580 ;
+    END
+  END rw1_wd_in[9]
+  PIN rw1_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 204.000 0.300 204.300 ;
+    END
+  END rw1_wd_in[10]
+  PIN rw1_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 206.720 0.300 207.020 ;
+    END
+  END rw1_wd_in[11]
+  PIN rw1_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 209.440 0.300 209.740 ;
+    END
+  END rw1_wd_in[12]
+  PIN rw1_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 212.160 0.300 212.460 ;
+    END
+  END rw1_wd_in[13]
+  PIN rw1_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 214.880 0.300 215.180 ;
+    END
+  END rw1_wd_in[14]
+  PIN rw1_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 217.600 0.300 217.900 ;
+    END
+  END rw1_wd_in[15]
+  PIN rw1_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 220.320 0.300 220.620 ;
+    END
+  END rw1_rd_out[0]
+  PIN rw1_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 223.040 0.300 223.340 ;
+    END
+  END rw1_rd_out[1]
+  PIN rw1_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 225.760 0.300 226.060 ;
+    END
+  END rw1_rd_out[2]
+  PIN rw1_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 228.480 0.300 228.780 ;
+    END
+  END rw1_rd_out[3]
+  PIN rw1_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 231.200 0.300 231.500 ;
+    END
+  END rw1_rd_out[4]
+  PIN rw1_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 233.920 0.300 234.220 ;
+    END
+  END rw1_rd_out[5]
+  PIN rw1_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 236.640 0.300 236.940 ;
+    END
+  END rw1_rd_out[6]
+  PIN rw1_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 239.360 0.300 239.660 ;
+    END
+  END rw1_rd_out[7]
+  PIN rw1_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 242.080 0.300 242.380 ;
+    END
+  END rw1_rd_out[8]
+  PIN rw1_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 244.800 0.300 245.100 ;
+    END
+  END rw1_rd_out[9]
+  PIN rw1_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 247.520 0.300 247.820 ;
+    END
+  END rw1_rd_out[10]
+  PIN rw1_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 250.240 0.300 250.540 ;
+    END
+  END rw1_rd_out[11]
+  PIN rw1_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 252.960 0.300 253.260 ;
+    END
+  END rw1_rd_out[12]
+  PIN rw1_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 255.680 0.300 255.980 ;
+    END
+  END rw1_rd_out[13]
+  PIN rw1_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 258.400 0.300 258.700 ;
+    END
+  END rw1_rd_out[14]
+  PIN rw1_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 261.120 0.300 261.420 ;
+    END
+  END rw1_rd_out[15]
+  OBS
+    LAYER li1 ;
+      RECT 0.000 0.000 1024.420 514.080 ;
+    LAYER met1 ;
+      RECT 0.000 0.000 1024.420 514.080 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 1024.420 514.080 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 1024.420 514.080 ;
+    LAYER met4 ;
+      RECT 0.000 0.000 1024.420 514.080 ;
+  END
+END fakeram_w16_l8192
+END LIBRARY

--- a/designs/sky130hd/cnn/sram/lef/fakeram_w64_l256.lef
+++ b/designs/sky130hd/cnn/sram/lef/fakeram_w64_l256.lef
@@ -1,0 +1,2523 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_w64_l256
+  FOREIGN fakeram_w64_l256 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 362.480 BY 767.040 ;
+  CLASS BLOCK ;
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.720 0.300 3.020 ;
+    END
+  END rw0_clk
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.440 0.300 5.740 ;
+    END
+  END rw0_ce_in
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.160 0.300 8.460 ;
+    END
+  END rw0_we_in
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.880 0.300 11.180 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.600 0.300 13.900 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.320 0.300 16.620 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.040 0.300 19.340 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.760 0.300 22.060 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.480 0.300 24.780 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.200 0.300 27.500 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.920 0.300 30.220 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.640 0.300 32.940 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.360 0.300 35.660 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.080 0.300 38.380 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.800 0.300 41.100 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.520 0.300 43.820 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.240 0.300 46.540 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.960 0.300 49.260 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.680 0.300 51.980 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.400 0.300 54.700 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.120 0.300 57.420 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.840 0.300 60.140 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.300 62.860 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.280 0.300 65.580 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.000 0.300 68.300 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.720 0.300 71.020 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.440 0.300 73.740 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.160 0.300 76.460 ;
+    END
+  END rw0_wd_in[16]
+  PIN rw0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.880 0.300 79.180 ;
+    END
+  END rw0_wd_in[17]
+  PIN rw0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.600 0.300 81.900 ;
+    END
+  END rw0_wd_in[18]
+  PIN rw0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.320 0.300 84.620 ;
+    END
+  END rw0_wd_in[19]
+  PIN rw0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.040 0.300 87.340 ;
+    END
+  END rw0_wd_in[20]
+  PIN rw0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.760 0.300 90.060 ;
+    END
+  END rw0_wd_in[21]
+  PIN rw0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.480 0.300 92.780 ;
+    END
+  END rw0_wd_in[22]
+  PIN rw0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.200 0.300 95.500 ;
+    END
+  END rw0_wd_in[23]
+  PIN rw0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.920 0.300 98.220 ;
+    END
+  END rw0_wd_in[24]
+  PIN rw0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.640 0.300 100.940 ;
+    END
+  END rw0_wd_in[25]
+  PIN rw0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.360 0.300 103.660 ;
+    END
+  END rw0_wd_in[26]
+  PIN rw0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.080 0.300 106.380 ;
+    END
+  END rw0_wd_in[27]
+  PIN rw0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.800 0.300 109.100 ;
+    END
+  END rw0_wd_in[28]
+  PIN rw0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.520 0.300 111.820 ;
+    END
+  END rw0_wd_in[29]
+  PIN rw0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.240 0.300 114.540 ;
+    END
+  END rw0_wd_in[30]
+  PIN rw0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.960 0.300 117.260 ;
+    END
+  END rw0_wd_in[31]
+  PIN rw0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.680 0.300 119.980 ;
+    END
+  END rw0_wd_in[32]
+  PIN rw0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.400 0.300 122.700 ;
+    END
+  END rw0_wd_in[33]
+  PIN rw0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.300 125.420 ;
+    END
+  END rw0_wd_in[34]
+  PIN rw0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.840 0.300 128.140 ;
+    END
+  END rw0_wd_in[35]
+  PIN rw0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.560 0.300 130.860 ;
+    END
+  END rw0_wd_in[36]
+  PIN rw0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.280 0.300 133.580 ;
+    END
+  END rw0_wd_in[37]
+  PIN rw0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.000 0.300 136.300 ;
+    END
+  END rw0_wd_in[38]
+  PIN rw0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.720 0.300 139.020 ;
+    END
+  END rw0_wd_in[39]
+  PIN rw0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 141.440 0.300 141.740 ;
+    END
+  END rw0_wd_in[40]
+  PIN rw0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 144.160 0.300 144.460 ;
+    END
+  END rw0_wd_in[41]
+  PIN rw0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 146.880 0.300 147.180 ;
+    END
+  END rw0_wd_in[42]
+  PIN rw0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 149.600 0.300 149.900 ;
+    END
+  END rw0_wd_in[43]
+  PIN rw0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 152.320 0.300 152.620 ;
+    END
+  END rw0_wd_in[44]
+  PIN rw0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 155.040 0.300 155.340 ;
+    END
+  END rw0_wd_in[45]
+  PIN rw0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 157.760 0.300 158.060 ;
+    END
+  END rw0_wd_in[46]
+  PIN rw0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 160.480 0.300 160.780 ;
+    END
+  END rw0_wd_in[47]
+  PIN rw0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 163.200 0.300 163.500 ;
+    END
+  END rw0_wd_in[48]
+  PIN rw0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 165.920 0.300 166.220 ;
+    END
+  END rw0_wd_in[49]
+  PIN rw0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 168.640 0.300 168.940 ;
+    END
+  END rw0_wd_in[50]
+  PIN rw0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 171.360 0.300 171.660 ;
+    END
+  END rw0_wd_in[51]
+  PIN rw0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 174.080 0.300 174.380 ;
+    END
+  END rw0_wd_in[52]
+  PIN rw0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 176.800 0.300 177.100 ;
+    END
+  END rw0_wd_in[53]
+  PIN rw0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 179.520 0.300 179.820 ;
+    END
+  END rw0_wd_in[54]
+  PIN rw0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 182.240 0.300 182.540 ;
+    END
+  END rw0_wd_in[55]
+  PIN rw0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 184.960 0.300 185.260 ;
+    END
+  END rw0_wd_in[56]
+  PIN rw0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 187.680 0.300 187.980 ;
+    END
+  END rw0_wd_in[57]
+  PIN rw0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 190.400 0.300 190.700 ;
+    END
+  END rw0_wd_in[58]
+  PIN rw0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 193.120 0.300 193.420 ;
+    END
+  END rw0_wd_in[59]
+  PIN rw0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 195.840 0.300 196.140 ;
+    END
+  END rw0_wd_in[60]
+  PIN rw0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 198.560 0.300 198.860 ;
+    END
+  END rw0_wd_in[61]
+  PIN rw0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 201.280 0.300 201.580 ;
+    END
+  END rw0_wd_in[62]
+  PIN rw0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 204.000 0.300 204.300 ;
+    END
+  END rw0_wd_in[63]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 206.720 0.300 207.020 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 209.440 0.300 209.740 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 212.160 0.300 212.460 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 214.880 0.300 215.180 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 217.600 0.300 217.900 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 220.320 0.300 220.620 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 223.040 0.300 223.340 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 225.760 0.300 226.060 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 228.480 0.300 228.780 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 231.200 0.300 231.500 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 233.920 0.300 234.220 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 236.640 0.300 236.940 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 239.360 0.300 239.660 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 242.080 0.300 242.380 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 244.800 0.300 245.100 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 247.520 0.300 247.820 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 250.240 0.300 250.540 ;
+    END
+  END rw0_rd_out[16]
+  PIN rw0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 252.960 0.300 253.260 ;
+    END
+  END rw0_rd_out[17]
+  PIN rw0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 255.680 0.300 255.980 ;
+    END
+  END rw0_rd_out[18]
+  PIN rw0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 258.400 0.300 258.700 ;
+    END
+  END rw0_rd_out[19]
+  PIN rw0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 261.120 0.300 261.420 ;
+    END
+  END rw0_rd_out[20]
+  PIN rw0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 263.840 0.300 264.140 ;
+    END
+  END rw0_rd_out[21]
+  PIN rw0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 266.560 0.300 266.860 ;
+    END
+  END rw0_rd_out[22]
+  PIN rw0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 269.280 0.300 269.580 ;
+    END
+  END rw0_rd_out[23]
+  PIN rw0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 272.000 0.300 272.300 ;
+    END
+  END rw0_rd_out[24]
+  PIN rw0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 274.720 0.300 275.020 ;
+    END
+  END rw0_rd_out[25]
+  PIN rw0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 277.440 0.300 277.740 ;
+    END
+  END rw0_rd_out[26]
+  PIN rw0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 280.160 0.300 280.460 ;
+    END
+  END rw0_rd_out[27]
+  PIN rw0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 282.880 0.300 283.180 ;
+    END
+  END rw0_rd_out[28]
+  PIN rw0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 285.600 0.300 285.900 ;
+    END
+  END rw0_rd_out[29]
+  PIN rw0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 288.320 0.300 288.620 ;
+    END
+  END rw0_rd_out[30]
+  PIN rw0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 291.040 0.300 291.340 ;
+    END
+  END rw0_rd_out[31]
+  PIN rw0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 293.760 0.300 294.060 ;
+    END
+  END rw0_rd_out[32]
+  PIN rw0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 296.480 0.300 296.780 ;
+    END
+  END rw0_rd_out[33]
+  PIN rw0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 299.200 0.300 299.500 ;
+    END
+  END rw0_rd_out[34]
+  PIN rw0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 301.920 0.300 302.220 ;
+    END
+  END rw0_rd_out[35]
+  PIN rw0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 304.640 0.300 304.940 ;
+    END
+  END rw0_rd_out[36]
+  PIN rw0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 307.360 0.300 307.660 ;
+    END
+  END rw0_rd_out[37]
+  PIN rw0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 310.080 0.300 310.380 ;
+    END
+  END rw0_rd_out[38]
+  PIN rw0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 312.800 0.300 313.100 ;
+    END
+  END rw0_rd_out[39]
+  PIN rw0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 315.520 0.300 315.820 ;
+    END
+  END rw0_rd_out[40]
+  PIN rw0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 318.240 0.300 318.540 ;
+    END
+  END rw0_rd_out[41]
+  PIN rw0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 320.960 0.300 321.260 ;
+    END
+  END rw0_rd_out[42]
+  PIN rw0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 323.680 0.300 323.980 ;
+    END
+  END rw0_rd_out[43]
+  PIN rw0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 326.400 0.300 326.700 ;
+    END
+  END rw0_rd_out[44]
+  PIN rw0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 329.120 0.300 329.420 ;
+    END
+  END rw0_rd_out[45]
+  PIN rw0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 331.840 0.300 332.140 ;
+    END
+  END rw0_rd_out[46]
+  PIN rw0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 334.560 0.300 334.860 ;
+    END
+  END rw0_rd_out[47]
+  PIN rw0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 337.280 0.300 337.580 ;
+    END
+  END rw0_rd_out[48]
+  PIN rw0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 340.000 0.300 340.300 ;
+    END
+  END rw0_rd_out[49]
+  PIN rw0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 342.720 0.300 343.020 ;
+    END
+  END rw0_rd_out[50]
+  PIN rw0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 345.440 0.300 345.740 ;
+    END
+  END rw0_rd_out[51]
+  PIN rw0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 348.160 0.300 348.460 ;
+    END
+  END rw0_rd_out[52]
+  PIN rw0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 350.880 0.300 351.180 ;
+    END
+  END rw0_rd_out[53]
+  PIN rw0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 353.600 0.300 353.900 ;
+    END
+  END rw0_rd_out[54]
+  PIN rw0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 356.320 0.300 356.620 ;
+    END
+  END rw0_rd_out[55]
+  PIN rw0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 359.040 0.300 359.340 ;
+    END
+  END rw0_rd_out[56]
+  PIN rw0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 361.760 0.300 362.060 ;
+    END
+  END rw0_rd_out[57]
+  PIN rw0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 364.480 0.300 364.780 ;
+    END
+  END rw0_rd_out[58]
+  PIN rw0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 367.200 0.300 367.500 ;
+    END
+  END rw0_rd_out[59]
+  PIN rw0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 369.920 0.300 370.220 ;
+    END
+  END rw0_rd_out[60]
+  PIN rw0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 372.640 0.300 372.940 ;
+    END
+  END rw0_rd_out[61]
+  PIN rw0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 375.360 0.300 375.660 ;
+    END
+  END rw0_rd_out[62]
+  PIN rw0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 378.080 0.300 378.380 ;
+    END
+  END rw0_rd_out[63]
+  PIN rw1_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 380.800 0.300 381.100 ;
+    END
+  END rw1_clk
+  PIN rw1_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 383.520 0.300 383.820 ;
+    END
+  END rw1_ce_in
+  PIN rw1_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 386.240 0.300 386.540 ;
+    END
+  END rw1_we_in
+  PIN rw1_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 388.960 0.300 389.260 ;
+    END
+  END rw1_addr_in[0]
+  PIN rw1_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 391.680 0.300 391.980 ;
+    END
+  END rw1_addr_in[1]
+  PIN rw1_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 394.400 0.300 394.700 ;
+    END
+  END rw1_addr_in[2]
+  PIN rw1_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 397.120 0.300 397.420 ;
+    END
+  END rw1_addr_in[3]
+  PIN rw1_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 399.840 0.300 400.140 ;
+    END
+  END rw1_addr_in[4]
+  PIN rw1_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 402.560 0.300 402.860 ;
+    END
+  END rw1_addr_in[5]
+  PIN rw1_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 405.280 0.300 405.580 ;
+    END
+  END rw1_addr_in[6]
+  PIN rw1_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 408.000 0.300 408.300 ;
+    END
+  END rw1_addr_in[7]
+  PIN rw1_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 410.720 0.300 411.020 ;
+    END
+  END rw1_wd_in[0]
+  PIN rw1_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 413.440 0.300 413.740 ;
+    END
+  END rw1_wd_in[1]
+  PIN rw1_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 416.160 0.300 416.460 ;
+    END
+  END rw1_wd_in[2]
+  PIN rw1_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 418.880 0.300 419.180 ;
+    END
+  END rw1_wd_in[3]
+  PIN rw1_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 421.600 0.300 421.900 ;
+    END
+  END rw1_wd_in[4]
+  PIN rw1_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 424.320 0.300 424.620 ;
+    END
+  END rw1_wd_in[5]
+  PIN rw1_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 427.040 0.300 427.340 ;
+    END
+  END rw1_wd_in[6]
+  PIN rw1_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 429.760 0.300 430.060 ;
+    END
+  END rw1_wd_in[7]
+  PIN rw1_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 432.480 0.300 432.780 ;
+    END
+  END rw1_wd_in[8]
+  PIN rw1_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 435.200 0.300 435.500 ;
+    END
+  END rw1_wd_in[9]
+  PIN rw1_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 437.920 0.300 438.220 ;
+    END
+  END rw1_wd_in[10]
+  PIN rw1_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 440.640 0.300 440.940 ;
+    END
+  END rw1_wd_in[11]
+  PIN rw1_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 443.360 0.300 443.660 ;
+    END
+  END rw1_wd_in[12]
+  PIN rw1_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 446.080 0.300 446.380 ;
+    END
+  END rw1_wd_in[13]
+  PIN rw1_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 448.800 0.300 449.100 ;
+    END
+  END rw1_wd_in[14]
+  PIN rw1_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 451.520 0.300 451.820 ;
+    END
+  END rw1_wd_in[15]
+  PIN rw1_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 454.240 0.300 454.540 ;
+    END
+  END rw1_wd_in[16]
+  PIN rw1_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 456.960 0.300 457.260 ;
+    END
+  END rw1_wd_in[17]
+  PIN rw1_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 459.680 0.300 459.980 ;
+    END
+  END rw1_wd_in[18]
+  PIN rw1_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 462.400 0.300 462.700 ;
+    END
+  END rw1_wd_in[19]
+  PIN rw1_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 465.120 0.300 465.420 ;
+    END
+  END rw1_wd_in[20]
+  PIN rw1_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 467.840 0.300 468.140 ;
+    END
+  END rw1_wd_in[21]
+  PIN rw1_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 470.560 0.300 470.860 ;
+    END
+  END rw1_wd_in[22]
+  PIN rw1_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 473.280 0.300 473.580 ;
+    END
+  END rw1_wd_in[23]
+  PIN rw1_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 476.000 0.300 476.300 ;
+    END
+  END rw1_wd_in[24]
+  PIN rw1_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 478.720 0.300 479.020 ;
+    END
+  END rw1_wd_in[25]
+  PIN rw1_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 481.440 0.300 481.740 ;
+    END
+  END rw1_wd_in[26]
+  PIN rw1_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 484.160 0.300 484.460 ;
+    END
+  END rw1_wd_in[27]
+  PIN rw1_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 486.880 0.300 487.180 ;
+    END
+  END rw1_wd_in[28]
+  PIN rw1_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 489.600 0.300 489.900 ;
+    END
+  END rw1_wd_in[29]
+  PIN rw1_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 492.320 0.300 492.620 ;
+    END
+  END rw1_wd_in[30]
+  PIN rw1_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 495.040 0.300 495.340 ;
+    END
+  END rw1_wd_in[31]
+  PIN rw1_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 497.760 0.300 498.060 ;
+    END
+  END rw1_wd_in[32]
+  PIN rw1_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 500.480 0.300 500.780 ;
+    END
+  END rw1_wd_in[33]
+  PIN rw1_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 503.200 0.300 503.500 ;
+    END
+  END rw1_wd_in[34]
+  PIN rw1_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 505.920 0.300 506.220 ;
+    END
+  END rw1_wd_in[35]
+  PIN rw1_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 508.640 0.300 508.940 ;
+    END
+  END rw1_wd_in[36]
+  PIN rw1_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 511.360 0.300 511.660 ;
+    END
+  END rw1_wd_in[37]
+  PIN rw1_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 514.080 0.300 514.380 ;
+    END
+  END rw1_wd_in[38]
+  PIN rw1_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 516.800 0.300 517.100 ;
+    END
+  END rw1_wd_in[39]
+  PIN rw1_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 519.520 0.300 519.820 ;
+    END
+  END rw1_wd_in[40]
+  PIN rw1_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 522.240 0.300 522.540 ;
+    END
+  END rw1_wd_in[41]
+  PIN rw1_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 524.960 0.300 525.260 ;
+    END
+  END rw1_wd_in[42]
+  PIN rw1_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 527.680 0.300 527.980 ;
+    END
+  END rw1_wd_in[43]
+  PIN rw1_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 530.400 0.300 530.700 ;
+    END
+  END rw1_wd_in[44]
+  PIN rw1_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 533.120 0.300 533.420 ;
+    END
+  END rw1_wd_in[45]
+  PIN rw1_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 535.840 0.300 536.140 ;
+    END
+  END rw1_wd_in[46]
+  PIN rw1_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 538.560 0.300 538.860 ;
+    END
+  END rw1_wd_in[47]
+  PIN rw1_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 541.280 0.300 541.580 ;
+    END
+  END rw1_wd_in[48]
+  PIN rw1_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 544.000 0.300 544.300 ;
+    END
+  END rw1_wd_in[49]
+  PIN rw1_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 546.720 0.300 547.020 ;
+    END
+  END rw1_wd_in[50]
+  PIN rw1_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 549.440 0.300 549.740 ;
+    END
+  END rw1_wd_in[51]
+  PIN rw1_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 552.160 0.300 552.460 ;
+    END
+  END rw1_wd_in[52]
+  PIN rw1_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 554.880 0.300 555.180 ;
+    END
+  END rw1_wd_in[53]
+  PIN rw1_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 557.600 0.300 557.900 ;
+    END
+  END rw1_wd_in[54]
+  PIN rw1_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 560.320 0.300 560.620 ;
+    END
+  END rw1_wd_in[55]
+  PIN rw1_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 563.040 0.300 563.340 ;
+    END
+  END rw1_wd_in[56]
+  PIN rw1_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 565.760 0.300 566.060 ;
+    END
+  END rw1_wd_in[57]
+  PIN rw1_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 568.480 0.300 568.780 ;
+    END
+  END rw1_wd_in[58]
+  PIN rw1_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 571.200 0.300 571.500 ;
+    END
+  END rw1_wd_in[59]
+  PIN rw1_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 573.920 0.300 574.220 ;
+    END
+  END rw1_wd_in[60]
+  PIN rw1_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 576.640 0.300 576.940 ;
+    END
+  END rw1_wd_in[61]
+  PIN rw1_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 579.360 0.300 579.660 ;
+    END
+  END rw1_wd_in[62]
+  PIN rw1_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 582.080 0.300 582.380 ;
+    END
+  END rw1_wd_in[63]
+  PIN rw1_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 584.800 0.300 585.100 ;
+    END
+  END rw1_rd_out[0]
+  PIN rw1_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 587.520 0.300 587.820 ;
+    END
+  END rw1_rd_out[1]
+  PIN rw1_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 590.240 0.300 590.540 ;
+    END
+  END rw1_rd_out[2]
+  PIN rw1_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 592.960 0.300 593.260 ;
+    END
+  END rw1_rd_out[3]
+  PIN rw1_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 595.680 0.300 595.980 ;
+    END
+  END rw1_rd_out[4]
+  PIN rw1_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 598.400 0.300 598.700 ;
+    END
+  END rw1_rd_out[5]
+  PIN rw1_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 601.120 0.300 601.420 ;
+    END
+  END rw1_rd_out[6]
+  PIN rw1_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 603.840 0.300 604.140 ;
+    END
+  END rw1_rd_out[7]
+  PIN rw1_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 606.560 0.300 606.860 ;
+    END
+  END rw1_rd_out[8]
+  PIN rw1_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 609.280 0.300 609.580 ;
+    END
+  END rw1_rd_out[9]
+  PIN rw1_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 612.000 0.300 612.300 ;
+    END
+  END rw1_rd_out[10]
+  PIN rw1_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 614.720 0.300 615.020 ;
+    END
+  END rw1_rd_out[11]
+  PIN rw1_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 617.440 0.300 617.740 ;
+    END
+  END rw1_rd_out[12]
+  PIN rw1_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 620.160 0.300 620.460 ;
+    END
+  END rw1_rd_out[13]
+  PIN rw1_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 622.880 0.300 623.180 ;
+    END
+  END rw1_rd_out[14]
+  PIN rw1_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 625.600 0.300 625.900 ;
+    END
+  END rw1_rd_out[15]
+  PIN rw1_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 628.320 0.300 628.620 ;
+    END
+  END rw1_rd_out[16]
+  PIN rw1_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 631.040 0.300 631.340 ;
+    END
+  END rw1_rd_out[17]
+  PIN rw1_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 633.760 0.300 634.060 ;
+    END
+  END rw1_rd_out[18]
+  PIN rw1_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 636.480 0.300 636.780 ;
+    END
+  END rw1_rd_out[19]
+  PIN rw1_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 639.200 0.300 639.500 ;
+    END
+  END rw1_rd_out[20]
+  PIN rw1_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 641.920 0.300 642.220 ;
+    END
+  END rw1_rd_out[21]
+  PIN rw1_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 644.640 0.300 644.940 ;
+    END
+  END rw1_rd_out[22]
+  PIN rw1_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 647.360 0.300 647.660 ;
+    END
+  END rw1_rd_out[23]
+  PIN rw1_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 650.080 0.300 650.380 ;
+    END
+  END rw1_rd_out[24]
+  PIN rw1_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 652.800 0.300 653.100 ;
+    END
+  END rw1_rd_out[25]
+  PIN rw1_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 655.520 0.300 655.820 ;
+    END
+  END rw1_rd_out[26]
+  PIN rw1_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 658.240 0.300 658.540 ;
+    END
+  END rw1_rd_out[27]
+  PIN rw1_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 660.960 0.300 661.260 ;
+    END
+  END rw1_rd_out[28]
+  PIN rw1_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 663.680 0.300 663.980 ;
+    END
+  END rw1_rd_out[29]
+  PIN rw1_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 666.400 0.300 666.700 ;
+    END
+  END rw1_rd_out[30]
+  PIN rw1_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 669.120 0.300 669.420 ;
+    END
+  END rw1_rd_out[31]
+  PIN rw1_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 671.840 0.300 672.140 ;
+    END
+  END rw1_rd_out[32]
+  PIN rw1_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 674.560 0.300 674.860 ;
+    END
+  END rw1_rd_out[33]
+  PIN rw1_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 677.280 0.300 677.580 ;
+    END
+  END rw1_rd_out[34]
+  PIN rw1_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 680.000 0.300 680.300 ;
+    END
+  END rw1_rd_out[35]
+  PIN rw1_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 682.720 0.300 683.020 ;
+    END
+  END rw1_rd_out[36]
+  PIN rw1_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 685.440 0.300 685.740 ;
+    END
+  END rw1_rd_out[37]
+  PIN rw1_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 688.160 0.300 688.460 ;
+    END
+  END rw1_rd_out[38]
+  PIN rw1_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 690.880 0.300 691.180 ;
+    END
+  END rw1_rd_out[39]
+  PIN rw1_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 693.600 0.300 693.900 ;
+    END
+  END rw1_rd_out[40]
+  PIN rw1_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 696.320 0.300 696.620 ;
+    END
+  END rw1_rd_out[41]
+  PIN rw1_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 699.040 0.300 699.340 ;
+    END
+  END rw1_rd_out[42]
+  PIN rw1_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 701.760 0.300 702.060 ;
+    END
+  END rw1_rd_out[43]
+  PIN rw1_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 704.480 0.300 704.780 ;
+    END
+  END rw1_rd_out[44]
+  PIN rw1_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 707.200 0.300 707.500 ;
+    END
+  END rw1_rd_out[45]
+  PIN rw1_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 709.920 0.300 710.220 ;
+    END
+  END rw1_rd_out[46]
+  PIN rw1_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 712.640 0.300 712.940 ;
+    END
+  END rw1_rd_out[47]
+  PIN rw1_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 715.360 0.300 715.660 ;
+    END
+  END rw1_rd_out[48]
+  PIN rw1_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 718.080 0.300 718.380 ;
+    END
+  END rw1_rd_out[49]
+  PIN rw1_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 720.800 0.300 721.100 ;
+    END
+  END rw1_rd_out[50]
+  PIN rw1_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 723.520 0.300 723.820 ;
+    END
+  END rw1_rd_out[51]
+  PIN rw1_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 726.240 0.300 726.540 ;
+    END
+  END rw1_rd_out[52]
+  PIN rw1_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 728.960 0.300 729.260 ;
+    END
+  END rw1_rd_out[53]
+  PIN rw1_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 731.680 0.300 731.980 ;
+    END
+  END rw1_rd_out[54]
+  PIN rw1_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 734.400 0.300 734.700 ;
+    END
+  END rw1_rd_out[55]
+  PIN rw1_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 737.120 0.300 737.420 ;
+    END
+  END rw1_rd_out[56]
+  PIN rw1_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 739.840 0.300 740.140 ;
+    END
+  END rw1_rd_out[57]
+  PIN rw1_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 742.560 0.300 742.860 ;
+    END
+  END rw1_rd_out[58]
+  PIN rw1_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 745.280 0.300 745.580 ;
+    END
+  END rw1_rd_out[59]
+  PIN rw1_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 748.000 0.300 748.300 ;
+    END
+  END rw1_rd_out[60]
+  PIN rw1_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 750.720 0.300 751.020 ;
+    END
+  END rw1_rd_out[61]
+  PIN rw1_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 753.440 0.300 753.740 ;
+    END
+  END rw1_rd_out[62]
+  PIN rw1_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 756.160 0.300 756.460 ;
+    END
+  END rw1_rd_out[63]
+  OBS
+    LAYER li1 ;
+      RECT 0.000 0.000 362.480 767.040 ;
+    LAYER met1 ;
+      RECT 0.000 0.000 362.480 767.040 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 362.480 767.040 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 362.480 767.040 ;
+    LAYER met4 ;
+      RECT 0.000 0.000 362.480 767.040 ;
+  END
+END fakeram_w64_l256
+END LIBRARY

--- a/designs/sky130hd/cnn/sram/lib/fakeram_w16_l32768.lib
+++ b/designs/sky130hd/cnn/sram/lib/fakeram_w16_l32768.lib
@@ -1,0 +1,352 @@
+library(fakeram_w16_l32768) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2025-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_w16_l32768_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_w16_l32768_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_w16_l32768_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_w16_l32768_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 16; bit_from : 15; bit_to : 0; downto : true;
+    }
+    type (fakeram_w16_l32768_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 15; bit_from : 14; bit_to : 0; downto : true;
+    }
+    cell(fakeram_w16_l32768) {
+        area : 2100490.787;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(rw0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_addr_in) {
+            bus_type : fakeram_w16_l32768_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_wd_in) {
+            bus_type : fakeram_w16_l32768_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw0_addr_in; clocked_on : "rw0_clk"; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_rd_out) {
+            bus_type : fakeram_w16_l32768_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw0_addr_in; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_w16_l32768_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_w16_l32768_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_w16_l32768_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_w16_l32768_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+        pin(rw1_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw1_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw1_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_addr_in) {
+            bus_type : fakeram_w16_l32768_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_wd_in) {
+            bus_type : fakeram_w16_l32768_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw1_addr_in; clocked_on : "rw1_clk"; }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l32768_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_rd_out) {
+            bus_type : fakeram_w16_l32768_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw1_addr_in; }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_w16_l32768_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_w16_l32768_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_w16_l32768_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_w16_l32768_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/cnn/sram/lib/fakeram_w16_l512.lib
+++ b/designs/sky130hd/cnn/sram/lib/fakeram_w16_l512.lib
@@ -1,0 +1,352 @@
+library(fakeram_w16_l512) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2025-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_w16_l512_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_w16_l512_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_w16_l512_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_w16_l512_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 16; bit_from : 15; bit_to : 0; downto : true;
+    }
+    type (fakeram_w16_l512_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 9; bit_from : 8; bit_to : 0; downto : true;
+    }
+    cell(fakeram_w16_l512) {
+        area : 64116.493;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(rw0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_addr_in) {
+            bus_type : fakeram_w16_l512_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_wd_in) {
+            bus_type : fakeram_w16_l512_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw0_addr_in; clocked_on : "rw0_clk"; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_rd_out) {
+            bus_type : fakeram_w16_l512_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw0_addr_in; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_w16_l512_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_w16_l512_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_w16_l512_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_w16_l512_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+        pin(rw1_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw1_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw1_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_addr_in) {
+            bus_type : fakeram_w16_l512_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_wd_in) {
+            bus_type : fakeram_w16_l512_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw1_addr_in; clocked_on : "rw1_clk"; }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l512_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_rd_out) {
+            bus_type : fakeram_w16_l512_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw1_addr_in; }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_w16_l512_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_w16_l512_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_w16_l512_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_w16_l512_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/cnn/sram/lib/fakeram_w16_l8192.lib
+++ b/designs/sky130hd/cnn/sram/lib/fakeram_w16_l8192.lib
@@ -1,0 +1,352 @@
+library(fakeram_w16_l8192) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2025-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_w16_l8192_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_w16_l8192_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_w16_l8192_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_w16_l8192_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 16; bit_from : 15; bit_to : 0; downto : true;
+    }
+    type (fakeram_w16_l8192_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 13; bit_from : 12; bit_to : 0; downto : true;
+    }
+    cell(fakeram_w16_l8192) {
+        area : 526633.834;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(rw0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_addr_in) {
+            bus_type : fakeram_w16_l8192_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_wd_in) {
+            bus_type : fakeram_w16_l8192_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw0_addr_in; clocked_on : "rw0_clk"; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_rd_out) {
+            bus_type : fakeram_w16_l8192_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw0_addr_in; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_w16_l8192_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_w16_l8192_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_w16_l8192_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_w16_l8192_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+        pin(rw1_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw1_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw1_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_addr_in) {
+            bus_type : fakeram_w16_l8192_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_wd_in) {
+            bus_type : fakeram_w16_l8192_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw1_addr_in; clocked_on : "rw1_clk"; }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w16_l8192_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_rd_out) {
+            bus_type : fakeram_w16_l8192_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw1_addr_in; }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_w16_l8192_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_w16_l8192_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_w16_l8192_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_w16_l8192_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/cnn/sram/lib/fakeram_w64_l256.lib
+++ b/designs/sky130hd/cnn/sram/lib/fakeram_w64_l256.lib
@@ -1,0 +1,352 @@
+library(fakeram_w64_l256) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2025-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_w64_l256_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_w64_l256_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_w64_l256_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_w64_l256_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 64; bit_from : 63; bit_to : 0; downto : true;
+    }
+    type (fakeram_w64_l256_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 8; bit_from : 7; bit_to : 0; downto : true;
+    }
+    cell(fakeram_w64_l256) {
+        area : 278036.659;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(rw0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_addr_in) {
+            bus_type : fakeram_w64_l256_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_wd_in) {
+            bus_type : fakeram_w64_l256_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw0_addr_in; clocked_on : "rw0_clk"; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_rd_out) {
+            bus_type : fakeram_w64_l256_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw0_addr_in; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_w64_l256_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_w64_l256_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_w64_l256_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_w64_l256_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+        pin(rw1_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw1_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw1_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_addr_in) {
+            bus_type : fakeram_w64_l256_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_wd_in) {
+            bus_type : fakeram_w64_l256_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw1_addr_in; clocked_on : "rw1_clk"; }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_w64_l256_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw1_rd_out) {
+            bus_type : fakeram_w64_l256_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw1_addr_in; }
+            timing() {
+                related_pin : "rw1_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_w64_l256_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_w64_l256_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_w64_l256_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_w64_l256_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/src/cnn/dev/gen_fakeram_sky130hd.py
+++ b/designs/src/cnn/dev/gen_fakeram_sky130hd.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+Generate sky130hd-compatible FakeRAM LEF/LIB files for CNN SRAM memories.
+
+Mirrors gen_fakeram_nangate45.py but targets the sky130hd platform: met3
+pin layer, 1.8V operating conditions, and the sky130hd unithd site grid.
+
+Usage: python3 gen_fakeram_sky130hd.py <output_sram_dir>
+
+Generates LEF/LIB files in <output_sram_dir>/lef/ and <output_sram_dir>/lib/.
+"""
+import math
+import os
+import sys
+
+# CNN memory configurations: (name, width, depth)
+CNN_CONFIGS = [
+    ("fakeram_w16_l512",   16, 512),
+    ("fakeram_w16_l8192",  16, 8192),
+    ("fakeram_w16_l32768", 16, 32768),
+    ("fakeram_w64_l256",   64, 256),
+]
+
+# sky130hd grid constants (unithd site: 0.46 x 2.72; met3 track pitch 0.68)
+PIN_W = 0.300
+PIN_PITCH = 2.720
+SNAP_W = 0.460
+SNAP_H = 2.720
+AREA_PER_BIT = 4.0
+MIN_AREA = 800
+PIN_LAYER = "met3"
+OBS_LAYERS = ["li1", "met1", "met2", "met3", "met4"]
+NOM_VOLTAGE = 1.8
+OP_COND = "tt_1.0_25.0"
+
+
+def gen_lef(name, width, depth, outdir):
+    addr_bits = max(1, math.ceil(math.log2(depth))) if depth > 1 else 1
+
+    # Estimate macro size
+    bits = width * depth
+    area = max(bits * AREA_PER_BIT, MIN_AREA)
+    h = math.sqrt(area / 2.0)
+    w = area / h
+    w = math.ceil(w / SNAP_W) * SNAP_W
+    h = math.ceil(h / SNAP_H) * SNAP_H
+
+    # Dual-port pins: rw0 + rw1, each has: clk, ce_in, we_in, addr_in[N], wd_in[W], rd_out[W]
+    total_pins = 2 * (3 + addr_bits + width * 2)
+    min_h = PIN_PITCH * (total_pins + 4)
+    if h < min_h:
+        h = math.ceil(min_h / SNAP_H) * SNAP_H
+
+    lines = [
+        "VERSION 5.7 ;",
+        'BUSBITCHARS "[]" ;',
+        f"MACRO {name}",
+        f"  FOREIGN {name} 0 0 ;",
+        "  SYMMETRY X Y R90 ;",
+        f"  SIZE {w:.3f} BY {h:.3f} ;",
+        "  CLASS BLOCK ;",
+    ]
+
+    y_pos = PIN_PITCH
+
+    def add_pin(pname, direction):
+        nonlocal y_pos
+        lines.extend([
+            f"  PIN {pname}",
+            f"    DIRECTION {direction} ;",
+            "    USE SIGNAL ;",
+            "    SHAPE ABUTMENT ;",
+            "    PORT",
+            f"      LAYER {PIN_LAYER} ;",
+            f"      RECT 0.000 {y_pos:.3f} {PIN_W:.3f} {y_pos + PIN_W:.3f} ;",
+            "    END",
+            f"  END {pname}",
+        ])
+        y_pos += PIN_PITCH
+
+    # Port rw0
+    add_pin("rw0_clk", "INPUT")
+    add_pin("rw0_ce_in", "INPUT")
+    add_pin("rw0_we_in", "INPUT")
+    for i in range(addr_bits):
+        add_pin(f"rw0_addr_in[{i}]", "INPUT")
+    for i in range(width):
+        add_pin(f"rw0_wd_in[{i}]", "INPUT")
+    for i in range(width):
+        add_pin(f"rw0_rd_out[{i}]", "OUTPUT")
+
+    # Port rw1
+    add_pin("rw1_clk", "INPUT")
+    add_pin("rw1_ce_in", "INPUT")
+    add_pin("rw1_we_in", "INPUT")
+    for i in range(addr_bits):
+        add_pin(f"rw1_addr_in[{i}]", "INPUT")
+    for i in range(width):
+        add_pin(f"rw1_wd_in[{i}]", "INPUT")
+    for i in range(width):
+        add_pin(f"rw1_rd_out[{i}]", "OUTPUT")
+
+    lines.append("  OBS")
+    for layer in OBS_LAYERS:
+        lines.extend([
+            f"    LAYER {layer} ;",
+            f"      RECT 0.000 0.000 {w:.3f} {h:.3f} ;",
+        ])
+    lines.extend([
+        "  END",
+        f"END {name}",
+        "END LIBRARY",
+    ])
+
+    path = os.path.join(outdir, "lef", f"{name}.lef")
+    with open(path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    return w, h
+
+
+def gen_lib(name, width, depth, outdir, w_um, h_um):
+    addr_bits = max(1, math.ceil(math.log2(depth))) if depth > 1 else 1
+    area = w_um * h_um
+
+    lines = [
+        f"library({name}) {{",
+        "    technology (cmos);",
+        "    delay_model : table_lookup;",
+        "    revision : 1.0;",
+        '    date : "2025-01-01 00:00:00Z";',
+        '    comment : "SRAM";',
+        '    time_unit : "1ns";',
+        '    voltage_unit : "1V";',
+        '    current_unit : "1uA";',
+        '    leakage_power_unit : "1uW";',
+        "    nom_process : 1;",
+        "    nom_temperature : 25.000;",
+        f"    nom_voltage : {NOM_VOLTAGE};",
+        '    capacitive_load_unit (1,pf);',
+        '    pulling_resistance_unit : "1kohm";',
+        f"    operating_conditions({OP_COND}) {{",
+        "        process : 1;",
+        "        temperature : 25.000;",
+        f"        voltage : {NOM_VOLTAGE};",
+        "        tree_type : balanced_tree;",
+        "    }",
+        "    default_cell_leakage_power : 0;",
+        "    default_fanout_load : 1;",
+        "    default_inout_pin_cap : 0.0;",
+        "    default_input_pin_cap : 0.0;",
+        "    default_output_pin_cap : 0.0;",
+        "    default_max_transition : 0.227;",
+        f"    default_operating_conditions : {OP_COND};",
+        "    default_leakage_power_density : 0.0;",
+        "    slew_derate_from_library : 1.000;",
+        "    slew_lower_threshold_pct_fall : 20.000;",
+        "    slew_upper_threshold_pct_fall : 80.000;",
+        "    slew_lower_threshold_pct_rise : 20.000;",
+        "    slew_upper_threshold_pct_rise : 80.000;",
+        "    input_threshold_pct_fall : 50.000;",
+        "    input_threshold_pct_rise : 50.000;",
+        "    output_threshold_pct_fall : 50.000;",
+        "    output_threshold_pct_rise : 50.000;",
+        f"    lu_table_template({name}_delay) {{",
+        "        variable_1 : input_net_transition;",
+        "        variable_2 : total_output_net_capacitance;",
+        '            index_1 ("1000, 1001");',
+        '            index_2 ("1000, 1001");',
+        "    }",
+        f"    lu_table_template({name}_slew) {{",
+        "        variable_1 : total_output_net_capacitance;",
+        '            index_1 ("1000, 1001");',
+        "    }",
+        f"    lu_table_template({name}_constraint) {{",
+        "        variable_1 : related_pin_transition;",
+        "        variable_2 : constrained_pin_transition;",
+        '            index_1 ("1000, 1001");',
+        '            index_2 ("1000, 1001");',
+        "    }",
+        "    library_features(report_delay_calculation);",
+        f"    type ({name}_DATA) {{",
+        "        base_type : array; data_type : bit;",
+        f"        bit_width : {width}; bit_from : {width-1}; bit_to : 0; downto : true;",
+        "    }",
+        f"    type ({name}_ADDR) {{",
+        "        base_type : array; data_type : bit;",
+        f"        bit_width : {addr_bits}; bit_from : {addr_bits-1}; bit_to : 0; downto : true;",
+        "    }",
+        f"    cell({name}) {{",
+        f"        area : {area:.3f};",
+        "        interface_timing : true;",
+        "        dont_use : true;",
+        "        dont_touch : true;",
+    ]
+
+    def add_port_pins(prefix):
+        """Add LIB pin definitions for one read-write port (rw0 or rw1)."""
+        lines.append(f"        pin({prefix}_clk) {{ direction : input; capacitance : 0.0214; clock : true; }}")
+
+        def constraint_block(pin_name, direction, cap="0.0035", bus_type=None, extra=""):
+            block = []
+            if bus_type:
+                block.append(f"        bus({pin_name}) {{")
+                block.append(f"            bus_type : {bus_type};")
+            else:
+                block.append(f"        pin({pin_name}) {{")
+            block.append(f"            direction : {direction};")
+            if direction == "input":
+                block.append(f"            capacitance : {cap};")
+            if extra:
+                block.append(extra)
+            block.extend([
+                "            timing() {",
+                f'                related_pin : "{prefix}_clk";',
+                "                timing_type : setup_rising;",
+                f"                rise_constraint({name}_constraint) {{",
+                '                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");',
+                '                    values("0.050, 0.050", "0.050, 0.050");',
+                "                }",
+                f"                fall_constraint({name}_constraint) {{",
+                '                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");',
+                '                    values("0.050, 0.050", "0.050, 0.050");',
+                "                }",
+                "            }",
+                "            timing() {",
+                f'                related_pin : "{prefix}_clk";',
+                "                timing_type : hold_rising;",
+                f"                rise_constraint({name}_constraint) {{",
+                '                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");',
+                '                    values("0.005, 0.005", "0.005, 0.005");',
+                "                }",
+                f"                fall_constraint({name}_constraint) {{",
+                '                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");',
+                '                    values("0.005, 0.005", "0.005, 0.005");',
+                "                }",
+                "            }",
+                "        }",
+            ])
+            return block
+
+        lines.extend(constraint_block(f"{prefix}_ce_in", "input"))
+        lines.extend(constraint_block(f"{prefix}_we_in", "input"))
+        lines.extend(constraint_block(f"{prefix}_addr_in", "input", bus_type=f"{name}_ADDR"))
+        lines.extend(constraint_block(f"{prefix}_wd_in", "input", bus_type=f"{name}_DATA",
+                                      extra=f'            memory_write() {{ address : {prefix}_addr_in; clocked_on : "{prefix}_clk"; }}'))
+
+        lines.extend([
+            f"        bus({prefix}_rd_out) {{",
+            f"            bus_type : {name}_DATA;",
+            "            direction : output;",
+            "            max_capacitance : 0.500;",
+            f"            memory_read() {{ address : {prefix}_addr_in; }}",
+            "            timing() {",
+            f'                related_pin : "{prefix}_clk";',
+            "                timing_type : rising_edge;",
+            "                timing_sense : non_unate;",
+            f"                cell_rise({name}_delay) {{",
+            '                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");',
+            '                    values("0.200, 0.800", "0.250, 0.850");',
+            "                }",
+            f"                cell_fall({name}_delay) {{",
+            '                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");',
+            '                    values("0.200, 0.800", "0.250, 0.850");',
+            "                }",
+            f"                rise_transition({name}_slew) {{",
+            '                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");',
+            "                }",
+            f"                fall_transition({name}_slew) {{",
+            '                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");',
+            "                }",
+            "            }",
+            "        }",
+        ])
+
+    add_port_pins("rw0")
+    add_port_pins("rw1")
+
+    lines.extend([
+        "    }",
+        "}",
+    ])
+
+    path = os.path.join(outdir, "lib", f"{name}.lib")
+    with open(path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <output_sram_dir>")
+        sys.exit(1)
+
+    outdir = sys.argv[1]
+    os.makedirs(os.path.join(outdir, "lef"), exist_ok=True)
+    os.makedirs(os.path.join(outdir, "lib"), exist_ok=True)
+
+    print(f"Generating sky130hd FakeRAM files for {len(CNN_CONFIGS)} CNN memory configs:")
+    for cnn_name, width, depth in CNN_CONFIGS:
+        bits = width * depth
+        print(f"  {cnn_name} ({bits} bits)")
+        w, h = gen_lef(cnn_name, width, depth, outdir)
+        gen_lib(cnn_name, width, depth, outdir, w, h)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `designs/sky130hd/cnn/` (BUILD.bazel, config.mk, constraint.sdc, sram/{lef,lib}/) mirroring the nangate45/cnn config (CORE_UTILIZATION = 30, MACRO_PLACE_HALO 40 40, SYNTH_HIERARCHICAL) with a 10 ns clock — same cross-platform ratio used by sha3/gemmini.
- Adds `designs/src/cnn/dev/gen_fakeram_sky130hd.py`, a sky130hd-tuned analogue of `gen_fakeram_nangate45.py`: met3 pin layer, li1/met1..met4 OBS layers, 1.8 V op cond, unithd site grid (0.46 x 2.72), AREA_PER_BIT = 4.0. Produces the dual-port (rw0/rw1) FakeRAMs matching the existing CNN Verilog interfaces.
- Updates CLAUDE.md platforms table (cnn added to nangate45 + sky130hd rows) and FakeRAM section to point at the per-platform sram dirs and generator scripts.

## Test plan
- [x] `bazel build //designs/sky130hd/cnn:cnn_synth` — clean, 5 s
- [x] `bazel build //designs/sky130hd/cnn:cnn_final` — clean RTL-to-finish in ~114 min (detail-place 2m44s, route 24m23s, final report 14m19s); produces `6_final.{odb,v,spef,sdc}`
- [x] `bazel build //designs/nangate45/cnn:cnn_final` — still clean (cache hits)
- [x] `bazel build //designs/asap7/cnn:cnn_final` — still clean