### PR TITLE
NVDLA partition_c: clear PSM-0069 with util=30, halo=5

### DIFF
--- a/designs/asap7/NVDLA/partition_c/BUILD.bazel
+++ b/designs/asap7/NVDLA/partition_c/BUILD.bazel
@@ -14,9 +14,9 @@ hightide_design(
     arguments = {
         "SYNTH_HIERARCHICAL": "1",
         "VERILOG_INCLUDE_DIRS": "designs/src/NVDLA/vmod/include designs/src/NVDLA/vmod/vlibs",
-        "CORE_UTILIZATION": "40",
+        "CORE_UTILIZATION": "30",
         "PLACE_DENSITY_LB_ADDON": "0.30",
-        "MACRO_PLACE_HALO": "3 3",
+        "MACRO_PLACE_HALO": "5 5",
         "TNS_END_PERCENT": "100",
     },
 )


### PR DESCRIPTION
## Summary

Tune `designs/asap7/NVDLA/partition_c/BUILD.bazel`:
- `MACRO_PLACE_HALO`: `3 3` → `5 5`
- `CORE_UTILIZATION`: `40` → `30`

## Why

partition_c packs 84 SRAM macros into a 452μm-square asap7 die. With prior tuning (util=40, halo=3, density addon 0.30) the flow ran cleanly through detailed routing but tripped `[ERROR PSM-0069] Check connectivity failed on VSS` at finishing — ~1000 filler cells in a region near (380.9μm, 378–398μm) couldn't reach VSS because the M5 stripe at x=379.4μm dropped its M2-M5 vias across a continuous 106μm vertical span (193 PDN-0195 warnings) where it crossed obstructed regions between macros.

Increasing the macro halo alone fails MPL-0003 (`no valid tilings`) because at halo=5 macros+halos cover 60% of the floorplan — past the mixed-cluster tiler's limit. Lowering target utilization grows the die ~15% per side so macros+halos cover ~45%, restoring tileability and giving PDN straps continuous std-cell lanes between macros.

## After

Both VDD and VSS report fully connected (`[INFO PSM-0040] All shapes on net VDD/VSS are connected`). Final QoR (1500 ps clock, asap7):

| metric | value |
|---|---|
| Worst slack | 119.3 ps |
| TNS | 0 |
| Die | 272,840 μm² (522 × 522 μm) |
| Instances | 896,829 |
| Macros | 84 |
| Util | 32% |

## Test plan

- [x] `bazel build //designs/asap7/NVDLA/partition_c:partition_c_final` completes without PSM-0069
- [x] `bazel build //designs/asap7/NVDLA/partition_c:partition_c_generate_metadata` produces clean metadata.json (zero TNS, zero violations)
- [x] All 5 NVDLA partitions (a, c, m, o, p) build successfully on asap7
- [ ] Run on k8s as part of the cluster benchmark suite to confirm reproducibility