### PR TITLE
Add gallery image generation per design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,23 @@ Dev mode requires: `git submodule update --init designs/src/<design>/dev/repo` b
 
 | Platform | Node | Designs |
 |----------|------|---------|
-| asap7 | 7nm academic | gemmini, minimax, cnn, sha3, lfsr, NyuziProcessor, bp_processor/bp_uno/bp_quad, liteeth (6 variants), snitch_cluster, floonoc |
-| nangate45 | 45nm | minimax, lfsr, NyuziProcessor, cnn, liteeth (6 variants) |
-| sky130hd | 130nm open | minimax, lfsr, sha3, cnn, liteeth (6 variants) |
+| asap7 | 7nm academic | coralnpu, gemmini, lfsr, minimax, sha3, vortex, liteeth (6 variants), NVDLA (partitions a/c/m/o/p), bp_processor (bp_uno, bp_quad), cnn, floonoc, NyuziProcessor, snitch_cluster |
+| nangate45 | 45nm | coralnpu, gemmini, lfsr, minimax, NyuziProcessor, sha3, liteeth (6 variants), bp_processor (bp_uno, bp_quad), cnn |
+| sky130hd | 130nm open | gemmini, lfsr, minimax, sha3, liteeth (mac_axi_mii, mac_wb_mii, udp_stream_rgmii, udp_usp_gth_sgmii), cnn, liteeth (udp_raw_rgmii, udp_stream_sgmii) |
+
+#### Build status (as of 2026-04-26)
+
+Designs reaching `_final` (cached on remote build cache):
+- **asap7**: coralnpu, gemmini, lfsr, minimax, sha3, vortex, all 6 liteeth variants, NVDLA partitions a/m/o
+- **nangate45**: coralnpu, gemmini, lfsr, minimax, NyuziProcessor, sha3, all 6 liteeth variants
+- **sky130hd**: gemmini, lfsr, minimax, sha3, liteeth mac_axi_mii / mac_wb_mii / udp_stream_rgmii / udp_usp_gth_sgmii
+
+Not yet finishing (not cached):
+- **asap7**: cnn, floonoc, NyuziProcessor, snitch_cluster, bp_processor (bp_uno, bp_quad), NVDLA partitions c, p
+- **nangate45**: cnn, bp_processor (bp_uno, bp_quad)
+- **sky130hd**: cnn, liteeth udp_raw_rgmii, liteeth udp_stream_sgmii
+
+Use `tools/fetch_cache.sh` to pull cached `_final` results from the remote cache; designs marked NOT CACHED there are the not-yet-finishing set above.
 
 ### Output Directories
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,6 +1,6 @@
 """Shared Starlark helpers for HighTide design definitions."""
 
-load("@bazel-orfs//:openroad.bzl", "orfs_flow")
+load("@bazel-orfs//:openroad.bzl", "orfs_flow", "orfs_run")
 
 # PDK label mapping per platform
 PDKS = {
@@ -9,11 +9,29 @@ PDKS = {
     "sky130hd": "@orfs//flow:sky130hd",
 }
 
+def _gallery_image(name, src):
+    """Render a final-stage screenshot from a routed ODB.
+
+    Produces <name>.png via xvfb-run + OpenROAD GUI.
+    """
+    orfs_run(
+        name = name,
+        src = src,
+        outs = [name + ".png"],
+        arguments = {
+            "GALLERY_IMAGE": "$(location :" + name + ".png)",
+            "OR_ARGS": "-gui",
+        },
+        extra_args = "OPENROAD_CMD='xvfb-run -a $(OPENROAD_EXE) -exit $(OPENROAD_ARGS)'",
+        script = "//tools/gallery:final_image.tcl",
+    )
+
 def hightide_design(name, platform, verilog_files, top = None, arguments = {}, sources = {}, **kwargs):
     """Wraps orfs_flow with HighTide defaults.
 
-    Automatically sets GDS_ALLOW_EMPTY for FakeRAM and maps platform
-    names to PDK labels.
+    Automatically sets GDS_ALLOW_EMPTY for FakeRAM, maps platform
+    names to PDK labels, and emits a <name>_gallery target rendering
+    a final-stage screenshot from the routed ODB.
 
     Args:
         name: Base name for Bazel targets.
@@ -39,3 +57,8 @@ def hightide_design(name, platform, verilog_files, top = None, arguments = {}, s
     flow_kwargs.update(kwargs)
 
     orfs_flow(**flow_kwargs)
+
+    _gallery_image(
+        name = name + "_gallery",
+        src = ":" + name + "_final",
+    )

--- a/tools/gallery/BUILD.bazel
+++ b/tools/gallery/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["final_image.tcl"])

--- a/tools/gallery/collect_gallery.sh
+++ b/tools/gallery/collect_gallery.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Build all gallery images and copy them to a destination directory.
+#
+# Usage:
+#   tools/gallery/collect_gallery.sh [dest_dir]
+#
+# Default dest_dir is ../webpage/figures relative to the repo root.
+# Each image is renamed <leaf>_<platform>.png. Also generates JPEG
+# thumbnails under <dest_dir>/thumbs/ for the gallery page.
+
+set -euo pipefail
+
+dest_dir="${1:-../webpage/figures}"
+mkdir -p "$dest_dir"
+
+# Enumerate all *_gallery targets across designs and build them together.
+# --keep_going so a broken design doesn't block the rest.
+mapfile -t targets < <(bazel query 'filter(".*_gallery$", //designs/...)' 2>/dev/null)
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "No _gallery targets found under //designs/..." >&2
+    exit 1
+fi
+
+bazel build --keep_going "${targets[@]}" || true
+
+shopt -s globstar nullglob
+copied=0
+for img in bazel-bin/designs/**/*_gallery.png; do
+    rel="${img#bazel-bin/designs/}"
+    platform="${rel%%/*}"
+    rest="${rel#*/}"
+    pkg_dir=$(dirname "$rest")
+    leaf="${pkg_dir##*/}"
+    out="$dest_dir/${leaf}_${platform}.png"
+    if [[ -s "$img" ]]; then
+        cp -f "$img" "$out"
+        echo "  $out"
+        copied=$((copied + 1))
+    fi
+done
+
+echo "Copied $copied gallery images to $dest_dir"
+
+# Generate JPEG thumbnails for the gallery page.
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+python3 "$script_dir/make_thumbnails.py" "$dest_dir"

--- a/tools/gallery/final_image.tcl
+++ b/tools/gallery/final_image.tcl
@@ -1,0 +1,27 @@
+# Final-stage gallery screenshot for HighTide designs.
+# Mirrors bazel-orfs/gallery/scripts/route_image.tcl: routed view with
+# signal nets visible, power/ground hidden.
+
+read_db $::env(ODB_FILE)
+
+set block [ord::get_db_block]
+set bbox [$block getBBox]
+set xlo [ord::dbu_to_microns [$bbox xMin]]
+set ylo [ord::dbu_to_microns [$bbox yMin]]
+set xhi [ord::dbu_to_microns [$bbox xMax]]
+set yhi [ord::dbu_to_microns [$bbox yMax]]
+
+set width_um [expr {$xhi - $xlo}]
+set height_um [expr {$yhi - $ylo}]
+set width_px [expr {$width_um > $height_um ? 2000 : int(2000.0 * $width_um / $height_um)}]
+
+gui::clear_highlights -1
+gui::clear_selections
+
+gui::set_display_controls "Nets/Power" visible false
+gui::set_display_controls "Nets/Ground" visible false
+gui::set_display_controls "Nets/Signal" visible true
+gui::set_display_controls "Misc/Scale bar" visible true
+
+gui::fit
+save_image -area [list $xlo $ylo $xhi $yhi] -width $width_px $::env(GALLERY_IMAGE)

--- a/tools/gallery/make_thumbnails.py
+++ b/tools/gallery/make_thumbnails.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Generate JPEG thumbnails of full-resolution gallery PNGs.
+
+Usage:
+    make_thumbnails.py <src_dir> [--out-dir thumbs] [--max-px 400] [--quality 82]
+
+For each *.png in src_dir (excluding the thumbnail subdir and known
+non-design images), writes <stem>.jpg to src_dir/<out_dir>/.
+"""
+import argparse
+from pathlib import Path
+
+from PIL import Image
+
+EXCLUDE = {"HighTideFLOW.png", "lighthouse.png"}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("src_dir", type=Path)
+    p.add_argument("--out-dir", default="thumbs")
+    p.add_argument("--max-px", type=int, default=400)
+    p.add_argument("--quality", type=int, default=82)
+    args = p.parse_args()
+
+    out_dir = args.src_dir / args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    count = 0
+    for png in sorted(args.src_dir.glob("*.png")):
+        if png.name in EXCLUDE:
+            continue
+        with Image.open(png) as im:
+            im.thumbnail((args.max_px, args.max_px), Image.LANCZOS)
+            if im.mode in ("P", "LA"):
+                im = im.convert("RGBA")
+            if im.mode == "RGBA":
+                bg = Image.new("RGB", im.size, (0, 0, 0))
+                bg.paste(im, mask=im.split()[3])
+                im = bg
+            elif im.mode != "RGB":
+                im = im.convert("RGB")
+            out = out_dir / (png.stem + ".jpg")
+            im.save(out, "JPEG", quality=args.quality, optimize=True)
+        count += 1
+    print(f"Generated {count} thumbnails in {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- \`hightide_design()\` now emits a \`<name>_gallery\` target that renders the final-stage routed view via \`xvfb-run\` + OpenROAD GUI from the cached \`<name>_final\` ODB.
- New \`tools/gallery/\` directory with the screenshot Tcl, a collector script that copies PNGs to \`webpage/figures/\` and generates 400px JPEG thumbnails, and a Pillow-based thumbnailer.
- Updated CLAUDE.md platform table to reflect all current designs (NVDLA, coralnpu, vortex, sky130hd ports added 2026-04-26, etc.) and added a build-status section listing which designs reach \`_final\` on the remote cache vs. which don't yet.

## How it's used

After running \`tools/fetch_cache.sh\` to populate cached \`_final\` results, build galleries only for those designs (the gallery action itself takes <30s once \`_final\` is cached). \`tools/gallery/collect_gallery.sh\` automates this end-to-end: build, collect, thumbnail.

35 of 49 designs currently reach \`_final\` and produce a gallery PNG. The 14 not-yet-finishing ones (cnn on all platforms, floonoc, snitch_cluster, NVDLA partitions c/p, NyuziProcessor asap7, bp_processor, two sky130hd liteeth variants) are listed in CLAUDE.md.

## Test plan

- [x] Smoke test: \`bazel build //designs/sky130hd/lfsr:lfsr_gallery\` produces a valid 2000x2000 PNG of the routed view.
- [x] Full collection across cached designs: \`bazel build\` over all \`_gallery\` targets whose \`_final\` is cached succeeds (354 actions cache hit).
- [x] Thumbnail generator handles RGBA / palette / grayscale modes correctly.
- [ ] Requires \`xvfb-run\` on the build host — confirm K8s/CI image has it before relying on this in CI.