### PR TITLE
Add coralnpu (CoreMiniAxi) on sky130hd

### DIFF
--- a/designs/sky130hd/coralnpu/BUILD.bazel
+++ b/designs/sky130hd/coralnpu/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//:defs.bzl", "hightide_design")
+
+filegroup(
+    name = "sram_lefs",
+    srcs = glob(["sram/lef/*.lef"]),
+)
+
+filegroup(
+    name = "sram_libs",
+    srcs = glob(["sram/lib/*.lib"]),
+)
+
+hightide_design(
+    name = "coralnpu",
+    platform = "sky130hd",
+    top = "CoreMiniAxi",
+    verilog_files = ["//designs/src/coralnpu:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": [":sram_lefs"],
+        "ADDITIONAL_LIBS": [":sram_libs"],
+    },
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "CORE_UTILIZATION": "30",
+        "PLACE_DENSITY_LB_ADDON": "0.20",
+        "MACRO_PLACE_HALO": "30 30",
+        "TNS_END_PERCENT": "100",
+    },
+)

--- a/designs/sky130hd/coralnpu/BUILD.bazel
+++ b/designs/sky130hd/coralnpu/BUILD.bazel
@@ -22,9 +22,10 @@ hightide_design(
     },
     arguments = {
         "SYNTH_HIERARCHICAL": "1",
-        "CORE_UTILIZATION": "30",
-        "PLACE_DENSITY_LB_ADDON": "0.20",
+        "CORE_UTILIZATION": "20",
+        "PLACE_DENSITY": "0.15",
         "MACRO_PLACE_HALO": "30 30",
+        "ROUTING_LAYER_ADJUSTMENT": "0.25",
         "TNS_END_PERCENT": "100",
     },
 )

--- a/designs/sky130hd/coralnpu/config.mk
+++ b/designs/sky130hd/coralnpu/config.mk
@@ -1,0 +1,17 @@
+export DESIGN_NAME = CoreMiniAxi
+export PLATFORM    = sky130hd
+export DESIGN_NICKNAME = coralnpu
+export DESIGN_RESULTS_NAME = coralnpu
+
+-include $(BENCH_DESIGN_HOME)/src/coralnpu/verilog.mk
+
+export SYNTH_HIERARCHICAL = 1
+
+export SDC_FILE      = $(BENCH_DESIGN_HOME)/$(PLATFORM)/coralnpu/constraint.sdc
+
+export CORE_UTILIZATION = 30
+export PLACE_DENSITY_LB_ADDON = 0.20
+
+export MACRO_PLACE_HALO    = 30 30
+
+export TNS_END_PERCENT     = 100

--- a/designs/sky130hd/coralnpu/config.mk
+++ b/designs/sky130hd/coralnpu/config.mk
@@ -9,9 +9,11 @@ export SYNTH_HIERARCHICAL = 1
 
 export SDC_FILE      = $(BENCH_DESIGN_HOME)/$(PLATFORM)/coralnpu/constraint.sdc
 
-export CORE_UTILIZATION = 30
-export PLACE_DENSITY_LB_ADDON = 0.20
+export CORE_UTILIZATION = 20
+export PLACE_DENSITY = 0.15
 
 export MACRO_PLACE_HALO    = 30 30
+
+export ROUTING_LAYER_ADJUSTMENT = 0.25
 
 export TNS_END_PERCENT     = 100

--- a/designs/sky130hd/coralnpu/constraint.sdc
+++ b/designs/sky130hd/coralnpu/constraint.sdc
@@ -1,0 +1,18 @@
+current_design CoreMiniAxi
+
+set clk_name  io_aclk
+set clk_port_name io_aclk
+set clk_period 30
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set non_clock_outputs [lsearch -inline -all -not -exact [all_outputs] $clk_port]
+
+set_input_delay [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_false_path -from [get_ports io_aresetn]

--- a/designs/sky130hd/coralnpu/sram/lef/fakeram_2048x128_1rw.lef
+++ b/designs/sky130hd/coralnpu/sram/lef/fakeram_2048x128_1rw.lef
@@ -1,0 +1,4044 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_2048x128_1rw
+  FOREIGN fakeram_2048x128_1rw 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 7813.100 BY 304.640 ;
+  CLASS BLOCK ;
+  PIN rw0_wmask_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.930 0.900 4.230 ;
+    END
+  END rw0_wmask_in[0]
+  PIN rw0_wmask_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.010 0.900 8.310 ;
+    END
+  END rw0_wmask_in[1]
+  PIN rw0_wmask_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.090 0.900 12.390 ;
+    END
+  END rw0_wmask_in[2]
+  PIN rw0_wmask_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.170 0.900 16.470 ;
+    END
+  END rw0_wmask_in[3]
+  PIN rw0_wmask_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 3.930 7813.100 4.230 ;
+    END
+  END rw0_wmask_in[4]
+  PIN rw0_wmask_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 8.010 7813.100 8.310 ;
+    END
+  END rw0_wmask_in[5]
+  PIN rw0_wmask_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 12.090 7813.100 12.390 ;
+    END
+  END rw0_wmask_in[6]
+  PIN rw0_wmask_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 16.170 7813.100 16.470 ;
+    END
+  END rw0_wmask_in[7]
+  PIN rw0_wmask_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2.690 304.220 2.830 304.640 ;
+    END
+  END rw0_wmask_in[8]
+  PIN rw0_wmask_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 62.030 304.220 62.170 304.640 ;
+    END
+  END rw0_wmask_in[9]
+  PIN rw0_wmask_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 121.370 304.220 121.510 304.640 ;
+    END
+  END rw0_wmask_in[10]
+  PIN rw0_wmask_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 180.710 304.220 180.850 304.640 ;
+    END
+  END rw0_wmask_in[11]
+  PIN rw0_wmask_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 240.050 304.220 240.190 304.640 ;
+    END
+  END rw0_wmask_in[12]
+  PIN rw0_wmask_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 299.390 304.220 299.530 304.640 ;
+    END
+  END rw0_wmask_in[13]
+  PIN rw0_wmask_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 358.730 304.220 358.870 304.640 ;
+    END
+  END rw0_wmask_in[14]
+  PIN rw0_wmask_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 418.070 304.220 418.210 304.640 ;
+    END
+  END rw0_wmask_in[15]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.250 0.900 20.550 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.330 0.900 24.630 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.410 0.900 28.710 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.490 0.900 32.790 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.570 0.900 36.870 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.650 0.900 40.950 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.730 0.900 45.030 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.810 0.900 49.110 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.890 0.900 53.190 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.970 0.900 57.270 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.050 0.900 61.350 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.130 0.900 65.430 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.210 0.900 69.510 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.290 0.900 73.590 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.370 0.900 77.670 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.450 0.900 81.750 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.530 0.900 85.830 ;
+    END
+  END rw0_wd_in[16]
+  PIN rw0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.610 0.900 89.910 ;
+    END
+  END rw0_wd_in[17]
+  PIN rw0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.690 0.900 93.990 ;
+    END
+  END rw0_wd_in[18]
+  PIN rw0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.770 0.900 98.070 ;
+    END
+  END rw0_wd_in[19]
+  PIN rw0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.850 0.900 102.150 ;
+    END
+  END rw0_wd_in[20]
+  PIN rw0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.930 0.900 106.230 ;
+    END
+  END rw0_wd_in[21]
+  PIN rw0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.010 0.900 110.310 ;
+    END
+  END rw0_wd_in[22]
+  PIN rw0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.090 0.900 114.390 ;
+    END
+  END rw0_wd_in[23]
+  PIN rw0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.170 0.900 118.470 ;
+    END
+  END rw0_wd_in[24]
+  PIN rw0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.250 0.900 122.550 ;
+    END
+  END rw0_wd_in[25]
+  PIN rw0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.330 0.900 126.630 ;
+    END
+  END rw0_wd_in[26]
+  PIN rw0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.410 0.900 130.710 ;
+    END
+  END rw0_wd_in[27]
+  PIN rw0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 134.490 0.900 134.790 ;
+    END
+  END rw0_wd_in[28]
+  PIN rw0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.570 0.900 138.870 ;
+    END
+  END rw0_wd_in[29]
+  PIN rw0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 142.650 0.900 142.950 ;
+    END
+  END rw0_wd_in[30]
+  PIN rw0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 146.730 0.900 147.030 ;
+    END
+  END rw0_wd_in[31]
+  PIN rw0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 20.250 7813.100 20.550 ;
+    END
+  END rw0_wd_in[32]
+  PIN rw0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 24.330 7813.100 24.630 ;
+    END
+  END rw0_wd_in[33]
+  PIN rw0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 28.410 7813.100 28.710 ;
+    END
+  END rw0_wd_in[34]
+  PIN rw0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 32.490 7813.100 32.790 ;
+    END
+  END rw0_wd_in[35]
+  PIN rw0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 36.570 7813.100 36.870 ;
+    END
+  END rw0_wd_in[36]
+  PIN rw0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 40.650 7813.100 40.950 ;
+    END
+  END rw0_wd_in[37]
+  PIN rw0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 44.730 7813.100 45.030 ;
+    END
+  END rw0_wd_in[38]
+  PIN rw0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 48.810 7813.100 49.110 ;
+    END
+  END rw0_wd_in[39]
+  PIN rw0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 52.890 7813.100 53.190 ;
+    END
+  END rw0_wd_in[40]
+  PIN rw0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 56.970 7813.100 57.270 ;
+    END
+  END rw0_wd_in[41]
+  PIN rw0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 61.050 7813.100 61.350 ;
+    END
+  END rw0_wd_in[42]
+  PIN rw0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 65.130 7813.100 65.430 ;
+    END
+  END rw0_wd_in[43]
+  PIN rw0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 69.210 7813.100 69.510 ;
+    END
+  END rw0_wd_in[44]
+  PIN rw0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 73.290 7813.100 73.590 ;
+    END
+  END rw0_wd_in[45]
+  PIN rw0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 77.370 7813.100 77.670 ;
+    END
+  END rw0_wd_in[46]
+  PIN rw0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 81.450 7813.100 81.750 ;
+    END
+  END rw0_wd_in[47]
+  PIN rw0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 85.530 7813.100 85.830 ;
+    END
+  END rw0_wd_in[48]
+  PIN rw0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 89.610 7813.100 89.910 ;
+    END
+  END rw0_wd_in[49]
+  PIN rw0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 93.690 7813.100 93.990 ;
+    END
+  END rw0_wd_in[50]
+  PIN rw0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 97.770 7813.100 98.070 ;
+    END
+  END rw0_wd_in[51]
+  PIN rw0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 101.850 7813.100 102.150 ;
+    END
+  END rw0_wd_in[52]
+  PIN rw0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 105.930 7813.100 106.230 ;
+    END
+  END rw0_wd_in[53]
+  PIN rw0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 110.010 7813.100 110.310 ;
+    END
+  END rw0_wd_in[54]
+  PIN rw0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 114.090 7813.100 114.390 ;
+    END
+  END rw0_wd_in[55]
+  PIN rw0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 118.170 7813.100 118.470 ;
+    END
+  END rw0_wd_in[56]
+  PIN rw0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 122.250 7813.100 122.550 ;
+    END
+  END rw0_wd_in[57]
+  PIN rw0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 126.330 7813.100 126.630 ;
+    END
+  END rw0_wd_in[58]
+  PIN rw0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 130.410 7813.100 130.710 ;
+    END
+  END rw0_wd_in[59]
+  PIN rw0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 134.490 7813.100 134.790 ;
+    END
+  END rw0_wd_in[60]
+  PIN rw0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 138.570 7813.100 138.870 ;
+    END
+  END rw0_wd_in[61]
+  PIN rw0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 142.650 7813.100 142.950 ;
+    END
+  END rw0_wd_in[62]
+  PIN rw0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 146.730 7813.100 147.030 ;
+    END
+  END rw0_wd_in[63]
+  PIN rw0_wd_in[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2.690 0.000 2.830 0.420 ;
+    END
+  END rw0_wd_in[64]
+  PIN rw0_wd_in[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 63.410 0.000 63.550 0.420 ;
+    END
+  END rw0_wd_in[65]
+  PIN rw0_wd_in[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 124.130 0.000 124.270 0.420 ;
+    END
+  END rw0_wd_in[66]
+  PIN rw0_wd_in[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 184.850 0.000 184.990 0.420 ;
+    END
+  END rw0_wd_in[67]
+  PIN rw0_wd_in[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 245.570 0.000 245.710 0.420 ;
+    END
+  END rw0_wd_in[68]
+  PIN rw0_wd_in[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 306.290 0.000 306.430 0.420 ;
+    END
+  END rw0_wd_in[69]
+  PIN rw0_wd_in[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 367.010 0.000 367.150 0.420 ;
+    END
+  END rw0_wd_in[70]
+  PIN rw0_wd_in[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 427.730 0.000 427.870 0.420 ;
+    END
+  END rw0_wd_in[71]
+  PIN rw0_wd_in[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 488.450 0.000 488.590 0.420 ;
+    END
+  END rw0_wd_in[72]
+  PIN rw0_wd_in[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 549.170 0.000 549.310 0.420 ;
+    END
+  END rw0_wd_in[73]
+  PIN rw0_wd_in[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 609.890 0.000 610.030 0.420 ;
+    END
+  END rw0_wd_in[74]
+  PIN rw0_wd_in[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 670.610 0.000 670.750 0.420 ;
+    END
+  END rw0_wd_in[75]
+  PIN rw0_wd_in[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 731.330 0.000 731.470 0.420 ;
+    END
+  END rw0_wd_in[76]
+  PIN rw0_wd_in[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 792.050 0.000 792.190 0.420 ;
+    END
+  END rw0_wd_in[77]
+  PIN rw0_wd_in[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 852.770 0.000 852.910 0.420 ;
+    END
+  END rw0_wd_in[78]
+  PIN rw0_wd_in[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 913.490 0.000 913.630 0.420 ;
+    END
+  END rw0_wd_in[79]
+  PIN rw0_wd_in[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 974.210 0.000 974.350 0.420 ;
+    END
+  END rw0_wd_in[80]
+  PIN rw0_wd_in[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1034.930 0.000 1035.070 0.420 ;
+    END
+  END rw0_wd_in[81]
+  PIN rw0_wd_in[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1095.650 0.000 1095.790 0.420 ;
+    END
+  END rw0_wd_in[82]
+  PIN rw0_wd_in[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1156.370 0.000 1156.510 0.420 ;
+    END
+  END rw0_wd_in[83]
+  PIN rw0_wd_in[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1217.090 0.000 1217.230 0.420 ;
+    END
+  END rw0_wd_in[84]
+  PIN rw0_wd_in[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1277.810 0.000 1277.950 0.420 ;
+    END
+  END rw0_wd_in[85]
+  PIN rw0_wd_in[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1338.530 0.000 1338.670 0.420 ;
+    END
+  END rw0_wd_in[86]
+  PIN rw0_wd_in[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1399.250 0.000 1399.390 0.420 ;
+    END
+  END rw0_wd_in[87]
+  PIN rw0_wd_in[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1459.970 0.000 1460.110 0.420 ;
+    END
+  END rw0_wd_in[88]
+  PIN rw0_wd_in[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1520.690 0.000 1520.830 0.420 ;
+    END
+  END rw0_wd_in[89]
+  PIN rw0_wd_in[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1581.410 0.000 1581.550 0.420 ;
+    END
+  END rw0_wd_in[90]
+  PIN rw0_wd_in[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1642.130 0.000 1642.270 0.420 ;
+    END
+  END rw0_wd_in[91]
+  PIN rw0_wd_in[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1702.850 0.000 1702.990 0.420 ;
+    END
+  END rw0_wd_in[92]
+  PIN rw0_wd_in[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1763.570 0.000 1763.710 0.420 ;
+    END
+  END rw0_wd_in[93]
+  PIN rw0_wd_in[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1824.290 0.000 1824.430 0.420 ;
+    END
+  END rw0_wd_in[94]
+  PIN rw0_wd_in[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1885.010 0.000 1885.150 0.420 ;
+    END
+  END rw0_wd_in[95]
+  PIN rw0_wd_in[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1945.730 0.000 1945.870 0.420 ;
+    END
+  END rw0_wd_in[96]
+  PIN rw0_wd_in[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2006.450 0.000 2006.590 0.420 ;
+    END
+  END rw0_wd_in[97]
+  PIN rw0_wd_in[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2067.170 0.000 2067.310 0.420 ;
+    END
+  END rw0_wd_in[98]
+  PIN rw0_wd_in[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2127.890 0.000 2128.030 0.420 ;
+    END
+  END rw0_wd_in[99]
+  PIN rw0_wd_in[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2188.610 0.000 2188.750 0.420 ;
+    END
+  END rw0_wd_in[100]
+  PIN rw0_wd_in[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2249.330 0.000 2249.470 0.420 ;
+    END
+  END rw0_wd_in[101]
+  PIN rw0_wd_in[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2310.050 0.000 2310.190 0.420 ;
+    END
+  END rw0_wd_in[102]
+  PIN rw0_wd_in[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2370.770 0.000 2370.910 0.420 ;
+    END
+  END rw0_wd_in[103]
+  PIN rw0_wd_in[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2431.490 0.000 2431.630 0.420 ;
+    END
+  END rw0_wd_in[104]
+  PIN rw0_wd_in[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2492.210 0.000 2492.350 0.420 ;
+    END
+  END rw0_wd_in[105]
+  PIN rw0_wd_in[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2552.930 0.000 2553.070 0.420 ;
+    END
+  END rw0_wd_in[106]
+  PIN rw0_wd_in[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2613.650 0.000 2613.790 0.420 ;
+    END
+  END rw0_wd_in[107]
+  PIN rw0_wd_in[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2674.370 0.000 2674.510 0.420 ;
+    END
+  END rw0_wd_in[108]
+  PIN rw0_wd_in[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2735.090 0.000 2735.230 0.420 ;
+    END
+  END rw0_wd_in[109]
+  PIN rw0_wd_in[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2795.810 0.000 2795.950 0.420 ;
+    END
+  END rw0_wd_in[110]
+  PIN rw0_wd_in[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2856.530 0.000 2856.670 0.420 ;
+    END
+  END rw0_wd_in[111]
+  PIN rw0_wd_in[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2917.250 0.000 2917.390 0.420 ;
+    END
+  END rw0_wd_in[112]
+  PIN rw0_wd_in[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2977.970 0.000 2978.110 0.420 ;
+    END
+  END rw0_wd_in[113]
+  PIN rw0_wd_in[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3038.690 0.000 3038.830 0.420 ;
+    END
+  END rw0_wd_in[114]
+  PIN rw0_wd_in[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3099.410 0.000 3099.550 0.420 ;
+    END
+  END rw0_wd_in[115]
+  PIN rw0_wd_in[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3160.130 0.000 3160.270 0.420 ;
+    END
+  END rw0_wd_in[116]
+  PIN rw0_wd_in[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3220.850 0.000 3220.990 0.420 ;
+    END
+  END rw0_wd_in[117]
+  PIN rw0_wd_in[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3281.570 0.000 3281.710 0.420 ;
+    END
+  END rw0_wd_in[118]
+  PIN rw0_wd_in[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3342.290 0.000 3342.430 0.420 ;
+    END
+  END rw0_wd_in[119]
+  PIN rw0_wd_in[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3403.010 0.000 3403.150 0.420 ;
+    END
+  END rw0_wd_in[120]
+  PIN rw0_wd_in[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3463.730 0.000 3463.870 0.420 ;
+    END
+  END rw0_wd_in[121]
+  PIN rw0_wd_in[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3524.450 0.000 3524.590 0.420 ;
+    END
+  END rw0_wd_in[122]
+  PIN rw0_wd_in[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3585.170 0.000 3585.310 0.420 ;
+    END
+  END rw0_wd_in[123]
+  PIN rw0_wd_in[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3645.890 0.000 3646.030 0.420 ;
+    END
+  END rw0_wd_in[124]
+  PIN rw0_wd_in[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3706.610 0.000 3706.750 0.420 ;
+    END
+  END rw0_wd_in[125]
+  PIN rw0_wd_in[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3767.330 0.000 3767.470 0.420 ;
+    END
+  END rw0_wd_in[126]
+  PIN rw0_wd_in[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3828.050 0.000 3828.190 0.420 ;
+    END
+  END rw0_wd_in[127]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3888.770 0.000 3888.910 0.420 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3949.490 0.000 3949.630 0.420 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4010.210 0.000 4010.350 0.420 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4070.930 0.000 4071.070 0.420 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4131.650 0.000 4131.790 0.420 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4192.370 0.000 4192.510 0.420 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4253.090 0.000 4253.230 0.420 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4313.810 0.000 4313.950 0.420 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4374.530 0.000 4374.670 0.420 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4435.250 0.000 4435.390 0.420 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4495.970 0.000 4496.110 0.420 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4556.690 0.000 4556.830 0.420 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4617.410 0.000 4617.550 0.420 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4678.130 0.000 4678.270 0.420 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4738.850 0.000 4738.990 0.420 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4799.570 0.000 4799.710 0.420 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4860.290 0.000 4860.430 0.420 ;
+    END
+  END rw0_rd_out[16]
+  PIN rw0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4921.010 0.000 4921.150 0.420 ;
+    END
+  END rw0_rd_out[17]
+  PIN rw0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4981.730 0.000 4981.870 0.420 ;
+    END
+  END rw0_rd_out[18]
+  PIN rw0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5042.450 0.000 5042.590 0.420 ;
+    END
+  END rw0_rd_out[19]
+  PIN rw0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5103.170 0.000 5103.310 0.420 ;
+    END
+  END rw0_rd_out[20]
+  PIN rw0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5163.890 0.000 5164.030 0.420 ;
+    END
+  END rw0_rd_out[21]
+  PIN rw0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5224.610 0.000 5224.750 0.420 ;
+    END
+  END rw0_rd_out[22]
+  PIN rw0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5285.330 0.000 5285.470 0.420 ;
+    END
+  END rw0_rd_out[23]
+  PIN rw0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5346.050 0.000 5346.190 0.420 ;
+    END
+  END rw0_rd_out[24]
+  PIN rw0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5406.770 0.000 5406.910 0.420 ;
+    END
+  END rw0_rd_out[25]
+  PIN rw0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5467.490 0.000 5467.630 0.420 ;
+    END
+  END rw0_rd_out[26]
+  PIN rw0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5528.210 0.000 5528.350 0.420 ;
+    END
+  END rw0_rd_out[27]
+  PIN rw0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5588.930 0.000 5589.070 0.420 ;
+    END
+  END rw0_rd_out[28]
+  PIN rw0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5649.650 0.000 5649.790 0.420 ;
+    END
+  END rw0_rd_out[29]
+  PIN rw0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5710.370 0.000 5710.510 0.420 ;
+    END
+  END rw0_rd_out[30]
+  PIN rw0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5771.090 0.000 5771.230 0.420 ;
+    END
+  END rw0_rd_out[31]
+  PIN rw0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5831.810 0.000 5831.950 0.420 ;
+    END
+  END rw0_rd_out[32]
+  PIN rw0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5892.530 0.000 5892.670 0.420 ;
+    END
+  END rw0_rd_out[33]
+  PIN rw0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 5953.250 0.000 5953.390 0.420 ;
+    END
+  END rw0_rd_out[34]
+  PIN rw0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6013.970 0.000 6014.110 0.420 ;
+    END
+  END rw0_rd_out[35]
+  PIN rw0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6074.690 0.000 6074.830 0.420 ;
+    END
+  END rw0_rd_out[36]
+  PIN rw0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6135.410 0.000 6135.550 0.420 ;
+    END
+  END rw0_rd_out[37]
+  PIN rw0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6196.130 0.000 6196.270 0.420 ;
+    END
+  END rw0_rd_out[38]
+  PIN rw0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6256.850 0.000 6256.990 0.420 ;
+    END
+  END rw0_rd_out[39]
+  PIN rw0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6317.570 0.000 6317.710 0.420 ;
+    END
+  END rw0_rd_out[40]
+  PIN rw0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6378.290 0.000 6378.430 0.420 ;
+    END
+  END rw0_rd_out[41]
+  PIN rw0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6439.010 0.000 6439.150 0.420 ;
+    END
+  END rw0_rd_out[42]
+  PIN rw0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6499.730 0.000 6499.870 0.420 ;
+    END
+  END rw0_rd_out[43]
+  PIN rw0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6560.450 0.000 6560.590 0.420 ;
+    END
+  END rw0_rd_out[44]
+  PIN rw0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6621.170 0.000 6621.310 0.420 ;
+    END
+  END rw0_rd_out[45]
+  PIN rw0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6681.890 0.000 6682.030 0.420 ;
+    END
+  END rw0_rd_out[46]
+  PIN rw0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6742.610 0.000 6742.750 0.420 ;
+    END
+  END rw0_rd_out[47]
+  PIN rw0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6803.330 0.000 6803.470 0.420 ;
+    END
+  END rw0_rd_out[48]
+  PIN rw0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6864.050 0.000 6864.190 0.420 ;
+    END
+  END rw0_rd_out[49]
+  PIN rw0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6924.770 0.000 6924.910 0.420 ;
+    END
+  END rw0_rd_out[50]
+  PIN rw0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6985.490 0.000 6985.630 0.420 ;
+    END
+  END rw0_rd_out[51]
+  PIN rw0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7046.210 0.000 7046.350 0.420 ;
+    END
+  END rw0_rd_out[52]
+  PIN rw0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7106.930 0.000 7107.070 0.420 ;
+    END
+  END rw0_rd_out[53]
+  PIN rw0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7167.650 0.000 7167.790 0.420 ;
+    END
+  END rw0_rd_out[54]
+  PIN rw0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7228.370 0.000 7228.510 0.420 ;
+    END
+  END rw0_rd_out[55]
+  PIN rw0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7289.090 0.000 7289.230 0.420 ;
+    END
+  END rw0_rd_out[56]
+  PIN rw0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7349.810 0.000 7349.950 0.420 ;
+    END
+  END rw0_rd_out[57]
+  PIN rw0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7410.530 0.000 7410.670 0.420 ;
+    END
+  END rw0_rd_out[58]
+  PIN rw0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7471.250 0.000 7471.390 0.420 ;
+    END
+  END rw0_rd_out[59]
+  PIN rw0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7531.970 0.000 7532.110 0.420 ;
+    END
+  END rw0_rd_out[60]
+  PIN rw0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7592.690 0.000 7592.830 0.420 ;
+    END
+  END rw0_rd_out[61]
+  PIN rw0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7653.410 0.000 7653.550 0.420 ;
+    END
+  END rw0_rd_out[62]
+  PIN rw0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7714.130 0.000 7714.270 0.420 ;
+    END
+  END rw0_rd_out[63]
+  PIN rw0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 477.410 304.220 477.550 304.640 ;
+    END
+  END rw0_rd_out[64]
+  PIN rw0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 536.750 304.220 536.890 304.640 ;
+    END
+  END rw0_rd_out[65]
+  PIN rw0_rd_out[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 596.090 304.220 596.230 304.640 ;
+    END
+  END rw0_rd_out[66]
+  PIN rw0_rd_out[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 655.430 304.220 655.570 304.640 ;
+    END
+  END rw0_rd_out[67]
+  PIN rw0_rd_out[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 714.770 304.220 714.910 304.640 ;
+    END
+  END rw0_rd_out[68]
+  PIN rw0_rd_out[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 774.110 304.220 774.250 304.640 ;
+    END
+  END rw0_rd_out[69]
+  PIN rw0_rd_out[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 833.450 304.220 833.590 304.640 ;
+    END
+  END rw0_rd_out[70]
+  PIN rw0_rd_out[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 892.790 304.220 892.930 304.640 ;
+    END
+  END rw0_rd_out[71]
+  PIN rw0_rd_out[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 952.130 304.220 952.270 304.640 ;
+    END
+  END rw0_rd_out[72]
+  PIN rw0_rd_out[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1011.470 304.220 1011.610 304.640 ;
+    END
+  END rw0_rd_out[73]
+  PIN rw0_rd_out[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1070.810 304.220 1070.950 304.640 ;
+    END
+  END rw0_rd_out[74]
+  PIN rw0_rd_out[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1130.150 304.220 1130.290 304.640 ;
+    END
+  END rw0_rd_out[75]
+  PIN rw0_rd_out[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1189.490 304.220 1189.630 304.640 ;
+    END
+  END rw0_rd_out[76]
+  PIN rw0_rd_out[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1248.830 304.220 1248.970 304.640 ;
+    END
+  END rw0_rd_out[77]
+  PIN rw0_rd_out[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1308.170 304.220 1308.310 304.640 ;
+    END
+  END rw0_rd_out[78]
+  PIN rw0_rd_out[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1367.510 304.220 1367.650 304.640 ;
+    END
+  END rw0_rd_out[79]
+  PIN rw0_rd_out[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1426.850 304.220 1426.990 304.640 ;
+    END
+  END rw0_rd_out[80]
+  PIN rw0_rd_out[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1486.190 304.220 1486.330 304.640 ;
+    END
+  END rw0_rd_out[81]
+  PIN rw0_rd_out[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1545.530 304.220 1545.670 304.640 ;
+    END
+  END rw0_rd_out[82]
+  PIN rw0_rd_out[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1604.870 304.220 1605.010 304.640 ;
+    END
+  END rw0_rd_out[83]
+  PIN rw0_rd_out[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1664.210 304.220 1664.350 304.640 ;
+    END
+  END rw0_rd_out[84]
+  PIN rw0_rd_out[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1723.550 304.220 1723.690 304.640 ;
+    END
+  END rw0_rd_out[85]
+  PIN rw0_rd_out[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1782.890 304.220 1783.030 304.640 ;
+    END
+  END rw0_rd_out[86]
+  PIN rw0_rd_out[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1842.230 304.220 1842.370 304.640 ;
+    END
+  END rw0_rd_out[87]
+  PIN rw0_rd_out[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1901.570 304.220 1901.710 304.640 ;
+    END
+  END rw0_rd_out[88]
+  PIN rw0_rd_out[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 1960.910 304.220 1961.050 304.640 ;
+    END
+  END rw0_rd_out[89]
+  PIN rw0_rd_out[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2020.250 304.220 2020.390 304.640 ;
+    END
+  END rw0_rd_out[90]
+  PIN rw0_rd_out[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2079.590 304.220 2079.730 304.640 ;
+    END
+  END rw0_rd_out[91]
+  PIN rw0_rd_out[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2138.930 304.220 2139.070 304.640 ;
+    END
+  END rw0_rd_out[92]
+  PIN rw0_rd_out[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2198.270 304.220 2198.410 304.640 ;
+    END
+  END rw0_rd_out[93]
+  PIN rw0_rd_out[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2257.610 304.220 2257.750 304.640 ;
+    END
+  END rw0_rd_out[94]
+  PIN rw0_rd_out[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2316.950 304.220 2317.090 304.640 ;
+    END
+  END rw0_rd_out[95]
+  PIN rw0_rd_out[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2376.290 304.220 2376.430 304.640 ;
+    END
+  END rw0_rd_out[96]
+  PIN rw0_rd_out[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2435.630 304.220 2435.770 304.640 ;
+    END
+  END rw0_rd_out[97]
+  PIN rw0_rd_out[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2494.970 304.220 2495.110 304.640 ;
+    END
+  END rw0_rd_out[98]
+  PIN rw0_rd_out[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2554.310 304.220 2554.450 304.640 ;
+    END
+  END rw0_rd_out[99]
+  PIN rw0_rd_out[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2613.650 304.220 2613.790 304.640 ;
+    END
+  END rw0_rd_out[100]
+  PIN rw0_rd_out[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2672.990 304.220 2673.130 304.640 ;
+    END
+  END rw0_rd_out[101]
+  PIN rw0_rd_out[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2732.330 304.220 2732.470 304.640 ;
+    END
+  END rw0_rd_out[102]
+  PIN rw0_rd_out[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2791.670 304.220 2791.810 304.640 ;
+    END
+  END rw0_rd_out[103]
+  PIN rw0_rd_out[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2851.010 304.220 2851.150 304.640 ;
+    END
+  END rw0_rd_out[104]
+  PIN rw0_rd_out[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2910.350 304.220 2910.490 304.640 ;
+    END
+  END rw0_rd_out[105]
+  PIN rw0_rd_out[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2969.690 304.220 2969.830 304.640 ;
+    END
+  END rw0_rd_out[106]
+  PIN rw0_rd_out[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3029.030 304.220 3029.170 304.640 ;
+    END
+  END rw0_rd_out[107]
+  PIN rw0_rd_out[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3088.370 304.220 3088.510 304.640 ;
+    END
+  END rw0_rd_out[108]
+  PIN rw0_rd_out[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3147.710 304.220 3147.850 304.640 ;
+    END
+  END rw0_rd_out[109]
+  PIN rw0_rd_out[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3207.050 304.220 3207.190 304.640 ;
+    END
+  END rw0_rd_out[110]
+  PIN rw0_rd_out[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3266.390 304.220 3266.530 304.640 ;
+    END
+  END rw0_rd_out[111]
+  PIN rw0_rd_out[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3325.730 304.220 3325.870 304.640 ;
+    END
+  END rw0_rd_out[112]
+  PIN rw0_rd_out[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3385.070 304.220 3385.210 304.640 ;
+    END
+  END rw0_rd_out[113]
+  PIN rw0_rd_out[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3444.410 304.220 3444.550 304.640 ;
+    END
+  END rw0_rd_out[114]
+  PIN rw0_rd_out[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3503.750 304.220 3503.890 304.640 ;
+    END
+  END rw0_rd_out[115]
+  PIN rw0_rd_out[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3563.090 304.220 3563.230 304.640 ;
+    END
+  END rw0_rd_out[116]
+  PIN rw0_rd_out[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3622.430 304.220 3622.570 304.640 ;
+    END
+  END rw0_rd_out[117]
+  PIN rw0_rd_out[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3681.770 304.220 3681.910 304.640 ;
+    END
+  END rw0_rd_out[118]
+  PIN rw0_rd_out[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3741.110 304.220 3741.250 304.640 ;
+    END
+  END rw0_rd_out[119]
+  PIN rw0_rd_out[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3800.450 304.220 3800.590 304.640 ;
+    END
+  END rw0_rd_out[120]
+  PIN rw0_rd_out[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3859.790 304.220 3859.930 304.640 ;
+    END
+  END rw0_rd_out[121]
+  PIN rw0_rd_out[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3919.130 304.220 3919.270 304.640 ;
+    END
+  END rw0_rd_out[122]
+  PIN rw0_rd_out[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 3978.470 304.220 3978.610 304.640 ;
+    END
+  END rw0_rd_out[123]
+  PIN rw0_rd_out[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4037.810 304.220 4037.950 304.640 ;
+    END
+  END rw0_rd_out[124]
+  PIN rw0_rd_out[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4097.150 304.220 4097.290 304.640 ;
+    END
+  END rw0_rd_out[125]
+  PIN rw0_rd_out[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4156.490 304.220 4156.630 304.640 ;
+    END
+  END rw0_rd_out[126]
+  PIN rw0_rd_out[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4215.830 304.220 4215.970 304.640 ;
+    END
+  END rw0_rd_out[127]
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 150.810 0.900 151.110 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 154.890 0.900 155.190 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 158.970 0.900 159.270 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 163.050 0.900 163.350 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 167.130 0.900 167.430 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 171.210 0.900 171.510 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 150.810 7813.100 151.110 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 154.890 7813.100 155.190 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 158.970 7813.100 159.270 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_addr_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 163.050 7813.100 163.350 ;
+    END
+  END rw0_addr_in[9]
+  PIN rw0_addr_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 7812.200 167.130 7813.100 167.430 ;
+    END
+  END rw0_addr_in[10]
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4275.170 304.220 4275.310 304.640 ;
+    END
+  END rw0_we_in
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4334.510 304.220 4334.650 304.640 ;
+    END
+  END rw0_ce_in
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 4393.850 304.220 4393.990 304.640 ;
+    END
+  END rw0_clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 2.160 4.080 3.360 300.560 ;
+      RECT 13.040 4.080 14.240 300.560 ;
+      RECT 23.920 4.080 25.120 300.560 ;
+      RECT 34.800 4.080 36.000 300.560 ;
+      RECT 45.680 4.080 46.880 300.560 ;
+      RECT 56.560 4.080 57.760 300.560 ;
+      RECT 67.440 4.080 68.640 300.560 ;
+      RECT 78.320 4.080 79.520 300.560 ;
+      RECT 89.200 4.080 90.400 300.560 ;
+      RECT 100.080 4.080 101.280 300.560 ;
+      RECT 110.960 4.080 112.160 300.560 ;
+      RECT 121.840 4.080 123.040 300.560 ;
+      RECT 132.720 4.080 133.920 300.560 ;
+      RECT 143.600 4.080 144.800 300.560 ;
+      RECT 154.480 4.080 155.680 300.560 ;
+      RECT 165.360 4.080 166.560 300.560 ;
+      RECT 176.240 4.080 177.440 300.560 ;
+      RECT 187.120 4.080 188.320 300.560 ;
+      RECT 198.000 4.080 199.200 300.560 ;
+      RECT 208.880 4.080 210.080 300.560 ;
+      RECT 219.760 4.080 220.960 300.560 ;
+      RECT 230.640 4.080 231.840 300.560 ;
+      RECT 241.520 4.080 242.720 300.560 ;
+      RECT 252.400 4.080 253.600 300.560 ;
+      RECT 263.280 4.080 264.480 300.560 ;
+      RECT 274.160 4.080 275.360 300.560 ;
+      RECT 285.040 4.080 286.240 300.560 ;
+      RECT 295.920 4.080 297.120 300.560 ;
+      RECT 306.800 4.080 308.000 300.560 ;
+      RECT 317.680 4.080 318.880 300.560 ;
+      RECT 328.560 4.080 329.760 300.560 ;
+      RECT 339.440 4.080 340.640 300.560 ;
+      RECT 350.320 4.080 351.520 300.560 ;
+      RECT 361.200 4.080 362.400 300.560 ;
+      RECT 372.080 4.080 373.280 300.560 ;
+      RECT 382.960 4.080 384.160 300.560 ;
+      RECT 393.840 4.080 395.040 300.560 ;
+      RECT 404.720 4.080 405.920 300.560 ;
+      RECT 415.600 4.080 416.800 300.560 ;
+      RECT 426.480 4.080 427.680 300.560 ;
+      RECT 437.360 4.080 438.560 300.560 ;
+      RECT 448.240 4.080 449.440 300.560 ;
+      RECT 459.120 4.080 460.320 300.560 ;
+      RECT 470.000 4.080 471.200 300.560 ;
+      RECT 480.880 4.080 482.080 300.560 ;
+      RECT 491.760 4.080 492.960 300.560 ;
+      RECT 502.640 4.080 503.840 300.560 ;
+      RECT 513.520 4.080 514.720 300.560 ;
+      RECT 524.400 4.080 525.600 300.560 ;
+      RECT 535.280 4.080 536.480 300.560 ;
+      RECT 546.160 4.080 547.360 300.560 ;
+      RECT 557.040 4.080 558.240 300.560 ;
+      RECT 567.920 4.080 569.120 300.560 ;
+      RECT 578.800 4.080 580.000 300.560 ;
+      RECT 589.680 4.080 590.880 300.560 ;
+      RECT 600.560 4.080 601.760 300.560 ;
+      RECT 611.440 4.080 612.640 300.560 ;
+      RECT 622.320 4.080 623.520 300.560 ;
+      RECT 633.200 4.080 634.400 300.560 ;
+      RECT 644.080 4.080 645.280 300.560 ;
+      RECT 654.960 4.080 656.160 300.560 ;
+      RECT 665.840 4.080 667.040 300.560 ;
+      RECT 676.720 4.080 677.920 300.560 ;
+      RECT 687.600 4.080 688.800 300.560 ;
+      RECT 698.480 4.080 699.680 300.560 ;
+      RECT 709.360 4.080 710.560 300.560 ;
+      RECT 720.240 4.080 721.440 300.560 ;
+      RECT 731.120 4.080 732.320 300.560 ;
+      RECT 742.000 4.080 743.200 300.560 ;
+      RECT 752.880 4.080 754.080 300.560 ;
+      RECT 763.760 4.080 764.960 300.560 ;
+      RECT 774.640 4.080 775.840 300.560 ;
+      RECT 785.520 4.080 786.720 300.560 ;
+      RECT 796.400 4.080 797.600 300.560 ;
+      RECT 807.280 4.080 808.480 300.560 ;
+      RECT 818.160 4.080 819.360 300.560 ;
+      RECT 829.040 4.080 830.240 300.560 ;
+      RECT 839.920 4.080 841.120 300.560 ;
+      RECT 850.800 4.080 852.000 300.560 ;
+      RECT 861.680 4.080 862.880 300.560 ;
+      RECT 872.560 4.080 873.760 300.560 ;
+      RECT 883.440 4.080 884.640 300.560 ;
+      RECT 894.320 4.080 895.520 300.560 ;
+      RECT 905.200 4.080 906.400 300.560 ;
+      RECT 916.080 4.080 917.280 300.560 ;
+      RECT 926.960 4.080 928.160 300.560 ;
+      RECT 937.840 4.080 939.040 300.560 ;
+      RECT 948.720 4.080 949.920 300.560 ;
+      RECT 959.600 4.080 960.800 300.560 ;
+      RECT 970.480 4.080 971.680 300.560 ;
+      RECT 981.360 4.080 982.560 300.560 ;
+      RECT 992.240 4.080 993.440 300.560 ;
+      RECT 1003.120 4.080 1004.320 300.560 ;
+      RECT 1014.000 4.080 1015.200 300.560 ;
+      RECT 1024.880 4.080 1026.080 300.560 ;
+      RECT 1035.760 4.080 1036.960 300.560 ;
+      RECT 1046.640 4.080 1047.840 300.560 ;
+      RECT 1057.520 4.080 1058.720 300.560 ;
+      RECT 1068.400 4.080 1069.600 300.560 ;
+      RECT 1079.280 4.080 1080.480 300.560 ;
+      RECT 1090.160 4.080 1091.360 300.560 ;
+      RECT 1101.040 4.080 1102.240 300.560 ;
+      RECT 1111.920 4.080 1113.120 300.560 ;
+      RECT 1122.800 4.080 1124.000 300.560 ;
+      RECT 1133.680 4.080 1134.880 300.560 ;
+      RECT 1144.560 4.080 1145.760 300.560 ;
+      RECT 1155.440 4.080 1156.640 300.560 ;
+      RECT 1166.320 4.080 1167.520 300.560 ;
+      RECT 1177.200 4.080 1178.400 300.560 ;
+      RECT 1188.080 4.080 1189.280 300.560 ;
+      RECT 1198.960 4.080 1200.160 300.560 ;
+      RECT 1209.840 4.080 1211.040 300.560 ;
+      RECT 1220.720 4.080 1221.920 300.560 ;
+      RECT 1231.600 4.080 1232.800 300.560 ;
+      RECT 1242.480 4.080 1243.680 300.560 ;
+      RECT 1253.360 4.080 1254.560 300.560 ;
+      RECT 1264.240 4.080 1265.440 300.560 ;
+      RECT 1275.120 4.080 1276.320 300.560 ;
+      RECT 1286.000 4.080 1287.200 300.560 ;
+      RECT 1296.880 4.080 1298.080 300.560 ;
+      RECT 1307.760 4.080 1308.960 300.560 ;
+      RECT 1318.640 4.080 1319.840 300.560 ;
+      RECT 1329.520 4.080 1330.720 300.560 ;
+      RECT 1340.400 4.080 1341.600 300.560 ;
+      RECT 1351.280 4.080 1352.480 300.560 ;
+      RECT 1362.160 4.080 1363.360 300.560 ;
+      RECT 1373.040 4.080 1374.240 300.560 ;
+      RECT 1383.920 4.080 1385.120 300.560 ;
+      RECT 1394.800 4.080 1396.000 300.560 ;
+      RECT 1405.680 4.080 1406.880 300.560 ;
+      RECT 1416.560 4.080 1417.760 300.560 ;
+      RECT 1427.440 4.080 1428.640 300.560 ;
+      RECT 1438.320 4.080 1439.520 300.560 ;
+      RECT 1449.200 4.080 1450.400 300.560 ;
+      RECT 1460.080 4.080 1461.280 300.560 ;
+      RECT 1470.960 4.080 1472.160 300.560 ;
+      RECT 1481.840 4.080 1483.040 300.560 ;
+      RECT 1492.720 4.080 1493.920 300.560 ;
+      RECT 1503.600 4.080 1504.800 300.560 ;
+      RECT 1514.480 4.080 1515.680 300.560 ;
+      RECT 1525.360 4.080 1526.560 300.560 ;
+      RECT 1536.240 4.080 1537.440 300.560 ;
+      RECT 1547.120 4.080 1548.320 300.560 ;
+      RECT 1558.000 4.080 1559.200 300.560 ;
+      RECT 1568.880 4.080 1570.080 300.560 ;
+      RECT 1579.760 4.080 1580.960 300.560 ;
+      RECT 1590.640 4.080 1591.840 300.560 ;
+      RECT 1601.520 4.080 1602.720 300.560 ;
+      RECT 1612.400 4.080 1613.600 300.560 ;
+      RECT 1623.280 4.080 1624.480 300.560 ;
+      RECT 1634.160 4.080 1635.360 300.560 ;
+      RECT 1645.040 4.080 1646.240 300.560 ;
+      RECT 1655.920 4.080 1657.120 300.560 ;
+      RECT 1666.800 4.080 1668.000 300.560 ;
+      RECT 1677.680 4.080 1678.880 300.560 ;
+      RECT 1688.560 4.080 1689.760 300.560 ;
+      RECT 1699.440 4.080 1700.640 300.560 ;
+      RECT 1710.320 4.080 1711.520 300.560 ;
+      RECT 1721.200 4.080 1722.400 300.560 ;
+      RECT 1732.080 4.080 1733.280 300.560 ;
+      RECT 1742.960 4.080 1744.160 300.560 ;
+      RECT 1753.840 4.080 1755.040 300.560 ;
+      RECT 1764.720 4.080 1765.920 300.560 ;
+      RECT 1775.600 4.080 1776.800 300.560 ;
+      RECT 1786.480 4.080 1787.680 300.560 ;
+      RECT 1797.360 4.080 1798.560 300.560 ;
+      RECT 1808.240 4.080 1809.440 300.560 ;
+      RECT 1819.120 4.080 1820.320 300.560 ;
+      RECT 1830.000 4.080 1831.200 300.560 ;
+      RECT 1840.880 4.080 1842.080 300.560 ;
+      RECT 1851.760 4.080 1852.960 300.560 ;
+      RECT 1862.640 4.080 1863.840 300.560 ;
+      RECT 1873.520 4.080 1874.720 300.560 ;
+      RECT 1884.400 4.080 1885.600 300.560 ;
+      RECT 1895.280 4.080 1896.480 300.560 ;
+      RECT 1906.160 4.080 1907.360 300.560 ;
+      RECT 1917.040 4.080 1918.240 300.560 ;
+      RECT 1927.920 4.080 1929.120 300.560 ;
+      RECT 1938.800 4.080 1940.000 300.560 ;
+      RECT 1949.680 4.080 1950.880 300.560 ;
+      RECT 1960.560 4.080 1961.760 300.560 ;
+      RECT 1971.440 4.080 1972.640 300.560 ;
+      RECT 1982.320 4.080 1983.520 300.560 ;
+      RECT 1993.200 4.080 1994.400 300.560 ;
+      RECT 2004.080 4.080 2005.280 300.560 ;
+      RECT 2014.960 4.080 2016.160 300.560 ;
+      RECT 2025.840 4.080 2027.040 300.560 ;
+      RECT 2036.720 4.080 2037.920 300.560 ;
+      RECT 2047.600 4.080 2048.800 300.560 ;
+      RECT 2058.480 4.080 2059.680 300.560 ;
+      RECT 2069.360 4.080 2070.560 300.560 ;
+      RECT 2080.240 4.080 2081.440 300.560 ;
+      RECT 2091.120 4.080 2092.320 300.560 ;
+      RECT 2102.000 4.080 2103.200 300.560 ;
+      RECT 2112.880 4.080 2114.080 300.560 ;
+      RECT 2123.760 4.080 2124.960 300.560 ;
+      RECT 2134.640 4.080 2135.840 300.560 ;
+      RECT 2145.520 4.080 2146.720 300.560 ;
+      RECT 2156.400 4.080 2157.600 300.560 ;
+      RECT 2167.280 4.080 2168.480 300.560 ;
+      RECT 2178.160 4.080 2179.360 300.560 ;
+      RECT 2189.040 4.080 2190.240 300.560 ;
+      RECT 2199.920 4.080 2201.120 300.560 ;
+      RECT 2210.800 4.080 2212.000 300.560 ;
+      RECT 2221.680 4.080 2222.880 300.560 ;
+      RECT 2232.560 4.080 2233.760 300.560 ;
+      RECT 2243.440 4.080 2244.640 300.560 ;
+      RECT 2254.320 4.080 2255.520 300.560 ;
+      RECT 2265.200 4.080 2266.400 300.560 ;
+      RECT 2276.080 4.080 2277.280 300.560 ;
+      RECT 2286.960 4.080 2288.160 300.560 ;
+      RECT 2297.840 4.080 2299.040 300.560 ;
+      RECT 2308.720 4.080 2309.920 300.560 ;
+      RECT 2319.600 4.080 2320.800 300.560 ;
+      RECT 2330.480 4.080 2331.680 300.560 ;
+      RECT 2341.360 4.080 2342.560 300.560 ;
+      RECT 2352.240 4.080 2353.440 300.560 ;
+      RECT 2363.120 4.080 2364.320 300.560 ;
+      RECT 2374.000 4.080 2375.200 300.560 ;
+      RECT 2384.880 4.080 2386.080 300.560 ;
+      RECT 2395.760 4.080 2396.960 300.560 ;
+      RECT 2406.640 4.080 2407.840 300.560 ;
+      RECT 2417.520 4.080 2418.720 300.560 ;
+      RECT 2428.400 4.080 2429.600 300.560 ;
+      RECT 2439.280 4.080 2440.480 300.560 ;
+      RECT 2450.160 4.080 2451.360 300.560 ;
+      RECT 2461.040 4.080 2462.240 300.560 ;
+      RECT 2471.920 4.080 2473.120 300.560 ;
+      RECT 2482.800 4.080 2484.000 300.560 ;
+      RECT 2493.680 4.080 2494.880 300.560 ;
+      RECT 2504.560 4.080 2505.760 300.560 ;
+      RECT 2515.440 4.080 2516.640 300.560 ;
+      RECT 2526.320 4.080 2527.520 300.560 ;
+      RECT 2537.200 4.080 2538.400 300.560 ;
+      RECT 2548.080 4.080 2549.280 300.560 ;
+      RECT 2558.960 4.080 2560.160 300.560 ;
+      RECT 2569.840 4.080 2571.040 300.560 ;
+      RECT 2580.720 4.080 2581.920 300.560 ;
+      RECT 2591.600 4.080 2592.800 300.560 ;
+      RECT 2602.480 4.080 2603.680 300.560 ;
+      RECT 2613.360 4.080 2614.560 300.560 ;
+      RECT 2624.240 4.080 2625.440 300.560 ;
+      RECT 2635.120 4.080 2636.320 300.560 ;
+      RECT 2646.000 4.080 2647.200 300.560 ;
+      RECT 2656.880 4.080 2658.080 300.560 ;
+      RECT 2667.760 4.080 2668.960 300.560 ;
+      RECT 2678.640 4.080 2679.840 300.560 ;
+      RECT 2689.520 4.080 2690.720 300.560 ;
+      RECT 2700.400 4.080 2701.600 300.560 ;
+      RECT 2711.280 4.080 2712.480 300.560 ;
+      RECT 2722.160 4.080 2723.360 300.560 ;
+      RECT 2733.040 4.080 2734.240 300.560 ;
+      RECT 2743.920 4.080 2745.120 300.560 ;
+      RECT 2754.800 4.080 2756.000 300.560 ;
+      RECT 2765.680 4.080 2766.880 300.560 ;
+      RECT 2776.560 4.080 2777.760 300.560 ;
+      RECT 2787.440 4.080 2788.640 300.560 ;
+      RECT 2798.320 4.080 2799.520 300.560 ;
+      RECT 2809.200 4.080 2810.400 300.560 ;
+      RECT 2820.080 4.080 2821.280 300.560 ;
+      RECT 2830.960 4.080 2832.160 300.560 ;
+      RECT 2841.840 4.080 2843.040 300.560 ;
+      RECT 2852.720 4.080 2853.920 300.560 ;
+      RECT 2863.600 4.080 2864.800 300.560 ;
+      RECT 2874.480 4.080 2875.680 300.560 ;
+      RECT 2885.360 4.080 2886.560 300.560 ;
+      RECT 2896.240 4.080 2897.440 300.560 ;
+      RECT 2907.120 4.080 2908.320 300.560 ;
+      RECT 2918.000 4.080 2919.200 300.560 ;
+      RECT 2928.880 4.080 2930.080 300.560 ;
+      RECT 2939.760 4.080 2940.960 300.560 ;
+      RECT 2950.640 4.080 2951.840 300.560 ;
+      RECT 2961.520 4.080 2962.720 300.560 ;
+      RECT 2972.400 4.080 2973.600 300.560 ;
+      RECT 2983.280 4.080 2984.480 300.560 ;
+      RECT 2994.160 4.080 2995.360 300.560 ;
+      RECT 3005.040 4.080 3006.240 300.560 ;
+      RECT 3015.920 4.080 3017.120 300.560 ;
+      RECT 3026.800 4.080 3028.000 300.560 ;
+      RECT 3037.680 4.080 3038.880 300.560 ;
+      RECT 3048.560 4.080 3049.760 300.560 ;
+      RECT 3059.440 4.080 3060.640 300.560 ;
+      RECT 3070.320 4.080 3071.520 300.560 ;
+      RECT 3081.200 4.080 3082.400 300.560 ;
+      RECT 3092.080 4.080 3093.280 300.560 ;
+      RECT 3102.960 4.080 3104.160 300.560 ;
+      RECT 3113.840 4.080 3115.040 300.560 ;
+      RECT 3124.720 4.080 3125.920 300.560 ;
+      RECT 3135.600 4.080 3136.800 300.560 ;
+      RECT 3146.480 4.080 3147.680 300.560 ;
+      RECT 3157.360 4.080 3158.560 300.560 ;
+      RECT 3168.240 4.080 3169.440 300.560 ;
+      RECT 3179.120 4.080 3180.320 300.560 ;
+      RECT 3190.000 4.080 3191.200 300.560 ;
+      RECT 3200.880 4.080 3202.080 300.560 ;
+      RECT 3211.760 4.080 3212.960 300.560 ;
+      RECT 3222.640 4.080 3223.840 300.560 ;
+      RECT 3233.520 4.080 3234.720 300.560 ;
+      RECT 3244.400 4.080 3245.600 300.560 ;
+      RECT 3255.280 4.080 3256.480 300.560 ;
+      RECT 3266.160 4.080 3267.360 300.560 ;
+      RECT 3277.040 4.080 3278.240 300.560 ;
+      RECT 3287.920 4.080 3289.120 300.560 ;
+      RECT 3298.800 4.080 3300.000 300.560 ;
+      RECT 3309.680 4.080 3310.880 300.560 ;
+      RECT 3320.560 4.080 3321.760 300.560 ;
+      RECT 3331.440 4.080 3332.640 300.560 ;
+      RECT 3342.320 4.080 3343.520 300.560 ;
+      RECT 3353.200 4.080 3354.400 300.560 ;
+      RECT 3364.080 4.080 3365.280 300.560 ;
+      RECT 3374.960 4.080 3376.160 300.560 ;
+      RECT 3385.840 4.080 3387.040 300.560 ;
+      RECT 3396.720 4.080 3397.920 300.560 ;
+      RECT 3407.600 4.080 3408.800 300.560 ;
+      RECT 3418.480 4.080 3419.680 300.560 ;
+      RECT 3429.360 4.080 3430.560 300.560 ;
+      RECT 3440.240 4.080 3441.440 300.560 ;
+      RECT 3451.120 4.080 3452.320 300.560 ;
+      RECT 3462.000 4.080 3463.200 300.560 ;
+      RECT 3472.880 4.080 3474.080 300.560 ;
+      RECT 3483.760 4.080 3484.960 300.560 ;
+      RECT 3494.640 4.080 3495.840 300.560 ;
+      RECT 3505.520 4.080 3506.720 300.560 ;
+      RECT 3516.400 4.080 3517.600 300.560 ;
+      RECT 3527.280 4.080 3528.480 300.560 ;
+      RECT 3538.160 4.080 3539.360 300.560 ;
+      RECT 3549.040 4.080 3550.240 300.560 ;
+      RECT 3559.920 4.080 3561.120 300.560 ;
+      RECT 3570.800 4.080 3572.000 300.560 ;
+      RECT 3581.680 4.080 3582.880 300.560 ;
+      RECT 3592.560 4.080 3593.760 300.560 ;
+      RECT 3603.440 4.080 3604.640 300.560 ;
+      RECT 3614.320 4.080 3615.520 300.560 ;
+      RECT 3625.200 4.080 3626.400 300.560 ;
+      RECT 3636.080 4.080 3637.280 300.560 ;
+      RECT 3646.960 4.080 3648.160 300.560 ;
+      RECT 3657.840 4.080 3659.040 300.560 ;
+      RECT 3668.720 4.080 3669.920 300.560 ;
+      RECT 3679.600 4.080 3680.800 300.560 ;
+      RECT 3690.480 4.080 3691.680 300.560 ;
+      RECT 3701.360 4.080 3702.560 300.560 ;
+      RECT 3712.240 4.080 3713.440 300.560 ;
+      RECT 3723.120 4.080 3724.320 300.560 ;
+      RECT 3734.000 4.080 3735.200 300.560 ;
+      RECT 3744.880 4.080 3746.080 300.560 ;
+      RECT 3755.760 4.080 3756.960 300.560 ;
+      RECT 3766.640 4.080 3767.840 300.560 ;
+      RECT 3777.520 4.080 3778.720 300.560 ;
+      RECT 3788.400 4.080 3789.600 300.560 ;
+      RECT 3799.280 4.080 3800.480 300.560 ;
+      RECT 3810.160 4.080 3811.360 300.560 ;
+      RECT 3821.040 4.080 3822.240 300.560 ;
+      RECT 3831.920 4.080 3833.120 300.560 ;
+      RECT 3842.800 4.080 3844.000 300.560 ;
+      RECT 3853.680 4.080 3854.880 300.560 ;
+      RECT 3864.560 4.080 3865.760 300.560 ;
+      RECT 3875.440 4.080 3876.640 300.560 ;
+      RECT 3886.320 4.080 3887.520 300.560 ;
+      RECT 3897.200 4.080 3898.400 300.560 ;
+      RECT 3908.080 4.080 3909.280 300.560 ;
+      RECT 3918.960 4.080 3920.160 300.560 ;
+      RECT 3929.840 4.080 3931.040 300.560 ;
+      RECT 3940.720 4.080 3941.920 300.560 ;
+      RECT 3951.600 4.080 3952.800 300.560 ;
+      RECT 3962.480 4.080 3963.680 300.560 ;
+      RECT 3973.360 4.080 3974.560 300.560 ;
+      RECT 3984.240 4.080 3985.440 300.560 ;
+      RECT 3995.120 4.080 3996.320 300.560 ;
+      RECT 4006.000 4.080 4007.200 300.560 ;
+      RECT 4016.880 4.080 4018.080 300.560 ;
+      RECT 4027.760 4.080 4028.960 300.560 ;
+      RECT 4038.640 4.080 4039.840 300.560 ;
+      RECT 4049.520 4.080 4050.720 300.560 ;
+      RECT 4060.400 4.080 4061.600 300.560 ;
+      RECT 4071.280 4.080 4072.480 300.560 ;
+      RECT 4082.160 4.080 4083.360 300.560 ;
+      RECT 4093.040 4.080 4094.240 300.560 ;
+      RECT 4103.920 4.080 4105.120 300.560 ;
+      RECT 4114.800 4.080 4116.000 300.560 ;
+      RECT 4125.680 4.080 4126.880 300.560 ;
+      RECT 4136.560 4.080 4137.760 300.560 ;
+      RECT 4147.440 4.080 4148.640 300.560 ;
+      RECT 4158.320 4.080 4159.520 300.560 ;
+      RECT 4169.200 4.080 4170.400 300.560 ;
+      RECT 4180.080 4.080 4181.280 300.560 ;
+      RECT 4190.960 4.080 4192.160 300.560 ;
+      RECT 4201.840 4.080 4203.040 300.560 ;
+      RECT 4212.720 4.080 4213.920 300.560 ;
+      RECT 4223.600 4.080 4224.800 300.560 ;
+      RECT 4234.480 4.080 4235.680 300.560 ;
+      RECT 4245.360 4.080 4246.560 300.560 ;
+      RECT 4256.240 4.080 4257.440 300.560 ;
+      RECT 4267.120 4.080 4268.320 300.560 ;
+      RECT 4278.000 4.080 4279.200 300.560 ;
+      RECT 4288.880 4.080 4290.080 300.560 ;
+      RECT 4299.760 4.080 4300.960 300.560 ;
+      RECT 4310.640 4.080 4311.840 300.560 ;
+      RECT 4321.520 4.080 4322.720 300.560 ;
+      RECT 4332.400 4.080 4333.600 300.560 ;
+      RECT 4343.280 4.080 4344.480 300.560 ;
+      RECT 4354.160 4.080 4355.360 300.560 ;
+      RECT 4365.040 4.080 4366.240 300.560 ;
+      RECT 4375.920 4.080 4377.120 300.560 ;
+      RECT 4386.800 4.080 4388.000 300.560 ;
+      RECT 4397.680 4.080 4398.880 300.560 ;
+      RECT 4408.560 4.080 4409.760 300.560 ;
+      RECT 4419.440 4.080 4420.640 300.560 ;
+      RECT 4430.320 4.080 4431.520 300.560 ;
+      RECT 4441.200 4.080 4442.400 300.560 ;
+      RECT 4452.080 4.080 4453.280 300.560 ;
+      RECT 4462.960 4.080 4464.160 300.560 ;
+      RECT 4473.840 4.080 4475.040 300.560 ;
+      RECT 4484.720 4.080 4485.920 300.560 ;
+      RECT 4495.600 4.080 4496.800 300.560 ;
+      RECT 4506.480 4.080 4507.680 300.560 ;
+      RECT 4517.360 4.080 4518.560 300.560 ;
+      RECT 4528.240 4.080 4529.440 300.560 ;
+      RECT 4539.120 4.080 4540.320 300.560 ;
+      RECT 4550.000 4.080 4551.200 300.560 ;
+      RECT 4560.880 4.080 4562.080 300.560 ;
+      RECT 4571.760 4.080 4572.960 300.560 ;
+      RECT 4582.640 4.080 4583.840 300.560 ;
+      RECT 4593.520 4.080 4594.720 300.560 ;
+      RECT 4604.400 4.080 4605.600 300.560 ;
+      RECT 4615.280 4.080 4616.480 300.560 ;
+      RECT 4626.160 4.080 4627.360 300.560 ;
+      RECT 4637.040 4.080 4638.240 300.560 ;
+      RECT 4647.920 4.080 4649.120 300.560 ;
+      RECT 4658.800 4.080 4660.000 300.560 ;
+      RECT 4669.680 4.080 4670.880 300.560 ;
+      RECT 4680.560 4.080 4681.760 300.560 ;
+      RECT 4691.440 4.080 4692.640 300.560 ;
+      RECT 4702.320 4.080 4703.520 300.560 ;
+      RECT 4713.200 4.080 4714.400 300.560 ;
+      RECT 4724.080 4.080 4725.280 300.560 ;
+      RECT 4734.960 4.080 4736.160 300.560 ;
+      RECT 4745.840 4.080 4747.040 300.560 ;
+      RECT 4756.720 4.080 4757.920 300.560 ;
+      RECT 4767.600 4.080 4768.800 300.560 ;
+      RECT 4778.480 4.080 4779.680 300.560 ;
+      RECT 4789.360 4.080 4790.560 300.560 ;
+      RECT 4800.240 4.080 4801.440 300.560 ;
+      RECT 4811.120 4.080 4812.320 300.560 ;
+      RECT 4822.000 4.080 4823.200 300.560 ;
+      RECT 4832.880 4.080 4834.080 300.560 ;
+      RECT 4843.760 4.080 4844.960 300.560 ;
+      RECT 4854.640 4.080 4855.840 300.560 ;
+      RECT 4865.520 4.080 4866.720 300.560 ;
+      RECT 4876.400 4.080 4877.600 300.560 ;
+      RECT 4887.280 4.080 4888.480 300.560 ;
+      RECT 4898.160 4.080 4899.360 300.560 ;
+      RECT 4909.040 4.080 4910.240 300.560 ;
+      RECT 4919.920 4.080 4921.120 300.560 ;
+      RECT 4930.800 4.080 4932.000 300.560 ;
+      RECT 4941.680 4.080 4942.880 300.560 ;
+      RECT 4952.560 4.080 4953.760 300.560 ;
+      RECT 4963.440 4.080 4964.640 300.560 ;
+      RECT 4974.320 4.080 4975.520 300.560 ;
+      RECT 4985.200 4.080 4986.400 300.560 ;
+      RECT 4996.080 4.080 4997.280 300.560 ;
+      RECT 5006.960 4.080 5008.160 300.560 ;
+      RECT 5017.840 4.080 5019.040 300.560 ;
+      RECT 5028.720 4.080 5029.920 300.560 ;
+      RECT 5039.600 4.080 5040.800 300.560 ;
+      RECT 5050.480 4.080 5051.680 300.560 ;
+      RECT 5061.360 4.080 5062.560 300.560 ;
+      RECT 5072.240 4.080 5073.440 300.560 ;
+      RECT 5083.120 4.080 5084.320 300.560 ;
+      RECT 5094.000 4.080 5095.200 300.560 ;
+      RECT 5104.880 4.080 5106.080 300.560 ;
+      RECT 5115.760 4.080 5116.960 300.560 ;
+      RECT 5126.640 4.080 5127.840 300.560 ;
+      RECT 5137.520 4.080 5138.720 300.560 ;
+      RECT 5148.400 4.080 5149.600 300.560 ;
+      RECT 5159.280 4.080 5160.480 300.560 ;
+      RECT 5170.160 4.080 5171.360 300.560 ;
+      RECT 5181.040 4.080 5182.240 300.560 ;
+      RECT 5191.920 4.080 5193.120 300.560 ;
+      RECT 5202.800 4.080 5204.000 300.560 ;
+      RECT 5213.680 4.080 5214.880 300.560 ;
+      RECT 5224.560 4.080 5225.760 300.560 ;
+      RECT 5235.440 4.080 5236.640 300.560 ;
+      RECT 5246.320 4.080 5247.520 300.560 ;
+      RECT 5257.200 4.080 5258.400 300.560 ;
+      RECT 5268.080 4.080 5269.280 300.560 ;
+      RECT 5278.960 4.080 5280.160 300.560 ;
+      RECT 5289.840 4.080 5291.040 300.560 ;
+      RECT 5300.720 4.080 5301.920 300.560 ;
+      RECT 5311.600 4.080 5312.800 300.560 ;
+      RECT 5322.480 4.080 5323.680 300.560 ;
+      RECT 5333.360 4.080 5334.560 300.560 ;
+      RECT 5344.240 4.080 5345.440 300.560 ;
+      RECT 5355.120 4.080 5356.320 300.560 ;
+      RECT 5366.000 4.080 5367.200 300.560 ;
+      RECT 5376.880 4.080 5378.080 300.560 ;
+      RECT 5387.760 4.080 5388.960 300.560 ;
+      RECT 5398.640 4.080 5399.840 300.560 ;
+      RECT 5409.520 4.080 5410.720 300.560 ;
+      RECT 5420.400 4.080 5421.600 300.560 ;
+      RECT 5431.280 4.080 5432.480 300.560 ;
+      RECT 5442.160 4.080 5443.360 300.560 ;
+      RECT 5453.040 4.080 5454.240 300.560 ;
+      RECT 5463.920 4.080 5465.120 300.560 ;
+      RECT 5474.800 4.080 5476.000 300.560 ;
+      RECT 5485.680 4.080 5486.880 300.560 ;
+      RECT 5496.560 4.080 5497.760 300.560 ;
+      RECT 5507.440 4.080 5508.640 300.560 ;
+      RECT 5518.320 4.080 5519.520 300.560 ;
+      RECT 5529.200 4.080 5530.400 300.560 ;
+      RECT 5540.080 4.080 5541.280 300.560 ;
+      RECT 5550.960 4.080 5552.160 300.560 ;
+      RECT 5561.840 4.080 5563.040 300.560 ;
+      RECT 5572.720 4.080 5573.920 300.560 ;
+      RECT 5583.600 4.080 5584.800 300.560 ;
+      RECT 5594.480 4.080 5595.680 300.560 ;
+      RECT 5605.360 4.080 5606.560 300.560 ;
+      RECT 5616.240 4.080 5617.440 300.560 ;
+      RECT 5627.120 4.080 5628.320 300.560 ;
+      RECT 5638.000 4.080 5639.200 300.560 ;
+      RECT 5648.880 4.080 5650.080 300.560 ;
+      RECT 5659.760 4.080 5660.960 300.560 ;
+      RECT 5670.640 4.080 5671.840 300.560 ;
+      RECT 5681.520 4.080 5682.720 300.560 ;
+      RECT 5692.400 4.080 5693.600 300.560 ;
+      RECT 5703.280 4.080 5704.480 300.560 ;
+      RECT 5714.160 4.080 5715.360 300.560 ;
+      RECT 5725.040 4.080 5726.240 300.560 ;
+      RECT 5735.920 4.080 5737.120 300.560 ;
+      RECT 5746.800 4.080 5748.000 300.560 ;
+      RECT 5757.680 4.080 5758.880 300.560 ;
+      RECT 5768.560 4.080 5769.760 300.560 ;
+      RECT 5779.440 4.080 5780.640 300.560 ;
+      RECT 5790.320 4.080 5791.520 300.560 ;
+      RECT 5801.200 4.080 5802.400 300.560 ;
+      RECT 5812.080 4.080 5813.280 300.560 ;
+      RECT 5822.960 4.080 5824.160 300.560 ;
+      RECT 5833.840 4.080 5835.040 300.560 ;
+      RECT 5844.720 4.080 5845.920 300.560 ;
+      RECT 5855.600 4.080 5856.800 300.560 ;
+      RECT 5866.480 4.080 5867.680 300.560 ;
+      RECT 5877.360 4.080 5878.560 300.560 ;
+      RECT 5888.240 4.080 5889.440 300.560 ;
+      RECT 5899.120 4.080 5900.320 300.560 ;
+      RECT 5910.000 4.080 5911.200 300.560 ;
+      RECT 5920.880 4.080 5922.080 300.560 ;
+      RECT 5931.760 4.080 5932.960 300.560 ;
+      RECT 5942.640 4.080 5943.840 300.560 ;
+      RECT 5953.520 4.080 5954.720 300.560 ;
+      RECT 5964.400 4.080 5965.600 300.560 ;
+      RECT 5975.280 4.080 5976.480 300.560 ;
+      RECT 5986.160 4.080 5987.360 300.560 ;
+      RECT 5997.040 4.080 5998.240 300.560 ;
+      RECT 6007.920 4.080 6009.120 300.560 ;
+      RECT 6018.800 4.080 6020.000 300.560 ;
+      RECT 6029.680 4.080 6030.880 300.560 ;
+      RECT 6040.560 4.080 6041.760 300.560 ;
+      RECT 6051.440 4.080 6052.640 300.560 ;
+      RECT 6062.320 4.080 6063.520 300.560 ;
+      RECT 6073.200 4.080 6074.400 300.560 ;
+      RECT 6084.080 4.080 6085.280 300.560 ;
+      RECT 6094.960 4.080 6096.160 300.560 ;
+      RECT 6105.840 4.080 6107.040 300.560 ;
+      RECT 6116.720 4.080 6117.920 300.560 ;
+      RECT 6127.600 4.080 6128.800 300.560 ;
+      RECT 6138.480 4.080 6139.680 300.560 ;
+      RECT 6149.360 4.080 6150.560 300.560 ;
+      RECT 6160.240 4.080 6161.440 300.560 ;
+      RECT 6171.120 4.080 6172.320 300.560 ;
+      RECT 6182.000 4.080 6183.200 300.560 ;
+      RECT 6192.880 4.080 6194.080 300.560 ;
+      RECT 6203.760 4.080 6204.960 300.560 ;
+      RECT 6214.640 4.080 6215.840 300.560 ;
+      RECT 6225.520 4.080 6226.720 300.560 ;
+      RECT 6236.400 4.080 6237.600 300.560 ;
+      RECT 6247.280 4.080 6248.480 300.560 ;
+      RECT 6258.160 4.080 6259.360 300.560 ;
+      RECT 6269.040 4.080 6270.240 300.560 ;
+      RECT 6279.920 4.080 6281.120 300.560 ;
+      RECT 6290.800 4.080 6292.000 300.560 ;
+      RECT 6301.680 4.080 6302.880 300.560 ;
+      RECT 6312.560 4.080 6313.760 300.560 ;
+      RECT 6323.440 4.080 6324.640 300.560 ;
+      RECT 6334.320 4.080 6335.520 300.560 ;
+      RECT 6345.200 4.080 6346.400 300.560 ;
+      RECT 6356.080 4.080 6357.280 300.560 ;
+      RECT 6366.960 4.080 6368.160 300.560 ;
+      RECT 6377.840 4.080 6379.040 300.560 ;
+      RECT 6388.720 4.080 6389.920 300.560 ;
+      RECT 6399.600 4.080 6400.800 300.560 ;
+      RECT 6410.480 4.080 6411.680 300.560 ;
+      RECT 6421.360 4.080 6422.560 300.560 ;
+      RECT 6432.240 4.080 6433.440 300.560 ;
+      RECT 6443.120 4.080 6444.320 300.560 ;
+      RECT 6454.000 4.080 6455.200 300.560 ;
+      RECT 6464.880 4.080 6466.080 300.560 ;
+      RECT 6475.760 4.080 6476.960 300.560 ;
+      RECT 6486.640 4.080 6487.840 300.560 ;
+      RECT 6497.520 4.080 6498.720 300.560 ;
+      RECT 6508.400 4.080 6509.600 300.560 ;
+      RECT 6519.280 4.080 6520.480 300.560 ;
+      RECT 6530.160 4.080 6531.360 300.560 ;
+      RECT 6541.040 4.080 6542.240 300.560 ;
+      RECT 6551.920 4.080 6553.120 300.560 ;
+      RECT 6562.800 4.080 6564.000 300.560 ;
+      RECT 6573.680 4.080 6574.880 300.560 ;
+      RECT 6584.560 4.080 6585.760 300.560 ;
+      RECT 6595.440 4.080 6596.640 300.560 ;
+      RECT 6606.320 4.080 6607.520 300.560 ;
+      RECT 6617.200 4.080 6618.400 300.560 ;
+      RECT 6628.080 4.080 6629.280 300.560 ;
+      RECT 6638.960 4.080 6640.160 300.560 ;
+      RECT 6649.840 4.080 6651.040 300.560 ;
+      RECT 6660.720 4.080 6661.920 300.560 ;
+      RECT 6671.600 4.080 6672.800 300.560 ;
+      RECT 6682.480 4.080 6683.680 300.560 ;
+      RECT 6693.360 4.080 6694.560 300.560 ;
+      RECT 6704.240 4.080 6705.440 300.560 ;
+      RECT 6715.120 4.080 6716.320 300.560 ;
+      RECT 6726.000 4.080 6727.200 300.560 ;
+      RECT 6736.880 4.080 6738.080 300.560 ;
+      RECT 6747.760 4.080 6748.960 300.560 ;
+      RECT 6758.640 4.080 6759.840 300.560 ;
+      RECT 6769.520 4.080 6770.720 300.560 ;
+      RECT 6780.400 4.080 6781.600 300.560 ;
+      RECT 6791.280 4.080 6792.480 300.560 ;
+      RECT 6802.160 4.080 6803.360 300.560 ;
+      RECT 6813.040 4.080 6814.240 300.560 ;
+      RECT 6823.920 4.080 6825.120 300.560 ;
+      RECT 6834.800 4.080 6836.000 300.560 ;
+      RECT 6845.680 4.080 6846.880 300.560 ;
+      RECT 6856.560 4.080 6857.760 300.560 ;
+      RECT 6867.440 4.080 6868.640 300.560 ;
+      RECT 6878.320 4.080 6879.520 300.560 ;
+      RECT 6889.200 4.080 6890.400 300.560 ;
+      RECT 6900.080 4.080 6901.280 300.560 ;
+      RECT 6910.960 4.080 6912.160 300.560 ;
+      RECT 6921.840 4.080 6923.040 300.560 ;
+      RECT 6932.720 4.080 6933.920 300.560 ;
+      RECT 6943.600 4.080 6944.800 300.560 ;
+      RECT 6954.480 4.080 6955.680 300.560 ;
+      RECT 6965.360 4.080 6966.560 300.560 ;
+      RECT 6976.240 4.080 6977.440 300.560 ;
+      RECT 6987.120 4.080 6988.320 300.560 ;
+      RECT 6998.000 4.080 6999.200 300.560 ;
+      RECT 7008.880 4.080 7010.080 300.560 ;
+      RECT 7019.760 4.080 7020.960 300.560 ;
+      RECT 7030.640 4.080 7031.840 300.560 ;
+      RECT 7041.520 4.080 7042.720 300.560 ;
+      RECT 7052.400 4.080 7053.600 300.560 ;
+      RECT 7063.280 4.080 7064.480 300.560 ;
+      RECT 7074.160 4.080 7075.360 300.560 ;
+      RECT 7085.040 4.080 7086.240 300.560 ;
+      RECT 7095.920 4.080 7097.120 300.560 ;
+      RECT 7106.800 4.080 7108.000 300.560 ;
+      RECT 7117.680 4.080 7118.880 300.560 ;
+      RECT 7128.560 4.080 7129.760 300.560 ;
+      RECT 7139.440 4.080 7140.640 300.560 ;
+      RECT 7150.320 4.080 7151.520 300.560 ;
+      RECT 7161.200 4.080 7162.400 300.560 ;
+      RECT 7172.080 4.080 7173.280 300.560 ;
+      RECT 7182.960 4.080 7184.160 300.560 ;
+      RECT 7193.840 4.080 7195.040 300.560 ;
+      RECT 7204.720 4.080 7205.920 300.560 ;
+      RECT 7215.600 4.080 7216.800 300.560 ;
+      RECT 7226.480 4.080 7227.680 300.560 ;
+      RECT 7237.360 4.080 7238.560 300.560 ;
+      RECT 7248.240 4.080 7249.440 300.560 ;
+      RECT 7259.120 4.080 7260.320 300.560 ;
+      RECT 7270.000 4.080 7271.200 300.560 ;
+      RECT 7280.880 4.080 7282.080 300.560 ;
+      RECT 7291.760 4.080 7292.960 300.560 ;
+      RECT 7302.640 4.080 7303.840 300.560 ;
+      RECT 7313.520 4.080 7314.720 300.560 ;
+      RECT 7324.400 4.080 7325.600 300.560 ;
+      RECT 7335.280 4.080 7336.480 300.560 ;
+      RECT 7346.160 4.080 7347.360 300.560 ;
+      RECT 7357.040 4.080 7358.240 300.560 ;
+      RECT 7367.920 4.080 7369.120 300.560 ;
+      RECT 7378.800 4.080 7380.000 300.560 ;
+      RECT 7389.680 4.080 7390.880 300.560 ;
+      RECT 7400.560 4.080 7401.760 300.560 ;
+      RECT 7411.440 4.080 7412.640 300.560 ;
+      RECT 7422.320 4.080 7423.520 300.560 ;
+      RECT 7433.200 4.080 7434.400 300.560 ;
+      RECT 7444.080 4.080 7445.280 300.560 ;
+      RECT 7454.960 4.080 7456.160 300.560 ;
+      RECT 7465.840 4.080 7467.040 300.560 ;
+      RECT 7476.720 4.080 7477.920 300.560 ;
+      RECT 7487.600 4.080 7488.800 300.560 ;
+      RECT 7498.480 4.080 7499.680 300.560 ;
+      RECT 7509.360 4.080 7510.560 300.560 ;
+      RECT 7520.240 4.080 7521.440 300.560 ;
+      RECT 7531.120 4.080 7532.320 300.560 ;
+      RECT 7542.000 4.080 7543.200 300.560 ;
+      RECT 7552.880 4.080 7554.080 300.560 ;
+      RECT 7563.760 4.080 7564.960 300.560 ;
+      RECT 7574.640 4.080 7575.840 300.560 ;
+      RECT 7585.520 4.080 7586.720 300.560 ;
+      RECT 7596.400 4.080 7597.600 300.560 ;
+      RECT 7607.280 4.080 7608.480 300.560 ;
+      RECT 7618.160 4.080 7619.360 300.560 ;
+      RECT 7629.040 4.080 7630.240 300.560 ;
+      RECT 7639.920 4.080 7641.120 300.560 ;
+      RECT 7650.800 4.080 7652.000 300.560 ;
+      RECT 7661.680 4.080 7662.880 300.560 ;
+      RECT 7672.560 4.080 7673.760 300.560 ;
+      RECT 7683.440 4.080 7684.640 300.560 ;
+      RECT 7694.320 4.080 7695.520 300.560 ;
+      RECT 7705.200 4.080 7706.400 300.560 ;
+      RECT 7716.080 4.080 7717.280 300.560 ;
+      RECT 7726.960 4.080 7728.160 300.560 ;
+      RECT 7737.840 4.080 7739.040 300.560 ;
+      RECT 7748.720 4.080 7749.920 300.560 ;
+      RECT 7759.600 4.080 7760.800 300.560 ;
+      RECT 7770.480 4.080 7771.680 300.560 ;
+      RECT 7781.360 4.080 7782.560 300.560 ;
+      RECT 7792.240 4.080 7793.440 300.560 ;
+      RECT 7803.120 4.080 7804.320 300.560 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 2.160 4.080 3.360 300.560 ;
+      RECT 13.040 4.080 14.240 300.560 ;
+      RECT 23.920 4.080 25.120 300.560 ;
+      RECT 34.800 4.080 36.000 300.560 ;
+      RECT 45.680 4.080 46.880 300.560 ;
+      RECT 56.560 4.080 57.760 300.560 ;
+      RECT 67.440 4.080 68.640 300.560 ;
+      RECT 78.320 4.080 79.520 300.560 ;
+      RECT 89.200 4.080 90.400 300.560 ;
+      RECT 100.080 4.080 101.280 300.560 ;
+      RECT 110.960 4.080 112.160 300.560 ;
+      RECT 121.840 4.080 123.040 300.560 ;
+      RECT 132.720 4.080 133.920 300.560 ;
+      RECT 143.600 4.080 144.800 300.560 ;
+      RECT 154.480 4.080 155.680 300.560 ;
+      RECT 165.360 4.080 166.560 300.560 ;
+      RECT 176.240 4.080 177.440 300.560 ;
+      RECT 187.120 4.080 188.320 300.560 ;
+      RECT 198.000 4.080 199.200 300.560 ;
+      RECT 208.880 4.080 210.080 300.560 ;
+      RECT 219.760 4.080 220.960 300.560 ;
+      RECT 230.640 4.080 231.840 300.560 ;
+      RECT 241.520 4.080 242.720 300.560 ;
+      RECT 252.400 4.080 253.600 300.560 ;
+      RECT 263.280 4.080 264.480 300.560 ;
+      RECT 274.160 4.080 275.360 300.560 ;
+      RECT 285.040 4.080 286.240 300.560 ;
+      RECT 295.920 4.080 297.120 300.560 ;
+      RECT 306.800 4.080 308.000 300.560 ;
+      RECT 317.680 4.080 318.880 300.560 ;
+      RECT 328.560 4.080 329.760 300.560 ;
+      RECT 339.440 4.080 340.640 300.560 ;
+      RECT 350.320 4.080 351.520 300.560 ;
+      RECT 361.200 4.080 362.400 300.560 ;
+      RECT 372.080 4.080 373.280 300.560 ;
+      RECT 382.960 4.080 384.160 300.560 ;
+      RECT 393.840 4.080 395.040 300.560 ;
+      RECT 404.720 4.080 405.920 300.560 ;
+      RECT 415.600 4.080 416.800 300.560 ;
+      RECT 426.480 4.080 427.680 300.560 ;
+      RECT 437.360 4.080 438.560 300.560 ;
+      RECT 448.240 4.080 449.440 300.560 ;
+      RECT 459.120 4.080 460.320 300.560 ;
+      RECT 470.000 4.080 471.200 300.560 ;
+      RECT 480.880 4.080 482.080 300.560 ;
+      RECT 491.760 4.080 492.960 300.560 ;
+      RECT 502.640 4.080 503.840 300.560 ;
+      RECT 513.520 4.080 514.720 300.560 ;
+      RECT 524.400 4.080 525.600 300.560 ;
+      RECT 535.280 4.080 536.480 300.560 ;
+      RECT 546.160 4.080 547.360 300.560 ;
+      RECT 557.040 4.080 558.240 300.560 ;
+      RECT 567.920 4.080 569.120 300.560 ;
+      RECT 578.800 4.080 580.000 300.560 ;
+      RECT 589.680 4.080 590.880 300.560 ;
+      RECT 600.560 4.080 601.760 300.560 ;
+      RECT 611.440 4.080 612.640 300.560 ;
+      RECT 622.320 4.080 623.520 300.560 ;
+      RECT 633.200 4.080 634.400 300.560 ;
+      RECT 644.080 4.080 645.280 300.560 ;
+      RECT 654.960 4.080 656.160 300.560 ;
+      RECT 665.840 4.080 667.040 300.560 ;
+      RECT 676.720 4.080 677.920 300.560 ;
+      RECT 687.600 4.080 688.800 300.560 ;
+      RECT 698.480 4.080 699.680 300.560 ;
+      RECT 709.360 4.080 710.560 300.560 ;
+      RECT 720.240 4.080 721.440 300.560 ;
+      RECT 731.120 4.080 732.320 300.560 ;
+      RECT 742.000 4.080 743.200 300.560 ;
+      RECT 752.880 4.080 754.080 300.560 ;
+      RECT 763.760 4.080 764.960 300.560 ;
+      RECT 774.640 4.080 775.840 300.560 ;
+      RECT 785.520 4.080 786.720 300.560 ;
+      RECT 796.400 4.080 797.600 300.560 ;
+      RECT 807.280 4.080 808.480 300.560 ;
+      RECT 818.160 4.080 819.360 300.560 ;
+      RECT 829.040 4.080 830.240 300.560 ;
+      RECT 839.920 4.080 841.120 300.560 ;
+      RECT 850.800 4.080 852.000 300.560 ;
+      RECT 861.680 4.080 862.880 300.560 ;
+      RECT 872.560 4.080 873.760 300.560 ;
+      RECT 883.440 4.080 884.640 300.560 ;
+      RECT 894.320 4.080 895.520 300.560 ;
+      RECT 905.200 4.080 906.400 300.560 ;
+      RECT 916.080 4.080 917.280 300.560 ;
+      RECT 926.960 4.080 928.160 300.560 ;
+      RECT 937.840 4.080 939.040 300.560 ;
+      RECT 948.720 4.080 949.920 300.560 ;
+      RECT 959.600 4.080 960.800 300.560 ;
+      RECT 970.480 4.080 971.680 300.560 ;
+      RECT 981.360 4.080 982.560 300.560 ;
+      RECT 992.240 4.080 993.440 300.560 ;
+      RECT 1003.120 4.080 1004.320 300.560 ;
+      RECT 1014.000 4.080 1015.200 300.560 ;
+      RECT 1024.880 4.080 1026.080 300.560 ;
+      RECT 1035.760 4.080 1036.960 300.560 ;
+      RECT 1046.640 4.080 1047.840 300.560 ;
+      RECT 1057.520 4.080 1058.720 300.560 ;
+      RECT 1068.400 4.080 1069.600 300.560 ;
+      RECT 1079.280 4.080 1080.480 300.560 ;
+      RECT 1090.160 4.080 1091.360 300.560 ;
+      RECT 1101.040 4.080 1102.240 300.560 ;
+      RECT 1111.920 4.080 1113.120 300.560 ;
+      RECT 1122.800 4.080 1124.000 300.560 ;
+      RECT 1133.680 4.080 1134.880 300.560 ;
+      RECT 1144.560 4.080 1145.760 300.560 ;
+      RECT 1155.440 4.080 1156.640 300.560 ;
+      RECT 1166.320 4.080 1167.520 300.560 ;
+      RECT 1177.200 4.080 1178.400 300.560 ;
+      RECT 1188.080 4.080 1189.280 300.560 ;
+      RECT 1198.960 4.080 1200.160 300.560 ;
+      RECT 1209.840 4.080 1211.040 300.560 ;
+      RECT 1220.720 4.080 1221.920 300.560 ;
+      RECT 1231.600 4.080 1232.800 300.560 ;
+      RECT 1242.480 4.080 1243.680 300.560 ;
+      RECT 1253.360 4.080 1254.560 300.560 ;
+      RECT 1264.240 4.080 1265.440 300.560 ;
+      RECT 1275.120 4.080 1276.320 300.560 ;
+      RECT 1286.000 4.080 1287.200 300.560 ;
+      RECT 1296.880 4.080 1298.080 300.560 ;
+      RECT 1307.760 4.080 1308.960 300.560 ;
+      RECT 1318.640 4.080 1319.840 300.560 ;
+      RECT 1329.520 4.080 1330.720 300.560 ;
+      RECT 1340.400 4.080 1341.600 300.560 ;
+      RECT 1351.280 4.080 1352.480 300.560 ;
+      RECT 1362.160 4.080 1363.360 300.560 ;
+      RECT 1373.040 4.080 1374.240 300.560 ;
+      RECT 1383.920 4.080 1385.120 300.560 ;
+      RECT 1394.800 4.080 1396.000 300.560 ;
+      RECT 1405.680 4.080 1406.880 300.560 ;
+      RECT 1416.560 4.080 1417.760 300.560 ;
+      RECT 1427.440 4.080 1428.640 300.560 ;
+      RECT 1438.320 4.080 1439.520 300.560 ;
+      RECT 1449.200 4.080 1450.400 300.560 ;
+      RECT 1460.080 4.080 1461.280 300.560 ;
+      RECT 1470.960 4.080 1472.160 300.560 ;
+      RECT 1481.840 4.080 1483.040 300.560 ;
+      RECT 1492.720 4.080 1493.920 300.560 ;
+      RECT 1503.600 4.080 1504.800 300.560 ;
+      RECT 1514.480 4.080 1515.680 300.560 ;
+      RECT 1525.360 4.080 1526.560 300.560 ;
+      RECT 1536.240 4.080 1537.440 300.560 ;
+      RECT 1547.120 4.080 1548.320 300.560 ;
+      RECT 1558.000 4.080 1559.200 300.560 ;
+      RECT 1568.880 4.080 1570.080 300.560 ;
+      RECT 1579.760 4.080 1580.960 300.560 ;
+      RECT 1590.640 4.080 1591.840 300.560 ;
+      RECT 1601.520 4.080 1602.720 300.560 ;
+      RECT 1612.400 4.080 1613.600 300.560 ;
+      RECT 1623.280 4.080 1624.480 300.560 ;
+      RECT 1634.160 4.080 1635.360 300.560 ;
+      RECT 1645.040 4.080 1646.240 300.560 ;
+      RECT 1655.920 4.080 1657.120 300.560 ;
+      RECT 1666.800 4.080 1668.000 300.560 ;
+      RECT 1677.680 4.080 1678.880 300.560 ;
+      RECT 1688.560 4.080 1689.760 300.560 ;
+      RECT 1699.440 4.080 1700.640 300.560 ;
+      RECT 1710.320 4.080 1711.520 300.560 ;
+      RECT 1721.200 4.080 1722.400 300.560 ;
+      RECT 1732.080 4.080 1733.280 300.560 ;
+      RECT 1742.960 4.080 1744.160 300.560 ;
+      RECT 1753.840 4.080 1755.040 300.560 ;
+      RECT 1764.720 4.080 1765.920 300.560 ;
+      RECT 1775.600 4.080 1776.800 300.560 ;
+      RECT 1786.480 4.080 1787.680 300.560 ;
+      RECT 1797.360 4.080 1798.560 300.560 ;
+      RECT 1808.240 4.080 1809.440 300.560 ;
+      RECT 1819.120 4.080 1820.320 300.560 ;
+      RECT 1830.000 4.080 1831.200 300.560 ;
+      RECT 1840.880 4.080 1842.080 300.560 ;
+      RECT 1851.760 4.080 1852.960 300.560 ;
+      RECT 1862.640 4.080 1863.840 300.560 ;
+      RECT 1873.520 4.080 1874.720 300.560 ;
+      RECT 1884.400 4.080 1885.600 300.560 ;
+      RECT 1895.280 4.080 1896.480 300.560 ;
+      RECT 1906.160 4.080 1907.360 300.560 ;
+      RECT 1917.040 4.080 1918.240 300.560 ;
+      RECT 1927.920 4.080 1929.120 300.560 ;
+      RECT 1938.800 4.080 1940.000 300.560 ;
+      RECT 1949.680 4.080 1950.880 300.560 ;
+      RECT 1960.560 4.080 1961.760 300.560 ;
+      RECT 1971.440 4.080 1972.640 300.560 ;
+      RECT 1982.320 4.080 1983.520 300.560 ;
+      RECT 1993.200 4.080 1994.400 300.560 ;
+      RECT 2004.080 4.080 2005.280 300.560 ;
+      RECT 2014.960 4.080 2016.160 300.560 ;
+      RECT 2025.840 4.080 2027.040 300.560 ;
+      RECT 2036.720 4.080 2037.920 300.560 ;
+      RECT 2047.600 4.080 2048.800 300.560 ;
+      RECT 2058.480 4.080 2059.680 300.560 ;
+      RECT 2069.360 4.080 2070.560 300.560 ;
+      RECT 2080.240 4.080 2081.440 300.560 ;
+      RECT 2091.120 4.080 2092.320 300.560 ;
+      RECT 2102.000 4.080 2103.200 300.560 ;
+      RECT 2112.880 4.080 2114.080 300.560 ;
+      RECT 2123.760 4.080 2124.960 300.560 ;
+      RECT 2134.640 4.080 2135.840 300.560 ;
+      RECT 2145.520 4.080 2146.720 300.560 ;
+      RECT 2156.400 4.080 2157.600 300.560 ;
+      RECT 2167.280 4.080 2168.480 300.560 ;
+      RECT 2178.160 4.080 2179.360 300.560 ;
+      RECT 2189.040 4.080 2190.240 300.560 ;
+      RECT 2199.920 4.080 2201.120 300.560 ;
+      RECT 2210.800 4.080 2212.000 300.560 ;
+      RECT 2221.680 4.080 2222.880 300.560 ;
+      RECT 2232.560 4.080 2233.760 300.560 ;
+      RECT 2243.440 4.080 2244.640 300.560 ;
+      RECT 2254.320 4.080 2255.520 300.560 ;
+      RECT 2265.200 4.080 2266.400 300.560 ;
+      RECT 2276.080 4.080 2277.280 300.560 ;
+      RECT 2286.960 4.080 2288.160 300.560 ;
+      RECT 2297.840 4.080 2299.040 300.560 ;
+      RECT 2308.720 4.080 2309.920 300.560 ;
+      RECT 2319.600 4.080 2320.800 300.560 ;
+      RECT 2330.480 4.080 2331.680 300.560 ;
+      RECT 2341.360 4.080 2342.560 300.560 ;
+      RECT 2352.240 4.080 2353.440 300.560 ;
+      RECT 2363.120 4.080 2364.320 300.560 ;
+      RECT 2374.000 4.080 2375.200 300.560 ;
+      RECT 2384.880 4.080 2386.080 300.560 ;
+      RECT 2395.760 4.080 2396.960 300.560 ;
+      RECT 2406.640 4.080 2407.840 300.560 ;
+      RECT 2417.520 4.080 2418.720 300.560 ;
+      RECT 2428.400 4.080 2429.600 300.560 ;
+      RECT 2439.280 4.080 2440.480 300.560 ;
+      RECT 2450.160 4.080 2451.360 300.560 ;
+      RECT 2461.040 4.080 2462.240 300.560 ;
+      RECT 2471.920 4.080 2473.120 300.560 ;
+      RECT 2482.800 4.080 2484.000 300.560 ;
+      RECT 2493.680 4.080 2494.880 300.560 ;
+      RECT 2504.560 4.080 2505.760 300.560 ;
+      RECT 2515.440 4.080 2516.640 300.560 ;
+      RECT 2526.320 4.080 2527.520 300.560 ;
+      RECT 2537.200 4.080 2538.400 300.560 ;
+      RECT 2548.080 4.080 2549.280 300.560 ;
+      RECT 2558.960 4.080 2560.160 300.560 ;
+      RECT 2569.840 4.080 2571.040 300.560 ;
+      RECT 2580.720 4.080 2581.920 300.560 ;
+      RECT 2591.600 4.080 2592.800 300.560 ;
+      RECT 2602.480 4.080 2603.680 300.560 ;
+      RECT 2613.360 4.080 2614.560 300.560 ;
+      RECT 2624.240 4.080 2625.440 300.560 ;
+      RECT 2635.120 4.080 2636.320 300.560 ;
+      RECT 2646.000 4.080 2647.200 300.560 ;
+      RECT 2656.880 4.080 2658.080 300.560 ;
+      RECT 2667.760 4.080 2668.960 300.560 ;
+      RECT 2678.640 4.080 2679.840 300.560 ;
+      RECT 2689.520 4.080 2690.720 300.560 ;
+      RECT 2700.400 4.080 2701.600 300.560 ;
+      RECT 2711.280 4.080 2712.480 300.560 ;
+      RECT 2722.160 4.080 2723.360 300.560 ;
+      RECT 2733.040 4.080 2734.240 300.560 ;
+      RECT 2743.920 4.080 2745.120 300.560 ;
+      RECT 2754.800 4.080 2756.000 300.560 ;
+      RECT 2765.680 4.080 2766.880 300.560 ;
+      RECT 2776.560 4.080 2777.760 300.560 ;
+      RECT 2787.440 4.080 2788.640 300.560 ;
+      RECT 2798.320 4.080 2799.520 300.560 ;
+      RECT 2809.200 4.080 2810.400 300.560 ;
+      RECT 2820.080 4.080 2821.280 300.560 ;
+      RECT 2830.960 4.080 2832.160 300.560 ;
+      RECT 2841.840 4.080 2843.040 300.560 ;
+      RECT 2852.720 4.080 2853.920 300.560 ;
+      RECT 2863.600 4.080 2864.800 300.560 ;
+      RECT 2874.480 4.080 2875.680 300.560 ;
+      RECT 2885.360 4.080 2886.560 300.560 ;
+      RECT 2896.240 4.080 2897.440 300.560 ;
+      RECT 2907.120 4.080 2908.320 300.560 ;
+      RECT 2918.000 4.080 2919.200 300.560 ;
+      RECT 2928.880 4.080 2930.080 300.560 ;
+      RECT 2939.760 4.080 2940.960 300.560 ;
+      RECT 2950.640 4.080 2951.840 300.560 ;
+      RECT 2961.520 4.080 2962.720 300.560 ;
+      RECT 2972.400 4.080 2973.600 300.560 ;
+      RECT 2983.280 4.080 2984.480 300.560 ;
+      RECT 2994.160 4.080 2995.360 300.560 ;
+      RECT 3005.040 4.080 3006.240 300.560 ;
+      RECT 3015.920 4.080 3017.120 300.560 ;
+      RECT 3026.800 4.080 3028.000 300.560 ;
+      RECT 3037.680 4.080 3038.880 300.560 ;
+      RECT 3048.560 4.080 3049.760 300.560 ;
+      RECT 3059.440 4.080 3060.640 300.560 ;
+      RECT 3070.320 4.080 3071.520 300.560 ;
+      RECT 3081.200 4.080 3082.400 300.560 ;
+      RECT 3092.080 4.080 3093.280 300.560 ;
+      RECT 3102.960 4.080 3104.160 300.560 ;
+      RECT 3113.840 4.080 3115.040 300.560 ;
+      RECT 3124.720 4.080 3125.920 300.560 ;
+      RECT 3135.600 4.080 3136.800 300.560 ;
+      RECT 3146.480 4.080 3147.680 300.560 ;
+      RECT 3157.360 4.080 3158.560 300.560 ;
+      RECT 3168.240 4.080 3169.440 300.560 ;
+      RECT 3179.120 4.080 3180.320 300.560 ;
+      RECT 3190.000 4.080 3191.200 300.560 ;
+      RECT 3200.880 4.080 3202.080 300.560 ;
+      RECT 3211.760 4.080 3212.960 300.560 ;
+      RECT 3222.640 4.080 3223.840 300.560 ;
+      RECT 3233.520 4.080 3234.720 300.560 ;
+      RECT 3244.400 4.080 3245.600 300.560 ;
+      RECT 3255.280 4.080 3256.480 300.560 ;
+      RECT 3266.160 4.080 3267.360 300.560 ;
+      RECT 3277.040 4.080 3278.240 300.560 ;
+      RECT 3287.920 4.080 3289.120 300.560 ;
+      RECT 3298.800 4.080 3300.000 300.560 ;
+      RECT 3309.680 4.080 3310.880 300.560 ;
+      RECT 3320.560 4.080 3321.760 300.560 ;
+      RECT 3331.440 4.080 3332.640 300.560 ;
+      RECT 3342.320 4.080 3343.520 300.560 ;
+      RECT 3353.200 4.080 3354.400 300.560 ;
+      RECT 3364.080 4.080 3365.280 300.560 ;
+      RECT 3374.960 4.080 3376.160 300.560 ;
+      RECT 3385.840 4.080 3387.040 300.560 ;
+      RECT 3396.720 4.080 3397.920 300.560 ;
+      RECT 3407.600 4.080 3408.800 300.560 ;
+      RECT 3418.480 4.080 3419.680 300.560 ;
+      RECT 3429.360 4.080 3430.560 300.560 ;
+      RECT 3440.240 4.080 3441.440 300.560 ;
+      RECT 3451.120 4.080 3452.320 300.560 ;
+      RECT 3462.000 4.080 3463.200 300.560 ;
+      RECT 3472.880 4.080 3474.080 300.560 ;
+      RECT 3483.760 4.080 3484.960 300.560 ;
+      RECT 3494.640 4.080 3495.840 300.560 ;
+      RECT 3505.520 4.080 3506.720 300.560 ;
+      RECT 3516.400 4.080 3517.600 300.560 ;
+      RECT 3527.280 4.080 3528.480 300.560 ;
+      RECT 3538.160 4.080 3539.360 300.560 ;
+      RECT 3549.040 4.080 3550.240 300.560 ;
+      RECT 3559.920 4.080 3561.120 300.560 ;
+      RECT 3570.800 4.080 3572.000 300.560 ;
+      RECT 3581.680 4.080 3582.880 300.560 ;
+      RECT 3592.560 4.080 3593.760 300.560 ;
+      RECT 3603.440 4.080 3604.640 300.560 ;
+      RECT 3614.320 4.080 3615.520 300.560 ;
+      RECT 3625.200 4.080 3626.400 300.560 ;
+      RECT 3636.080 4.080 3637.280 300.560 ;
+      RECT 3646.960 4.080 3648.160 300.560 ;
+      RECT 3657.840 4.080 3659.040 300.560 ;
+      RECT 3668.720 4.080 3669.920 300.560 ;
+      RECT 3679.600 4.080 3680.800 300.560 ;
+      RECT 3690.480 4.080 3691.680 300.560 ;
+      RECT 3701.360 4.080 3702.560 300.560 ;
+      RECT 3712.240 4.080 3713.440 300.560 ;
+      RECT 3723.120 4.080 3724.320 300.560 ;
+      RECT 3734.000 4.080 3735.200 300.560 ;
+      RECT 3744.880 4.080 3746.080 300.560 ;
+      RECT 3755.760 4.080 3756.960 300.560 ;
+      RECT 3766.640 4.080 3767.840 300.560 ;
+      RECT 3777.520 4.080 3778.720 300.560 ;
+      RECT 3788.400 4.080 3789.600 300.560 ;
+      RECT 3799.280 4.080 3800.480 300.560 ;
+      RECT 3810.160 4.080 3811.360 300.560 ;
+      RECT 3821.040 4.080 3822.240 300.560 ;
+      RECT 3831.920 4.080 3833.120 300.560 ;
+      RECT 3842.800 4.080 3844.000 300.560 ;
+      RECT 3853.680 4.080 3854.880 300.560 ;
+      RECT 3864.560 4.080 3865.760 300.560 ;
+      RECT 3875.440 4.080 3876.640 300.560 ;
+      RECT 3886.320 4.080 3887.520 300.560 ;
+      RECT 3897.200 4.080 3898.400 300.560 ;
+      RECT 3908.080 4.080 3909.280 300.560 ;
+      RECT 3918.960 4.080 3920.160 300.560 ;
+      RECT 3929.840 4.080 3931.040 300.560 ;
+      RECT 3940.720 4.080 3941.920 300.560 ;
+      RECT 3951.600 4.080 3952.800 300.560 ;
+      RECT 3962.480 4.080 3963.680 300.560 ;
+      RECT 3973.360 4.080 3974.560 300.560 ;
+      RECT 3984.240 4.080 3985.440 300.560 ;
+      RECT 3995.120 4.080 3996.320 300.560 ;
+      RECT 4006.000 4.080 4007.200 300.560 ;
+      RECT 4016.880 4.080 4018.080 300.560 ;
+      RECT 4027.760 4.080 4028.960 300.560 ;
+      RECT 4038.640 4.080 4039.840 300.560 ;
+      RECT 4049.520 4.080 4050.720 300.560 ;
+      RECT 4060.400 4.080 4061.600 300.560 ;
+      RECT 4071.280 4.080 4072.480 300.560 ;
+      RECT 4082.160 4.080 4083.360 300.560 ;
+      RECT 4093.040 4.080 4094.240 300.560 ;
+      RECT 4103.920 4.080 4105.120 300.560 ;
+      RECT 4114.800 4.080 4116.000 300.560 ;
+      RECT 4125.680 4.080 4126.880 300.560 ;
+      RECT 4136.560 4.080 4137.760 300.560 ;
+      RECT 4147.440 4.080 4148.640 300.560 ;
+      RECT 4158.320 4.080 4159.520 300.560 ;
+      RECT 4169.200 4.080 4170.400 300.560 ;
+      RECT 4180.080 4.080 4181.280 300.560 ;
+      RECT 4190.960 4.080 4192.160 300.560 ;
+      RECT 4201.840 4.080 4203.040 300.560 ;
+      RECT 4212.720 4.080 4213.920 300.560 ;
+      RECT 4223.600 4.080 4224.800 300.560 ;
+      RECT 4234.480 4.080 4235.680 300.560 ;
+      RECT 4245.360 4.080 4246.560 300.560 ;
+      RECT 4256.240 4.080 4257.440 300.560 ;
+      RECT 4267.120 4.080 4268.320 300.560 ;
+      RECT 4278.000 4.080 4279.200 300.560 ;
+      RECT 4288.880 4.080 4290.080 300.560 ;
+      RECT 4299.760 4.080 4300.960 300.560 ;
+      RECT 4310.640 4.080 4311.840 300.560 ;
+      RECT 4321.520 4.080 4322.720 300.560 ;
+      RECT 4332.400 4.080 4333.600 300.560 ;
+      RECT 4343.280 4.080 4344.480 300.560 ;
+      RECT 4354.160 4.080 4355.360 300.560 ;
+      RECT 4365.040 4.080 4366.240 300.560 ;
+      RECT 4375.920 4.080 4377.120 300.560 ;
+      RECT 4386.800 4.080 4388.000 300.560 ;
+      RECT 4397.680 4.080 4398.880 300.560 ;
+      RECT 4408.560 4.080 4409.760 300.560 ;
+      RECT 4419.440 4.080 4420.640 300.560 ;
+      RECT 4430.320 4.080 4431.520 300.560 ;
+      RECT 4441.200 4.080 4442.400 300.560 ;
+      RECT 4452.080 4.080 4453.280 300.560 ;
+      RECT 4462.960 4.080 4464.160 300.560 ;
+      RECT 4473.840 4.080 4475.040 300.560 ;
+      RECT 4484.720 4.080 4485.920 300.560 ;
+      RECT 4495.600 4.080 4496.800 300.560 ;
+      RECT 4506.480 4.080 4507.680 300.560 ;
+      RECT 4517.360 4.080 4518.560 300.560 ;
+      RECT 4528.240 4.080 4529.440 300.560 ;
+      RECT 4539.120 4.080 4540.320 300.560 ;
+      RECT 4550.000 4.080 4551.200 300.560 ;
+      RECT 4560.880 4.080 4562.080 300.560 ;
+      RECT 4571.760 4.080 4572.960 300.560 ;
+      RECT 4582.640 4.080 4583.840 300.560 ;
+      RECT 4593.520 4.080 4594.720 300.560 ;
+      RECT 4604.400 4.080 4605.600 300.560 ;
+      RECT 4615.280 4.080 4616.480 300.560 ;
+      RECT 4626.160 4.080 4627.360 300.560 ;
+      RECT 4637.040 4.080 4638.240 300.560 ;
+      RECT 4647.920 4.080 4649.120 300.560 ;
+      RECT 4658.800 4.080 4660.000 300.560 ;
+      RECT 4669.680 4.080 4670.880 300.560 ;
+      RECT 4680.560 4.080 4681.760 300.560 ;
+      RECT 4691.440 4.080 4692.640 300.560 ;
+      RECT 4702.320 4.080 4703.520 300.560 ;
+      RECT 4713.200 4.080 4714.400 300.560 ;
+      RECT 4724.080 4.080 4725.280 300.560 ;
+      RECT 4734.960 4.080 4736.160 300.560 ;
+      RECT 4745.840 4.080 4747.040 300.560 ;
+      RECT 4756.720 4.080 4757.920 300.560 ;
+      RECT 4767.600 4.080 4768.800 300.560 ;
+      RECT 4778.480 4.080 4779.680 300.560 ;
+      RECT 4789.360 4.080 4790.560 300.560 ;
+      RECT 4800.240 4.080 4801.440 300.560 ;
+      RECT 4811.120 4.080 4812.320 300.560 ;
+      RECT 4822.000 4.080 4823.200 300.560 ;
+      RECT 4832.880 4.080 4834.080 300.560 ;
+      RECT 4843.760 4.080 4844.960 300.560 ;
+      RECT 4854.640 4.080 4855.840 300.560 ;
+      RECT 4865.520 4.080 4866.720 300.560 ;
+      RECT 4876.400 4.080 4877.600 300.560 ;
+      RECT 4887.280 4.080 4888.480 300.560 ;
+      RECT 4898.160 4.080 4899.360 300.560 ;
+      RECT 4909.040 4.080 4910.240 300.560 ;
+      RECT 4919.920 4.080 4921.120 300.560 ;
+      RECT 4930.800 4.080 4932.000 300.560 ;
+      RECT 4941.680 4.080 4942.880 300.560 ;
+      RECT 4952.560 4.080 4953.760 300.560 ;
+      RECT 4963.440 4.080 4964.640 300.560 ;
+      RECT 4974.320 4.080 4975.520 300.560 ;
+      RECT 4985.200 4.080 4986.400 300.560 ;
+      RECT 4996.080 4.080 4997.280 300.560 ;
+      RECT 5006.960 4.080 5008.160 300.560 ;
+      RECT 5017.840 4.080 5019.040 300.560 ;
+      RECT 5028.720 4.080 5029.920 300.560 ;
+      RECT 5039.600 4.080 5040.800 300.560 ;
+      RECT 5050.480 4.080 5051.680 300.560 ;
+      RECT 5061.360 4.080 5062.560 300.560 ;
+      RECT 5072.240 4.080 5073.440 300.560 ;
+      RECT 5083.120 4.080 5084.320 300.560 ;
+      RECT 5094.000 4.080 5095.200 300.560 ;
+      RECT 5104.880 4.080 5106.080 300.560 ;
+      RECT 5115.760 4.080 5116.960 300.560 ;
+      RECT 5126.640 4.080 5127.840 300.560 ;
+      RECT 5137.520 4.080 5138.720 300.560 ;
+      RECT 5148.400 4.080 5149.600 300.560 ;
+      RECT 5159.280 4.080 5160.480 300.560 ;
+      RECT 5170.160 4.080 5171.360 300.560 ;
+      RECT 5181.040 4.080 5182.240 300.560 ;
+      RECT 5191.920 4.080 5193.120 300.560 ;
+      RECT 5202.800 4.080 5204.000 300.560 ;
+      RECT 5213.680 4.080 5214.880 300.560 ;
+      RECT 5224.560 4.080 5225.760 300.560 ;
+      RECT 5235.440 4.080 5236.640 300.560 ;
+      RECT 5246.320 4.080 5247.520 300.560 ;
+      RECT 5257.200 4.080 5258.400 300.560 ;
+      RECT 5268.080 4.080 5269.280 300.560 ;
+      RECT 5278.960 4.080 5280.160 300.560 ;
+      RECT 5289.840 4.080 5291.040 300.560 ;
+      RECT 5300.720 4.080 5301.920 300.560 ;
+      RECT 5311.600 4.080 5312.800 300.560 ;
+      RECT 5322.480 4.080 5323.680 300.560 ;
+      RECT 5333.360 4.080 5334.560 300.560 ;
+      RECT 5344.240 4.080 5345.440 300.560 ;
+      RECT 5355.120 4.080 5356.320 300.560 ;
+      RECT 5366.000 4.080 5367.200 300.560 ;
+      RECT 5376.880 4.080 5378.080 300.560 ;
+      RECT 5387.760 4.080 5388.960 300.560 ;
+      RECT 5398.640 4.080 5399.840 300.560 ;
+      RECT 5409.520 4.080 5410.720 300.560 ;
+      RECT 5420.400 4.080 5421.600 300.560 ;
+      RECT 5431.280 4.080 5432.480 300.560 ;
+      RECT 5442.160 4.080 5443.360 300.560 ;
+      RECT 5453.040 4.080 5454.240 300.560 ;
+      RECT 5463.920 4.080 5465.120 300.560 ;
+      RECT 5474.800 4.080 5476.000 300.560 ;
+      RECT 5485.680 4.080 5486.880 300.560 ;
+      RECT 5496.560 4.080 5497.760 300.560 ;
+      RECT 5507.440 4.080 5508.640 300.560 ;
+      RECT 5518.320 4.080 5519.520 300.560 ;
+      RECT 5529.200 4.080 5530.400 300.560 ;
+      RECT 5540.080 4.080 5541.280 300.560 ;
+      RECT 5550.960 4.080 5552.160 300.560 ;
+      RECT 5561.840 4.080 5563.040 300.560 ;
+      RECT 5572.720 4.080 5573.920 300.560 ;
+      RECT 5583.600 4.080 5584.800 300.560 ;
+      RECT 5594.480 4.080 5595.680 300.560 ;
+      RECT 5605.360 4.080 5606.560 300.560 ;
+      RECT 5616.240 4.080 5617.440 300.560 ;
+      RECT 5627.120 4.080 5628.320 300.560 ;
+      RECT 5638.000 4.080 5639.200 300.560 ;
+      RECT 5648.880 4.080 5650.080 300.560 ;
+      RECT 5659.760 4.080 5660.960 300.560 ;
+      RECT 5670.640 4.080 5671.840 300.560 ;
+      RECT 5681.520 4.080 5682.720 300.560 ;
+      RECT 5692.400 4.080 5693.600 300.560 ;
+      RECT 5703.280 4.080 5704.480 300.560 ;
+      RECT 5714.160 4.080 5715.360 300.560 ;
+      RECT 5725.040 4.080 5726.240 300.560 ;
+      RECT 5735.920 4.080 5737.120 300.560 ;
+      RECT 5746.800 4.080 5748.000 300.560 ;
+      RECT 5757.680 4.080 5758.880 300.560 ;
+      RECT 5768.560 4.080 5769.760 300.560 ;
+      RECT 5779.440 4.080 5780.640 300.560 ;
+      RECT 5790.320 4.080 5791.520 300.560 ;
+      RECT 5801.200 4.080 5802.400 300.560 ;
+      RECT 5812.080 4.080 5813.280 300.560 ;
+      RECT 5822.960 4.080 5824.160 300.560 ;
+      RECT 5833.840 4.080 5835.040 300.560 ;
+      RECT 5844.720 4.080 5845.920 300.560 ;
+      RECT 5855.600 4.080 5856.800 300.560 ;
+      RECT 5866.480 4.080 5867.680 300.560 ;
+      RECT 5877.360 4.080 5878.560 300.560 ;
+      RECT 5888.240 4.080 5889.440 300.560 ;
+      RECT 5899.120 4.080 5900.320 300.560 ;
+      RECT 5910.000 4.080 5911.200 300.560 ;
+      RECT 5920.880 4.080 5922.080 300.560 ;
+      RECT 5931.760 4.080 5932.960 300.560 ;
+      RECT 5942.640 4.080 5943.840 300.560 ;
+      RECT 5953.520 4.080 5954.720 300.560 ;
+      RECT 5964.400 4.080 5965.600 300.560 ;
+      RECT 5975.280 4.080 5976.480 300.560 ;
+      RECT 5986.160 4.080 5987.360 300.560 ;
+      RECT 5997.040 4.080 5998.240 300.560 ;
+      RECT 6007.920 4.080 6009.120 300.560 ;
+      RECT 6018.800 4.080 6020.000 300.560 ;
+      RECT 6029.680 4.080 6030.880 300.560 ;
+      RECT 6040.560 4.080 6041.760 300.560 ;
+      RECT 6051.440 4.080 6052.640 300.560 ;
+      RECT 6062.320 4.080 6063.520 300.560 ;
+      RECT 6073.200 4.080 6074.400 300.560 ;
+      RECT 6084.080 4.080 6085.280 300.560 ;
+      RECT 6094.960 4.080 6096.160 300.560 ;
+      RECT 6105.840 4.080 6107.040 300.560 ;
+      RECT 6116.720 4.080 6117.920 300.560 ;
+      RECT 6127.600 4.080 6128.800 300.560 ;
+      RECT 6138.480 4.080 6139.680 300.560 ;
+      RECT 6149.360 4.080 6150.560 300.560 ;
+      RECT 6160.240 4.080 6161.440 300.560 ;
+      RECT 6171.120 4.080 6172.320 300.560 ;
+      RECT 6182.000 4.080 6183.200 300.560 ;
+      RECT 6192.880 4.080 6194.080 300.560 ;
+      RECT 6203.760 4.080 6204.960 300.560 ;
+      RECT 6214.640 4.080 6215.840 300.560 ;
+      RECT 6225.520 4.080 6226.720 300.560 ;
+      RECT 6236.400 4.080 6237.600 300.560 ;
+      RECT 6247.280 4.080 6248.480 300.560 ;
+      RECT 6258.160 4.080 6259.360 300.560 ;
+      RECT 6269.040 4.080 6270.240 300.560 ;
+      RECT 6279.920 4.080 6281.120 300.560 ;
+      RECT 6290.800 4.080 6292.000 300.560 ;
+      RECT 6301.680 4.080 6302.880 300.560 ;
+      RECT 6312.560 4.080 6313.760 300.560 ;
+      RECT 6323.440 4.080 6324.640 300.560 ;
+      RECT 6334.320 4.080 6335.520 300.560 ;
+      RECT 6345.200 4.080 6346.400 300.560 ;
+      RECT 6356.080 4.080 6357.280 300.560 ;
+      RECT 6366.960 4.080 6368.160 300.560 ;
+      RECT 6377.840 4.080 6379.040 300.560 ;
+      RECT 6388.720 4.080 6389.920 300.560 ;
+      RECT 6399.600 4.080 6400.800 300.560 ;
+      RECT 6410.480 4.080 6411.680 300.560 ;
+      RECT 6421.360 4.080 6422.560 300.560 ;
+      RECT 6432.240 4.080 6433.440 300.560 ;
+      RECT 6443.120 4.080 6444.320 300.560 ;
+      RECT 6454.000 4.080 6455.200 300.560 ;
+      RECT 6464.880 4.080 6466.080 300.560 ;
+      RECT 6475.760 4.080 6476.960 300.560 ;
+      RECT 6486.640 4.080 6487.840 300.560 ;
+      RECT 6497.520 4.080 6498.720 300.560 ;
+      RECT 6508.400 4.080 6509.600 300.560 ;
+      RECT 6519.280 4.080 6520.480 300.560 ;
+      RECT 6530.160 4.080 6531.360 300.560 ;
+      RECT 6541.040 4.080 6542.240 300.560 ;
+      RECT 6551.920 4.080 6553.120 300.560 ;
+      RECT 6562.800 4.080 6564.000 300.560 ;
+      RECT 6573.680 4.080 6574.880 300.560 ;
+      RECT 6584.560 4.080 6585.760 300.560 ;
+      RECT 6595.440 4.080 6596.640 300.560 ;
+      RECT 6606.320 4.080 6607.520 300.560 ;
+      RECT 6617.200 4.080 6618.400 300.560 ;
+      RECT 6628.080 4.080 6629.280 300.560 ;
+      RECT 6638.960 4.080 6640.160 300.560 ;
+      RECT 6649.840 4.080 6651.040 300.560 ;
+      RECT 6660.720 4.080 6661.920 300.560 ;
+      RECT 6671.600 4.080 6672.800 300.560 ;
+      RECT 6682.480 4.080 6683.680 300.560 ;
+      RECT 6693.360 4.080 6694.560 300.560 ;
+      RECT 6704.240 4.080 6705.440 300.560 ;
+      RECT 6715.120 4.080 6716.320 300.560 ;
+      RECT 6726.000 4.080 6727.200 300.560 ;
+      RECT 6736.880 4.080 6738.080 300.560 ;
+      RECT 6747.760 4.080 6748.960 300.560 ;
+      RECT 6758.640 4.080 6759.840 300.560 ;
+      RECT 6769.520 4.080 6770.720 300.560 ;
+      RECT 6780.400 4.080 6781.600 300.560 ;
+      RECT 6791.280 4.080 6792.480 300.560 ;
+      RECT 6802.160 4.080 6803.360 300.560 ;
+      RECT 6813.040 4.080 6814.240 300.560 ;
+      RECT 6823.920 4.080 6825.120 300.560 ;
+      RECT 6834.800 4.080 6836.000 300.560 ;
+      RECT 6845.680 4.080 6846.880 300.560 ;
+      RECT 6856.560 4.080 6857.760 300.560 ;
+      RECT 6867.440 4.080 6868.640 300.560 ;
+      RECT 6878.320 4.080 6879.520 300.560 ;
+      RECT 6889.200 4.080 6890.400 300.560 ;
+      RECT 6900.080 4.080 6901.280 300.560 ;
+      RECT 6910.960 4.080 6912.160 300.560 ;
+      RECT 6921.840 4.080 6923.040 300.560 ;
+      RECT 6932.720 4.080 6933.920 300.560 ;
+      RECT 6943.600 4.080 6944.800 300.560 ;
+      RECT 6954.480 4.080 6955.680 300.560 ;
+      RECT 6965.360 4.080 6966.560 300.560 ;
+      RECT 6976.240 4.080 6977.440 300.560 ;
+      RECT 6987.120 4.080 6988.320 300.560 ;
+      RECT 6998.000 4.080 6999.200 300.560 ;
+      RECT 7008.880 4.080 7010.080 300.560 ;
+      RECT 7019.760 4.080 7020.960 300.560 ;
+      RECT 7030.640 4.080 7031.840 300.560 ;
+      RECT 7041.520 4.080 7042.720 300.560 ;
+      RECT 7052.400 4.080 7053.600 300.560 ;
+      RECT 7063.280 4.080 7064.480 300.560 ;
+      RECT 7074.160 4.080 7075.360 300.560 ;
+      RECT 7085.040 4.080 7086.240 300.560 ;
+      RECT 7095.920 4.080 7097.120 300.560 ;
+      RECT 7106.800 4.080 7108.000 300.560 ;
+      RECT 7117.680 4.080 7118.880 300.560 ;
+      RECT 7128.560 4.080 7129.760 300.560 ;
+      RECT 7139.440 4.080 7140.640 300.560 ;
+      RECT 7150.320 4.080 7151.520 300.560 ;
+      RECT 7161.200 4.080 7162.400 300.560 ;
+      RECT 7172.080 4.080 7173.280 300.560 ;
+      RECT 7182.960 4.080 7184.160 300.560 ;
+      RECT 7193.840 4.080 7195.040 300.560 ;
+      RECT 7204.720 4.080 7205.920 300.560 ;
+      RECT 7215.600 4.080 7216.800 300.560 ;
+      RECT 7226.480 4.080 7227.680 300.560 ;
+      RECT 7237.360 4.080 7238.560 300.560 ;
+      RECT 7248.240 4.080 7249.440 300.560 ;
+      RECT 7259.120 4.080 7260.320 300.560 ;
+      RECT 7270.000 4.080 7271.200 300.560 ;
+      RECT 7280.880 4.080 7282.080 300.560 ;
+      RECT 7291.760 4.080 7292.960 300.560 ;
+      RECT 7302.640 4.080 7303.840 300.560 ;
+      RECT 7313.520 4.080 7314.720 300.560 ;
+      RECT 7324.400 4.080 7325.600 300.560 ;
+      RECT 7335.280 4.080 7336.480 300.560 ;
+      RECT 7346.160 4.080 7347.360 300.560 ;
+      RECT 7357.040 4.080 7358.240 300.560 ;
+      RECT 7367.920 4.080 7369.120 300.560 ;
+      RECT 7378.800 4.080 7380.000 300.560 ;
+      RECT 7389.680 4.080 7390.880 300.560 ;
+      RECT 7400.560 4.080 7401.760 300.560 ;
+      RECT 7411.440 4.080 7412.640 300.560 ;
+      RECT 7422.320 4.080 7423.520 300.560 ;
+      RECT 7433.200 4.080 7434.400 300.560 ;
+      RECT 7444.080 4.080 7445.280 300.560 ;
+      RECT 7454.960 4.080 7456.160 300.560 ;
+      RECT 7465.840 4.080 7467.040 300.560 ;
+      RECT 7476.720 4.080 7477.920 300.560 ;
+      RECT 7487.600 4.080 7488.800 300.560 ;
+      RECT 7498.480 4.080 7499.680 300.560 ;
+      RECT 7509.360 4.080 7510.560 300.560 ;
+      RECT 7520.240 4.080 7521.440 300.560 ;
+      RECT 7531.120 4.080 7532.320 300.560 ;
+      RECT 7542.000 4.080 7543.200 300.560 ;
+      RECT 7552.880 4.080 7554.080 300.560 ;
+      RECT 7563.760 4.080 7564.960 300.560 ;
+      RECT 7574.640 4.080 7575.840 300.560 ;
+      RECT 7585.520 4.080 7586.720 300.560 ;
+      RECT 7596.400 4.080 7597.600 300.560 ;
+      RECT 7607.280 4.080 7608.480 300.560 ;
+      RECT 7618.160 4.080 7619.360 300.560 ;
+      RECT 7629.040 4.080 7630.240 300.560 ;
+      RECT 7639.920 4.080 7641.120 300.560 ;
+      RECT 7650.800 4.080 7652.000 300.560 ;
+      RECT 7661.680 4.080 7662.880 300.560 ;
+      RECT 7672.560 4.080 7673.760 300.560 ;
+      RECT 7683.440 4.080 7684.640 300.560 ;
+      RECT 7694.320 4.080 7695.520 300.560 ;
+      RECT 7705.200 4.080 7706.400 300.560 ;
+      RECT 7716.080 4.080 7717.280 300.560 ;
+      RECT 7726.960 4.080 7728.160 300.560 ;
+      RECT 7737.840 4.080 7739.040 300.560 ;
+      RECT 7748.720 4.080 7749.920 300.560 ;
+      RECT 7759.600 4.080 7760.800 300.560 ;
+      RECT 7770.480 4.080 7771.680 300.560 ;
+      RECT 7781.360 4.080 7782.560 300.560 ;
+      RECT 7792.240 4.080 7793.440 300.560 ;
+      RECT 7803.120 4.080 7804.320 300.560 ;
+    END
+  END VDD
+  OBS
+    LAYER met1 ;
+    RECT 0 0 7813.100 304.640 ;
+    LAYER met2 ;
+    RECT 0 0 7813.100 304.640 ;
+    LAYER met3 ;
+    RECT 0 0 7813.100 304.640 ;
+    LAYER met4 ;
+    RECT 0 0 7813.100 304.640 ;
+  END
+END fakeram_2048x128_1rw
+
+END LIBRARY

--- a/designs/sky130hd/coralnpu/sram/lef/fakeram_512x128_1rw.lef
+++ b/designs/sky130hd/coralnpu/sram/lef/fakeram_512x128_1rw.lef
@@ -1,0 +1,2700 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_512x128_1rw
+  FOREIGN fakeram_512x128_1rw 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 597.080 BY 650.080 ;
+  CLASS BLOCK ;
+  PIN rw0_wmask_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.930 0.900 4.230 ;
+    END
+  END rw0_wmask_in[0]
+  PIN rw0_wmask_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.770 0.900 13.070 ;
+    END
+  END rw0_wmask_in[1]
+  PIN rw0_wmask_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.610 0.900 21.910 ;
+    END
+  END rw0_wmask_in[2]
+  PIN rw0_wmask_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.450 0.900 30.750 ;
+    END
+  END rw0_wmask_in[3]
+  PIN rw0_wmask_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 3.930 597.080 4.230 ;
+    END
+  END rw0_wmask_in[4]
+  PIN rw0_wmask_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 12.770 597.080 13.070 ;
+    END
+  END rw0_wmask_in[5]
+  PIN rw0_wmask_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 21.610 597.080 21.910 ;
+    END
+  END rw0_wmask_in[6]
+  PIN rw0_wmask_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 30.450 597.080 30.750 ;
+    END
+  END rw0_wmask_in[7]
+  PIN rw0_wmask_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2.690 649.660 2.830 650.080 ;
+    END
+  END rw0_wmask_in[8]
+  PIN rw0_wmask_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 6.830 649.660 6.970 650.080 ;
+    END
+  END rw0_wmask_in[9]
+  PIN rw0_wmask_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 10.970 649.660 11.110 650.080 ;
+    END
+  END rw0_wmask_in[10]
+  PIN rw0_wmask_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 15.110 649.660 15.250 650.080 ;
+    END
+  END rw0_wmask_in[11]
+  PIN rw0_wmask_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 19.250 649.660 19.390 650.080 ;
+    END
+  END rw0_wmask_in[12]
+  PIN rw0_wmask_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 23.390 649.660 23.530 650.080 ;
+    END
+  END rw0_wmask_in[13]
+  PIN rw0_wmask_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 27.530 649.660 27.670 650.080 ;
+    END
+  END rw0_wmask_in[14]
+  PIN rw0_wmask_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 31.670 649.660 31.810 650.080 ;
+    END
+  END rw0_wmask_in[15]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.290 0.900 39.590 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.130 0.900 48.430 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.970 0.900 57.270 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.810 0.900 66.110 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.650 0.900 74.950 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.490 0.900 83.790 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.330 0.900 92.630 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.170 0.900 101.470 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.010 0.900 110.310 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.850 0.900 119.150 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.690 0.900 127.990 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.530 0.900 136.830 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 145.370 0.900 145.670 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 154.210 0.900 154.510 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 163.050 0.900 163.350 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 171.890 0.900 172.190 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 180.730 0.900 181.030 ;
+    END
+  END rw0_wd_in[16]
+  PIN rw0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 189.570 0.900 189.870 ;
+    END
+  END rw0_wd_in[17]
+  PIN rw0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 198.410 0.900 198.710 ;
+    END
+  END rw0_wd_in[18]
+  PIN rw0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 207.250 0.900 207.550 ;
+    END
+  END rw0_wd_in[19]
+  PIN rw0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 216.090 0.900 216.390 ;
+    END
+  END rw0_wd_in[20]
+  PIN rw0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 224.930 0.900 225.230 ;
+    END
+  END rw0_wd_in[21]
+  PIN rw0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 233.770 0.900 234.070 ;
+    END
+  END rw0_wd_in[22]
+  PIN rw0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 242.610 0.900 242.910 ;
+    END
+  END rw0_wd_in[23]
+  PIN rw0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 251.450 0.900 251.750 ;
+    END
+  END rw0_wd_in[24]
+  PIN rw0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 260.290 0.900 260.590 ;
+    END
+  END rw0_wd_in[25]
+  PIN rw0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 269.130 0.900 269.430 ;
+    END
+  END rw0_wd_in[26]
+  PIN rw0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 277.970 0.900 278.270 ;
+    END
+  END rw0_wd_in[27]
+  PIN rw0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 286.810 0.900 287.110 ;
+    END
+  END rw0_wd_in[28]
+  PIN rw0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 295.650 0.900 295.950 ;
+    END
+  END rw0_wd_in[29]
+  PIN rw0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 304.490 0.900 304.790 ;
+    END
+  END rw0_wd_in[30]
+  PIN rw0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 313.330 0.900 313.630 ;
+    END
+  END rw0_wd_in[31]
+  PIN rw0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 39.290 597.080 39.590 ;
+    END
+  END rw0_wd_in[32]
+  PIN rw0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 48.130 597.080 48.430 ;
+    END
+  END rw0_wd_in[33]
+  PIN rw0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 56.970 597.080 57.270 ;
+    END
+  END rw0_wd_in[34]
+  PIN rw0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 65.810 597.080 66.110 ;
+    END
+  END rw0_wd_in[35]
+  PIN rw0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 74.650 597.080 74.950 ;
+    END
+  END rw0_wd_in[36]
+  PIN rw0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 83.490 597.080 83.790 ;
+    END
+  END rw0_wd_in[37]
+  PIN rw0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 92.330 597.080 92.630 ;
+    END
+  END rw0_wd_in[38]
+  PIN rw0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 101.170 597.080 101.470 ;
+    END
+  END rw0_wd_in[39]
+  PIN rw0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 110.010 597.080 110.310 ;
+    END
+  END rw0_wd_in[40]
+  PIN rw0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 118.850 597.080 119.150 ;
+    END
+  END rw0_wd_in[41]
+  PIN rw0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 127.690 597.080 127.990 ;
+    END
+  END rw0_wd_in[42]
+  PIN rw0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 136.530 597.080 136.830 ;
+    END
+  END rw0_wd_in[43]
+  PIN rw0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 145.370 597.080 145.670 ;
+    END
+  END rw0_wd_in[44]
+  PIN rw0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 154.210 597.080 154.510 ;
+    END
+  END rw0_wd_in[45]
+  PIN rw0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 163.050 597.080 163.350 ;
+    END
+  END rw0_wd_in[46]
+  PIN rw0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 171.890 597.080 172.190 ;
+    END
+  END rw0_wd_in[47]
+  PIN rw0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 180.730 597.080 181.030 ;
+    END
+  END rw0_wd_in[48]
+  PIN rw0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 189.570 597.080 189.870 ;
+    END
+  END rw0_wd_in[49]
+  PIN rw0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 198.410 597.080 198.710 ;
+    END
+  END rw0_wd_in[50]
+  PIN rw0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 207.250 597.080 207.550 ;
+    END
+  END rw0_wd_in[51]
+  PIN rw0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 216.090 597.080 216.390 ;
+    END
+  END rw0_wd_in[52]
+  PIN rw0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 224.930 597.080 225.230 ;
+    END
+  END rw0_wd_in[53]
+  PIN rw0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 233.770 597.080 234.070 ;
+    END
+  END rw0_wd_in[54]
+  PIN rw0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 242.610 597.080 242.910 ;
+    END
+  END rw0_wd_in[55]
+  PIN rw0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 251.450 597.080 251.750 ;
+    END
+  END rw0_wd_in[56]
+  PIN rw0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 260.290 597.080 260.590 ;
+    END
+  END rw0_wd_in[57]
+  PIN rw0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 269.130 597.080 269.430 ;
+    END
+  END rw0_wd_in[58]
+  PIN rw0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 277.970 597.080 278.270 ;
+    END
+  END rw0_wd_in[59]
+  PIN rw0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 286.810 597.080 287.110 ;
+    END
+  END rw0_wd_in[60]
+  PIN rw0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 295.650 597.080 295.950 ;
+    END
+  END rw0_wd_in[61]
+  PIN rw0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 304.490 597.080 304.790 ;
+    END
+  END rw0_wd_in[62]
+  PIN rw0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 313.330 597.080 313.630 ;
+    END
+  END rw0_wd_in[63]
+  PIN rw0_wd_in[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2.690 0.000 2.830 0.420 ;
+    END
+  END rw0_wd_in[64]
+  PIN rw0_wd_in[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 7.290 0.000 7.430 0.420 ;
+    END
+  END rw0_wd_in[65]
+  PIN rw0_wd_in[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 11.890 0.000 12.030 0.420 ;
+    END
+  END rw0_wd_in[66]
+  PIN rw0_wd_in[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 16.490 0.000 16.630 0.420 ;
+    END
+  END rw0_wd_in[67]
+  PIN rw0_wd_in[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 21.090 0.000 21.230 0.420 ;
+    END
+  END rw0_wd_in[68]
+  PIN rw0_wd_in[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 25.690 0.000 25.830 0.420 ;
+    END
+  END rw0_wd_in[69]
+  PIN rw0_wd_in[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 30.290 0.000 30.430 0.420 ;
+    END
+  END rw0_wd_in[70]
+  PIN rw0_wd_in[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 34.890 0.000 35.030 0.420 ;
+    END
+  END rw0_wd_in[71]
+  PIN rw0_wd_in[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 39.490 0.000 39.630 0.420 ;
+    END
+  END rw0_wd_in[72]
+  PIN rw0_wd_in[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 44.090 0.000 44.230 0.420 ;
+    END
+  END rw0_wd_in[73]
+  PIN rw0_wd_in[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 48.690 0.000 48.830 0.420 ;
+    END
+  END rw0_wd_in[74]
+  PIN rw0_wd_in[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 53.290 0.000 53.430 0.420 ;
+    END
+  END rw0_wd_in[75]
+  PIN rw0_wd_in[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 57.890 0.000 58.030 0.420 ;
+    END
+  END rw0_wd_in[76]
+  PIN rw0_wd_in[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 62.490 0.000 62.630 0.420 ;
+    END
+  END rw0_wd_in[77]
+  PIN rw0_wd_in[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 67.090 0.000 67.230 0.420 ;
+    END
+  END rw0_wd_in[78]
+  PIN rw0_wd_in[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 71.690 0.000 71.830 0.420 ;
+    END
+  END rw0_wd_in[79]
+  PIN rw0_wd_in[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 76.290 0.000 76.430 0.420 ;
+    END
+  END rw0_wd_in[80]
+  PIN rw0_wd_in[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 80.890 0.000 81.030 0.420 ;
+    END
+  END rw0_wd_in[81]
+  PIN rw0_wd_in[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 85.490 0.000 85.630 0.420 ;
+    END
+  END rw0_wd_in[82]
+  PIN rw0_wd_in[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 90.090 0.000 90.230 0.420 ;
+    END
+  END rw0_wd_in[83]
+  PIN rw0_wd_in[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 94.690 0.000 94.830 0.420 ;
+    END
+  END rw0_wd_in[84]
+  PIN rw0_wd_in[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 99.290 0.000 99.430 0.420 ;
+    END
+  END rw0_wd_in[85]
+  PIN rw0_wd_in[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 103.890 0.000 104.030 0.420 ;
+    END
+  END rw0_wd_in[86]
+  PIN rw0_wd_in[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 108.490 0.000 108.630 0.420 ;
+    END
+  END rw0_wd_in[87]
+  PIN rw0_wd_in[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 113.090 0.000 113.230 0.420 ;
+    END
+  END rw0_wd_in[88]
+  PIN rw0_wd_in[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 117.690 0.000 117.830 0.420 ;
+    END
+  END rw0_wd_in[89]
+  PIN rw0_wd_in[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 122.290 0.000 122.430 0.420 ;
+    END
+  END rw0_wd_in[90]
+  PIN rw0_wd_in[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 126.890 0.000 127.030 0.420 ;
+    END
+  END rw0_wd_in[91]
+  PIN rw0_wd_in[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 131.490 0.000 131.630 0.420 ;
+    END
+  END rw0_wd_in[92]
+  PIN rw0_wd_in[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 136.090 0.000 136.230 0.420 ;
+    END
+  END rw0_wd_in[93]
+  PIN rw0_wd_in[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 140.690 0.000 140.830 0.420 ;
+    END
+  END rw0_wd_in[94]
+  PIN rw0_wd_in[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 145.290 0.000 145.430 0.420 ;
+    END
+  END rw0_wd_in[95]
+  PIN rw0_wd_in[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 149.890 0.000 150.030 0.420 ;
+    END
+  END rw0_wd_in[96]
+  PIN rw0_wd_in[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 154.490 0.000 154.630 0.420 ;
+    END
+  END rw0_wd_in[97]
+  PIN rw0_wd_in[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 159.090 0.000 159.230 0.420 ;
+    END
+  END rw0_wd_in[98]
+  PIN rw0_wd_in[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 163.690 0.000 163.830 0.420 ;
+    END
+  END rw0_wd_in[99]
+  PIN rw0_wd_in[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 168.290 0.000 168.430 0.420 ;
+    END
+  END rw0_wd_in[100]
+  PIN rw0_wd_in[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 172.890 0.000 173.030 0.420 ;
+    END
+  END rw0_wd_in[101]
+  PIN rw0_wd_in[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 177.490 0.000 177.630 0.420 ;
+    END
+  END rw0_wd_in[102]
+  PIN rw0_wd_in[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 182.090 0.000 182.230 0.420 ;
+    END
+  END rw0_wd_in[103]
+  PIN rw0_wd_in[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 186.690 0.000 186.830 0.420 ;
+    END
+  END rw0_wd_in[104]
+  PIN rw0_wd_in[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 191.290 0.000 191.430 0.420 ;
+    END
+  END rw0_wd_in[105]
+  PIN rw0_wd_in[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 195.890 0.000 196.030 0.420 ;
+    END
+  END rw0_wd_in[106]
+  PIN rw0_wd_in[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 200.490 0.000 200.630 0.420 ;
+    END
+  END rw0_wd_in[107]
+  PIN rw0_wd_in[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 205.090 0.000 205.230 0.420 ;
+    END
+  END rw0_wd_in[108]
+  PIN rw0_wd_in[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 209.690 0.000 209.830 0.420 ;
+    END
+  END rw0_wd_in[109]
+  PIN rw0_wd_in[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 214.290 0.000 214.430 0.420 ;
+    END
+  END rw0_wd_in[110]
+  PIN rw0_wd_in[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 218.890 0.000 219.030 0.420 ;
+    END
+  END rw0_wd_in[111]
+  PIN rw0_wd_in[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 223.490 0.000 223.630 0.420 ;
+    END
+  END rw0_wd_in[112]
+  PIN rw0_wd_in[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 228.090 0.000 228.230 0.420 ;
+    END
+  END rw0_wd_in[113]
+  PIN rw0_wd_in[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 232.690 0.000 232.830 0.420 ;
+    END
+  END rw0_wd_in[114]
+  PIN rw0_wd_in[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 237.290 0.000 237.430 0.420 ;
+    END
+  END rw0_wd_in[115]
+  PIN rw0_wd_in[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 241.890 0.000 242.030 0.420 ;
+    END
+  END rw0_wd_in[116]
+  PIN rw0_wd_in[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 246.490 0.000 246.630 0.420 ;
+    END
+  END rw0_wd_in[117]
+  PIN rw0_wd_in[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 251.090 0.000 251.230 0.420 ;
+    END
+  END rw0_wd_in[118]
+  PIN rw0_wd_in[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 255.690 0.000 255.830 0.420 ;
+    END
+  END rw0_wd_in[119]
+  PIN rw0_wd_in[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 260.290 0.000 260.430 0.420 ;
+    END
+  END rw0_wd_in[120]
+  PIN rw0_wd_in[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 264.890 0.000 265.030 0.420 ;
+    END
+  END rw0_wd_in[121]
+  PIN rw0_wd_in[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 269.490 0.000 269.630 0.420 ;
+    END
+  END rw0_wd_in[122]
+  PIN rw0_wd_in[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 274.090 0.000 274.230 0.420 ;
+    END
+  END rw0_wd_in[123]
+  PIN rw0_wd_in[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 278.690 0.000 278.830 0.420 ;
+    END
+  END rw0_wd_in[124]
+  PIN rw0_wd_in[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 283.290 0.000 283.430 0.420 ;
+    END
+  END rw0_wd_in[125]
+  PIN rw0_wd_in[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 287.890 0.000 288.030 0.420 ;
+    END
+  END rw0_wd_in[126]
+  PIN rw0_wd_in[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 292.490 0.000 292.630 0.420 ;
+    END
+  END rw0_wd_in[127]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 297.090 0.000 297.230 0.420 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 301.690 0.000 301.830 0.420 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 306.290 0.000 306.430 0.420 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 310.890 0.000 311.030 0.420 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 315.490 0.000 315.630 0.420 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 320.090 0.000 320.230 0.420 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 324.690 0.000 324.830 0.420 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 329.290 0.000 329.430 0.420 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 333.890 0.000 334.030 0.420 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 338.490 0.000 338.630 0.420 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 343.090 0.000 343.230 0.420 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 347.690 0.000 347.830 0.420 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 352.290 0.000 352.430 0.420 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 356.890 0.000 357.030 0.420 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 361.490 0.000 361.630 0.420 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 366.090 0.000 366.230 0.420 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 370.690 0.000 370.830 0.420 ;
+    END
+  END rw0_rd_out[16]
+  PIN rw0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 375.290 0.000 375.430 0.420 ;
+    END
+  END rw0_rd_out[17]
+  PIN rw0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 379.890 0.000 380.030 0.420 ;
+    END
+  END rw0_rd_out[18]
+  PIN rw0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 384.490 0.000 384.630 0.420 ;
+    END
+  END rw0_rd_out[19]
+  PIN rw0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 389.090 0.000 389.230 0.420 ;
+    END
+  END rw0_rd_out[20]
+  PIN rw0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 393.690 0.000 393.830 0.420 ;
+    END
+  END rw0_rd_out[21]
+  PIN rw0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 398.290 0.000 398.430 0.420 ;
+    END
+  END rw0_rd_out[22]
+  PIN rw0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 402.890 0.000 403.030 0.420 ;
+    END
+  END rw0_rd_out[23]
+  PIN rw0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 407.490 0.000 407.630 0.420 ;
+    END
+  END rw0_rd_out[24]
+  PIN rw0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 412.090 0.000 412.230 0.420 ;
+    END
+  END rw0_rd_out[25]
+  PIN rw0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 416.690 0.000 416.830 0.420 ;
+    END
+  END rw0_rd_out[26]
+  PIN rw0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 421.290 0.000 421.430 0.420 ;
+    END
+  END rw0_rd_out[27]
+  PIN rw0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 425.890 0.000 426.030 0.420 ;
+    END
+  END rw0_rd_out[28]
+  PIN rw0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 430.490 0.000 430.630 0.420 ;
+    END
+  END rw0_rd_out[29]
+  PIN rw0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 435.090 0.000 435.230 0.420 ;
+    END
+  END rw0_rd_out[30]
+  PIN rw0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 439.690 0.000 439.830 0.420 ;
+    END
+  END rw0_rd_out[31]
+  PIN rw0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 444.290 0.000 444.430 0.420 ;
+    END
+  END rw0_rd_out[32]
+  PIN rw0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 448.890 0.000 449.030 0.420 ;
+    END
+  END rw0_rd_out[33]
+  PIN rw0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 453.490 0.000 453.630 0.420 ;
+    END
+  END rw0_rd_out[34]
+  PIN rw0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 458.090 0.000 458.230 0.420 ;
+    END
+  END rw0_rd_out[35]
+  PIN rw0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 462.690 0.000 462.830 0.420 ;
+    END
+  END rw0_rd_out[36]
+  PIN rw0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 467.290 0.000 467.430 0.420 ;
+    END
+  END rw0_rd_out[37]
+  PIN rw0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 471.890 0.000 472.030 0.420 ;
+    END
+  END rw0_rd_out[38]
+  PIN rw0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 476.490 0.000 476.630 0.420 ;
+    END
+  END rw0_rd_out[39]
+  PIN rw0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 481.090 0.000 481.230 0.420 ;
+    END
+  END rw0_rd_out[40]
+  PIN rw0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 485.690 0.000 485.830 0.420 ;
+    END
+  END rw0_rd_out[41]
+  PIN rw0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 490.290 0.000 490.430 0.420 ;
+    END
+  END rw0_rd_out[42]
+  PIN rw0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 494.890 0.000 495.030 0.420 ;
+    END
+  END rw0_rd_out[43]
+  PIN rw0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 499.490 0.000 499.630 0.420 ;
+    END
+  END rw0_rd_out[44]
+  PIN rw0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 504.090 0.000 504.230 0.420 ;
+    END
+  END rw0_rd_out[45]
+  PIN rw0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 508.690 0.000 508.830 0.420 ;
+    END
+  END rw0_rd_out[46]
+  PIN rw0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 513.290 0.000 513.430 0.420 ;
+    END
+  END rw0_rd_out[47]
+  PIN rw0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 517.890 0.000 518.030 0.420 ;
+    END
+  END rw0_rd_out[48]
+  PIN rw0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 522.490 0.000 522.630 0.420 ;
+    END
+  END rw0_rd_out[49]
+  PIN rw0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 527.090 0.000 527.230 0.420 ;
+    END
+  END rw0_rd_out[50]
+  PIN rw0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 531.690 0.000 531.830 0.420 ;
+    END
+  END rw0_rd_out[51]
+  PIN rw0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 536.290 0.000 536.430 0.420 ;
+    END
+  END rw0_rd_out[52]
+  PIN rw0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 540.890 0.000 541.030 0.420 ;
+    END
+  END rw0_rd_out[53]
+  PIN rw0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 545.490 0.000 545.630 0.420 ;
+    END
+  END rw0_rd_out[54]
+  PIN rw0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 550.090 0.000 550.230 0.420 ;
+    END
+  END rw0_rd_out[55]
+  PIN rw0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 554.690 0.000 554.830 0.420 ;
+    END
+  END rw0_rd_out[56]
+  PIN rw0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 559.290 0.000 559.430 0.420 ;
+    END
+  END rw0_rd_out[57]
+  PIN rw0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 563.890 0.000 564.030 0.420 ;
+    END
+  END rw0_rd_out[58]
+  PIN rw0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 568.490 0.000 568.630 0.420 ;
+    END
+  END rw0_rd_out[59]
+  PIN rw0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 573.090 0.000 573.230 0.420 ;
+    END
+  END rw0_rd_out[60]
+  PIN rw0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 577.690 0.000 577.830 0.420 ;
+    END
+  END rw0_rd_out[61]
+  PIN rw0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 582.290 0.000 582.430 0.420 ;
+    END
+  END rw0_rd_out[62]
+  PIN rw0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 586.890 0.000 587.030 0.420 ;
+    END
+  END rw0_rd_out[63]
+  PIN rw0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 35.810 649.660 35.950 650.080 ;
+    END
+  END rw0_rd_out[64]
+  PIN rw0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 39.950 649.660 40.090 650.080 ;
+    END
+  END rw0_rd_out[65]
+  PIN rw0_rd_out[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 44.090 649.660 44.230 650.080 ;
+    END
+  END rw0_rd_out[66]
+  PIN rw0_rd_out[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 48.230 649.660 48.370 650.080 ;
+    END
+  END rw0_rd_out[67]
+  PIN rw0_rd_out[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 52.370 649.660 52.510 650.080 ;
+    END
+  END rw0_rd_out[68]
+  PIN rw0_rd_out[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 56.510 649.660 56.650 650.080 ;
+    END
+  END rw0_rd_out[69]
+  PIN rw0_rd_out[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 60.650 649.660 60.790 650.080 ;
+    END
+  END rw0_rd_out[70]
+  PIN rw0_rd_out[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 64.790 649.660 64.930 650.080 ;
+    END
+  END rw0_rd_out[71]
+  PIN rw0_rd_out[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 68.930 649.660 69.070 650.080 ;
+    END
+  END rw0_rd_out[72]
+  PIN rw0_rd_out[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 73.070 649.660 73.210 650.080 ;
+    END
+  END rw0_rd_out[73]
+  PIN rw0_rd_out[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 77.210 649.660 77.350 650.080 ;
+    END
+  END rw0_rd_out[74]
+  PIN rw0_rd_out[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 81.350 649.660 81.490 650.080 ;
+    END
+  END rw0_rd_out[75]
+  PIN rw0_rd_out[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 85.490 649.660 85.630 650.080 ;
+    END
+  END rw0_rd_out[76]
+  PIN rw0_rd_out[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 89.630 649.660 89.770 650.080 ;
+    END
+  END rw0_rd_out[77]
+  PIN rw0_rd_out[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 93.770 649.660 93.910 650.080 ;
+    END
+  END rw0_rd_out[78]
+  PIN rw0_rd_out[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 97.910 649.660 98.050 650.080 ;
+    END
+  END rw0_rd_out[79]
+  PIN rw0_rd_out[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 102.050 649.660 102.190 650.080 ;
+    END
+  END rw0_rd_out[80]
+  PIN rw0_rd_out[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 106.190 649.660 106.330 650.080 ;
+    END
+  END rw0_rd_out[81]
+  PIN rw0_rd_out[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 110.330 649.660 110.470 650.080 ;
+    END
+  END rw0_rd_out[82]
+  PIN rw0_rd_out[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 114.470 649.660 114.610 650.080 ;
+    END
+  END rw0_rd_out[83]
+  PIN rw0_rd_out[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 118.610 649.660 118.750 650.080 ;
+    END
+  END rw0_rd_out[84]
+  PIN rw0_rd_out[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 122.750 649.660 122.890 650.080 ;
+    END
+  END rw0_rd_out[85]
+  PIN rw0_rd_out[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 126.890 649.660 127.030 650.080 ;
+    END
+  END rw0_rd_out[86]
+  PIN rw0_rd_out[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 131.030 649.660 131.170 650.080 ;
+    END
+  END rw0_rd_out[87]
+  PIN rw0_rd_out[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 135.170 649.660 135.310 650.080 ;
+    END
+  END rw0_rd_out[88]
+  PIN rw0_rd_out[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 139.310 649.660 139.450 650.080 ;
+    END
+  END rw0_rd_out[89]
+  PIN rw0_rd_out[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 143.450 649.660 143.590 650.080 ;
+    END
+  END rw0_rd_out[90]
+  PIN rw0_rd_out[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 147.590 649.660 147.730 650.080 ;
+    END
+  END rw0_rd_out[91]
+  PIN rw0_rd_out[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 151.730 649.660 151.870 650.080 ;
+    END
+  END rw0_rd_out[92]
+  PIN rw0_rd_out[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 155.870 649.660 156.010 650.080 ;
+    END
+  END rw0_rd_out[93]
+  PIN rw0_rd_out[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 160.010 649.660 160.150 650.080 ;
+    END
+  END rw0_rd_out[94]
+  PIN rw0_rd_out[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 164.150 649.660 164.290 650.080 ;
+    END
+  END rw0_rd_out[95]
+  PIN rw0_rd_out[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 168.290 649.660 168.430 650.080 ;
+    END
+  END rw0_rd_out[96]
+  PIN rw0_rd_out[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 172.430 649.660 172.570 650.080 ;
+    END
+  END rw0_rd_out[97]
+  PIN rw0_rd_out[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 176.570 649.660 176.710 650.080 ;
+    END
+  END rw0_rd_out[98]
+  PIN rw0_rd_out[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 180.710 649.660 180.850 650.080 ;
+    END
+  END rw0_rd_out[99]
+  PIN rw0_rd_out[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 184.850 649.660 184.990 650.080 ;
+    END
+  END rw0_rd_out[100]
+  PIN rw0_rd_out[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 188.990 649.660 189.130 650.080 ;
+    END
+  END rw0_rd_out[101]
+  PIN rw0_rd_out[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 193.130 649.660 193.270 650.080 ;
+    END
+  END rw0_rd_out[102]
+  PIN rw0_rd_out[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 197.270 649.660 197.410 650.080 ;
+    END
+  END rw0_rd_out[103]
+  PIN rw0_rd_out[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 201.410 649.660 201.550 650.080 ;
+    END
+  END rw0_rd_out[104]
+  PIN rw0_rd_out[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 205.550 649.660 205.690 650.080 ;
+    END
+  END rw0_rd_out[105]
+  PIN rw0_rd_out[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 209.690 649.660 209.830 650.080 ;
+    END
+  END rw0_rd_out[106]
+  PIN rw0_rd_out[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 213.830 649.660 213.970 650.080 ;
+    END
+  END rw0_rd_out[107]
+  PIN rw0_rd_out[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 217.970 649.660 218.110 650.080 ;
+    END
+  END rw0_rd_out[108]
+  PIN rw0_rd_out[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 222.110 649.660 222.250 650.080 ;
+    END
+  END rw0_rd_out[109]
+  PIN rw0_rd_out[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 226.250 649.660 226.390 650.080 ;
+    END
+  END rw0_rd_out[110]
+  PIN rw0_rd_out[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 230.390 649.660 230.530 650.080 ;
+    END
+  END rw0_rd_out[111]
+  PIN rw0_rd_out[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 234.530 649.660 234.670 650.080 ;
+    END
+  END rw0_rd_out[112]
+  PIN rw0_rd_out[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 238.670 649.660 238.810 650.080 ;
+    END
+  END rw0_rd_out[113]
+  PIN rw0_rd_out[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 242.810 649.660 242.950 650.080 ;
+    END
+  END rw0_rd_out[114]
+  PIN rw0_rd_out[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 246.950 649.660 247.090 650.080 ;
+    END
+  END rw0_rd_out[115]
+  PIN rw0_rd_out[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 251.090 649.660 251.230 650.080 ;
+    END
+  END rw0_rd_out[116]
+  PIN rw0_rd_out[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 255.230 649.660 255.370 650.080 ;
+    END
+  END rw0_rd_out[117]
+  PIN rw0_rd_out[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 259.370 649.660 259.510 650.080 ;
+    END
+  END rw0_rd_out[118]
+  PIN rw0_rd_out[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 263.510 649.660 263.650 650.080 ;
+    END
+  END rw0_rd_out[119]
+  PIN rw0_rd_out[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 267.650 649.660 267.790 650.080 ;
+    END
+  END rw0_rd_out[120]
+  PIN rw0_rd_out[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 271.790 649.660 271.930 650.080 ;
+    END
+  END rw0_rd_out[121]
+  PIN rw0_rd_out[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 275.930 649.660 276.070 650.080 ;
+    END
+  END rw0_rd_out[122]
+  PIN rw0_rd_out[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 280.070 649.660 280.210 650.080 ;
+    END
+  END rw0_rd_out[123]
+  PIN rw0_rd_out[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 284.210 649.660 284.350 650.080 ;
+    END
+  END rw0_rd_out[124]
+  PIN rw0_rd_out[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 288.350 649.660 288.490 650.080 ;
+    END
+  END rw0_rd_out[125]
+  PIN rw0_rd_out[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 292.490 649.660 292.630 650.080 ;
+    END
+  END rw0_rd_out[126]
+  PIN rw0_rd_out[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 296.630 649.660 296.770 650.080 ;
+    END
+  END rw0_rd_out[127]
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 322.170 0.900 322.470 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 331.010 0.900 331.310 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 339.850 0.900 340.150 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 348.690 0.900 348.990 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 357.530 0.900 357.830 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 322.170 597.080 322.470 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 331.010 597.080 331.310 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 339.850 597.080 340.150 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 596.180 348.690 597.080 348.990 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 300.770 649.660 300.910 650.080 ;
+    END
+  END rw0_we_in
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 304.910 649.660 305.050 650.080 ;
+    END
+  END rw0_ce_in
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 309.050 649.660 309.190 650.080 ;
+    END
+  END rw0_clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 2.160 4.080 3.360 646.000 ;
+      RECT 13.040 4.080 14.240 646.000 ;
+      RECT 23.920 4.080 25.120 646.000 ;
+      RECT 34.800 4.080 36.000 646.000 ;
+      RECT 45.680 4.080 46.880 646.000 ;
+      RECT 56.560 4.080 57.760 646.000 ;
+      RECT 67.440 4.080 68.640 646.000 ;
+      RECT 78.320 4.080 79.520 646.000 ;
+      RECT 89.200 4.080 90.400 646.000 ;
+      RECT 100.080 4.080 101.280 646.000 ;
+      RECT 110.960 4.080 112.160 646.000 ;
+      RECT 121.840 4.080 123.040 646.000 ;
+      RECT 132.720 4.080 133.920 646.000 ;
+      RECT 143.600 4.080 144.800 646.000 ;
+      RECT 154.480 4.080 155.680 646.000 ;
+      RECT 165.360 4.080 166.560 646.000 ;
+      RECT 176.240 4.080 177.440 646.000 ;
+      RECT 187.120 4.080 188.320 646.000 ;
+      RECT 198.000 4.080 199.200 646.000 ;
+      RECT 208.880 4.080 210.080 646.000 ;
+      RECT 219.760 4.080 220.960 646.000 ;
+      RECT 230.640 4.080 231.840 646.000 ;
+      RECT 241.520 4.080 242.720 646.000 ;
+      RECT 252.400 4.080 253.600 646.000 ;
+      RECT 263.280 4.080 264.480 646.000 ;
+      RECT 274.160 4.080 275.360 646.000 ;
+      RECT 285.040 4.080 286.240 646.000 ;
+      RECT 295.920 4.080 297.120 646.000 ;
+      RECT 306.800 4.080 308.000 646.000 ;
+      RECT 317.680 4.080 318.880 646.000 ;
+      RECT 328.560 4.080 329.760 646.000 ;
+      RECT 339.440 4.080 340.640 646.000 ;
+      RECT 350.320 4.080 351.520 646.000 ;
+      RECT 361.200 4.080 362.400 646.000 ;
+      RECT 372.080 4.080 373.280 646.000 ;
+      RECT 382.960 4.080 384.160 646.000 ;
+      RECT 393.840 4.080 395.040 646.000 ;
+      RECT 404.720 4.080 405.920 646.000 ;
+      RECT 415.600 4.080 416.800 646.000 ;
+      RECT 426.480 4.080 427.680 646.000 ;
+      RECT 437.360 4.080 438.560 646.000 ;
+      RECT 448.240 4.080 449.440 646.000 ;
+      RECT 459.120 4.080 460.320 646.000 ;
+      RECT 470.000 4.080 471.200 646.000 ;
+      RECT 480.880 4.080 482.080 646.000 ;
+      RECT 491.760 4.080 492.960 646.000 ;
+      RECT 502.640 4.080 503.840 646.000 ;
+      RECT 513.520 4.080 514.720 646.000 ;
+      RECT 524.400 4.080 525.600 646.000 ;
+      RECT 535.280 4.080 536.480 646.000 ;
+      RECT 546.160 4.080 547.360 646.000 ;
+      RECT 557.040 4.080 558.240 646.000 ;
+      RECT 567.920 4.080 569.120 646.000 ;
+      RECT 578.800 4.080 580.000 646.000 ;
+      RECT 589.680 4.080 590.880 646.000 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 2.160 4.080 3.360 646.000 ;
+      RECT 13.040 4.080 14.240 646.000 ;
+      RECT 23.920 4.080 25.120 646.000 ;
+      RECT 34.800 4.080 36.000 646.000 ;
+      RECT 45.680 4.080 46.880 646.000 ;
+      RECT 56.560 4.080 57.760 646.000 ;
+      RECT 67.440 4.080 68.640 646.000 ;
+      RECT 78.320 4.080 79.520 646.000 ;
+      RECT 89.200 4.080 90.400 646.000 ;
+      RECT 100.080 4.080 101.280 646.000 ;
+      RECT 110.960 4.080 112.160 646.000 ;
+      RECT 121.840 4.080 123.040 646.000 ;
+      RECT 132.720 4.080 133.920 646.000 ;
+      RECT 143.600 4.080 144.800 646.000 ;
+      RECT 154.480 4.080 155.680 646.000 ;
+      RECT 165.360 4.080 166.560 646.000 ;
+      RECT 176.240 4.080 177.440 646.000 ;
+      RECT 187.120 4.080 188.320 646.000 ;
+      RECT 198.000 4.080 199.200 646.000 ;
+      RECT 208.880 4.080 210.080 646.000 ;
+      RECT 219.760 4.080 220.960 646.000 ;
+      RECT 230.640 4.080 231.840 646.000 ;
+      RECT 241.520 4.080 242.720 646.000 ;
+      RECT 252.400 4.080 253.600 646.000 ;
+      RECT 263.280 4.080 264.480 646.000 ;
+      RECT 274.160 4.080 275.360 646.000 ;
+      RECT 285.040 4.080 286.240 646.000 ;
+      RECT 295.920 4.080 297.120 646.000 ;
+      RECT 306.800 4.080 308.000 646.000 ;
+      RECT 317.680 4.080 318.880 646.000 ;
+      RECT 328.560 4.080 329.760 646.000 ;
+      RECT 339.440 4.080 340.640 646.000 ;
+      RECT 350.320 4.080 351.520 646.000 ;
+      RECT 361.200 4.080 362.400 646.000 ;
+      RECT 372.080 4.080 373.280 646.000 ;
+      RECT 382.960 4.080 384.160 646.000 ;
+      RECT 393.840 4.080 395.040 646.000 ;
+      RECT 404.720 4.080 405.920 646.000 ;
+      RECT 415.600 4.080 416.800 646.000 ;
+      RECT 426.480 4.080 427.680 646.000 ;
+      RECT 437.360 4.080 438.560 646.000 ;
+      RECT 448.240 4.080 449.440 646.000 ;
+      RECT 459.120 4.080 460.320 646.000 ;
+      RECT 470.000 4.080 471.200 646.000 ;
+      RECT 480.880 4.080 482.080 646.000 ;
+      RECT 491.760 4.080 492.960 646.000 ;
+      RECT 502.640 4.080 503.840 646.000 ;
+      RECT 513.520 4.080 514.720 646.000 ;
+      RECT 524.400 4.080 525.600 646.000 ;
+      RECT 535.280 4.080 536.480 646.000 ;
+      RECT 546.160 4.080 547.360 646.000 ;
+      RECT 557.040 4.080 558.240 646.000 ;
+      RECT 567.920 4.080 569.120 646.000 ;
+      RECT 578.800 4.080 580.000 646.000 ;
+      RECT 589.680 4.080 590.880 646.000 ;
+    END
+  END VDD
+  OBS
+    LAYER met1 ;
+    RECT 0 0 597.080 650.080 ;
+    LAYER met2 ;
+    RECT 0 0 597.080 650.080 ;
+    LAYER met3 ;
+    RECT 0 0 597.080 650.080 ;
+    LAYER met4 ;
+    RECT 0 0 597.080 650.080 ;
+  END
+END fakeram_512x128_1rw
+
+END LIBRARY

--- a/designs/sky130hd/coralnpu/sram/lib/fakeram_2048x128_1rw.lib
+++ b/designs/sky130hd/coralnpu/sram/lib/fakeram_2048x128_1rw.lib
@@ -1,0 +1,468 @@
+library(fakeram_2048x128_1rw) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-04-26 15:41:53Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 1.110;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram_2048x128_1rw_mem_out_delay_template) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_2048x128_1rw_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_2048x128_1rw_constraint_template) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    power_lut_template(fakeram_2048x128_1rw_energy_template_clkslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    power_lut_template(fakeram_2048x128_1rw_energy_template_sigslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_2048x128_1rw_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 128;
+        bit_from : 127;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram_2048x128_1rw_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 11;
+        bit_from : 10;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram_2048x128_1rw_WMASK) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 16;
+        bit_from : 15;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram_2048x128_1rw) {
+    area : 2380182.784;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 11;
+        word_width : 128;
+    }
+    pin(rw0_clk)   {
+        direction : input;
+        capacitance : 0.025;
+        clock : true;
+        min_period           : 2.254 ;
+        internal_power(){
+            rise_power(fakeram_2048x128_1rw_energy_template_clkslew) {
+                index_1 ("0.044, 1.110");
+                values ("121.395, 121.395")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_clkslew) {
+                index_1 ("0.044, 1.110");
+                values ("121.395, 121.395")
+            }
+        }
+    }
+
+    bus(rw0_rd_out)   {
+        bus_type : fakeram_2048x128_1rw_DATA;
+        direction : output;
+        max_capacitance : 0.500;
+        memory_read() {
+            address : r0_addr_in;
+        }
+        timing() {
+            related_pin : "rw0_clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(fakeram_2048x128_1rw_mem_out_delay_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.610, 0.610", \
+                  "0.610, 0.610" \
+                )
+            }
+            cell_fall(fakeram_2048x128_1rw_mem_out_delay_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.610, 0.610", \
+                  "0.610, 0.610" \
+                )
+            }
+            rise_transition(fakeram_2048x128_1rw_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.044, 1.110")
+            }
+            fall_transition(fakeram_2048x128_1rw_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.044, 1.110")
+            }
+        }
+    }
+    pin(rw0_we_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+        }
+    }
+    pin(rw0_ce_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+        }
+    }
+    bus(rw0_addr_in)   {
+        bus_type : fakeram_2048x128_1rw_ADDRESS;
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+        }
+    }
+    bus(rw0_wd_in)   {
+        bus_type : fakeram_2048x128_1rw_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+        }
+    }
+    bus(rw0_wmask_in)   {
+        bus_type : fakeram_2048x128_1rw_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_2048x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+            fall_power(fakeram_2048x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("1.214, 1.214")
+            }
+        }
+    }
+    cell_leakage_power : 2034.380;
+}
+
+}

--- a/designs/sky130hd/coralnpu/sram/lib/fakeram_512x128_1rw.lib
+++ b/designs/sky130hd/coralnpu/sram/lib/fakeram_512x128_1rw.lib
@@ -1,0 +1,468 @@
+library(fakeram_512x128_1rw) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-04-26 15:41:51Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 1.110;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram_512x128_1rw_mem_out_delay_template) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_512x128_1rw_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_512x128_1rw_constraint_template) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    power_lut_template(fakeram_512x128_1rw_energy_template_clkslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    power_lut_template(fakeram_512x128_1rw_energy_template_sigslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_512x128_1rw_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 128;
+        bit_from : 127;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram_512x128_1rw_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 9;
+        bit_from : 8;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram_512x128_1rw_WMASK) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 16;
+        bit_from : 15;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram_512x128_1rw) {
+    area : 388149.766;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 9;
+        word_width : 128;
+    }
+    pin(rw0_clk)   {
+        direction : input;
+        capacitance : 0.025;
+        clock : true;
+        min_period           : 0.537 ;
+        internal_power(){
+            rise_power(fakeram_512x128_1rw_energy_template_clkslew) {
+                index_1 ("0.044, 1.110");
+                values ("62.157, 62.157")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_clkslew) {
+                index_1 ("0.044, 1.110");
+                values ("62.157, 62.157")
+            }
+        }
+    }
+
+    bus(rw0_rd_out)   {
+        bus_type : fakeram_512x128_1rw_DATA;
+        direction : output;
+        max_capacitance : 0.500;
+        memory_read() {
+            address : r0_addr_in;
+        }
+        timing() {
+            related_pin : "rw0_clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(fakeram_512x128_1rw_mem_out_delay_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.651, 0.651", \
+                  "0.651, 0.651" \
+                )
+            }
+            cell_fall(fakeram_512x128_1rw_mem_out_delay_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.651, 0.651", \
+                  "0.651, 0.651" \
+                )
+            }
+            rise_transition(fakeram_512x128_1rw_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.044, 1.110")
+            }
+            fall_transition(fakeram_512x128_1rw_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.044, 1.110")
+            }
+        }
+    }
+    pin(rw0_we_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+        }
+    }
+    pin(rw0_ce_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+        }
+    }
+    bus(rw0_addr_in)   {
+        bus_type : fakeram_512x128_1rw_ADDRESS;
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+        }
+    }
+    bus(rw0_wd_in)   {
+        bus_type : fakeram_512x128_1rw_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+        }
+    }
+    bus(rw0_wmask_in)   {
+        bus_type : fakeram_512x128_1rw_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram_512x128_1rw_constraint_template) {
+                index_1 ("0.044, 1.110");
+                index_2 ("0.044, 1.110");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+            fall_power(fakeram_512x128_1rw_energy_template_sigslew) {
+                index_1 ("0.044, 1.110");
+                values ("0.622, 0.622")
+            }
+        }
+    }
+    cell_leakage_power : 669.531;
+}
+
+}

--- a/designs/src/coralnpu/dev/fakeram_sky130hd.cfg
+++ b/designs/src/coralnpu/dev/fakeram_sky130hd.cfg
@@ -1,0 +1,30 @@
+{
+  "tech_nm": 130,
+  "voltage": 1.8,
+  "metalPrefix": "met",
+  "LRpinWidth_nm": 300,
+  "LRpinPitch_nm": 680,
+  "TBpinWidth_nm": 140,
+  "TBpinPitch_nm": 460,
+  "snapWidth_nm":   460,
+  "snapHeight_nm": 2720,
+  "flipPins": true,
+  "srams": [
+    {
+     "name": "fakeram_512x128_1rw",
+     "width": 128,
+     "depth": 512,
+     "banks": 1,
+     "write_granularity": 8,
+     "ports": {"r": 0, "w": 0, "rw": 1}
+    },
+    {
+     "name": "fakeram_2048x128_1rw",
+     "width": 128,
+     "depth": 2048,
+     "banks": 1,
+     "write_granularity": 8,
+     "ports": {"r": 0, "w": 0, "rw": 1}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Ports the existing asap7/nangate45 coralnpu design (CoreMiniAxi) to sky130hd. RTL is reused from `designs/src/coralnpu/`; only the SRAM macros and platform-specific flow parameters change.

- Regenerates the two FakeRAM macros (`fakeram_512x128_1rw`, `fakeram_2048x128_1rw`) for sky130hd via `bsg_fakeram` with `flipPins=true` and `metalPrefix=met` / 1.8 V (signal pins on met3, leaving met4 obstructed). Cfg at `designs/src/coralnpu/dev/fakeram_sky130hd.cfg`.
- Clock period 30 ns (~10× asap7's 3 ns, consistent with lfsr 108 ps → 1.1 ns and minimax 400 ps → 4 ns scaling).
- Sky130 has only 5 metal layers vs nangate45's 10, so routing is much tighter. Settings spread the regfile/MLU/FPU logic out to fit: `CORE_UTILIZATION=20`, `PLACE_DENSITY=0.15`, `ROUTING_LAYER_ADJUSTMENT=0.25`, `MACRO_PLACE_HALO=30 30` (mirrors sky130 liteeth's knobs).

## Debugging notes
- Initial config (`CORE_UTILIZATION=30`, `PLACE_DENSITY_LB_ADDON=0.20`) hit 43k routing overflow at GRT (peak met2 at 86.8% utilization, regfile / MLU / FPU concentrated). Detailed routing failed with `Global routing failed`. Fix committed in `6d6f2dc2`: drop utilization, set explicit `PLACE_DENSITY` and `ROUTING_LAYER_ADJUSTMENT` so the placer accounts for limited routing capacity. The macros aren't great (cacti picks an awkward 7813×305 µm aspect for the unused 2048×128) but only the 512×128 is actually instantiated, so this doesn't affect placement.

## Test plan
- [x] `bazel build //designs/sky130hd/coralnpu:coralnpu_final` on Nautilus completes through 6_final
- [x] Empty VSS.rpt, VDD.rpt, 5_route_drc.rpt
- [x] Timing closes: tns=0, wns=0, fmax=33.66 MHz (target 33.3 MHz @ 30 ns)
- [x] 2 macros placed; 1.27 M total instances