### PR TITLE
Port NVDLA (5 partitions) to sky130hd

### DIFF
--- a/designs/sky130hd/NVDLA/BUILD.bazel
+++ b/designs/sky130hd/NVDLA/BUILD.bazel
@@ -1,0 +1,104 @@
+package(default_visibility = ["//designs/sky130hd/NVDLA:__subpackages__"])
+
+# All FakeRAM LEFs/LIBs shared across the 5 NVDLA partitions.
+# Per-partition BUILD.bazel pulls the relevant subset by name.
+
+filegroup(
+    name = "sram_lefs_all",
+    srcs = glob(["sram/lef/*.lef"]),
+)
+
+filegroup(
+    name = "sram_libs_all",
+    srcs = glob(["sram/lib/*.lib"]),
+)
+
+# ---- Per-partition SRAM subsets ----
+
+filegroup(
+    name = "sram_lefs_a",
+    srcs = [
+        "sram/lef/fakeram_256x16_1r1w.lef",
+        "sram/lef/fakeram_272x16_1r1w.lef",
+    ],
+)
+
+filegroup(
+    name = "sram_libs_a",
+    srcs = [
+        "sram/lib/fakeram_256x16_1r1w.lib",
+        "sram/lib/fakeram_272x16_1r1w.lib",
+    ],
+)
+
+filegroup(
+    name = "sram_lefs_c",
+    srcs = [
+        "sram/lef/fakeram_64x256_1r1w.lef",
+        "sram/lef/fakeram_64x16_1r1w.lef",
+        "sram/lef/fakeram_6x128_1r1w.lef",
+        "sram/lef/fakeram_66x8_1r1w.lef",
+        "sram/lef/fakeram_11x128_1r1w.lef",
+    ],
+)
+
+filegroup(
+    name = "sram_libs_c",
+    srcs = [
+        "sram/lib/fakeram_64x256_1r1w.lib",
+        "sram/lib/fakeram_64x16_1r1w.lib",
+        "sram/lib/fakeram_6x128_1r1w.lib",
+        "sram/lib/fakeram_66x8_1r1w.lib",
+        "sram/lib/fakeram_11x128_1r1w.lib",
+    ],
+)
+
+filegroup(
+    name = "sram_lefs_o",
+    srcs = [
+        "sram/lef/fakeram_18x128_1r1w.lef",
+        "sram/lef/fakeram_8x256_1r1w.lef",
+        "sram/lef/fakeram_4x256_1r1w.lef",
+        "sram/lef/fakeram_7x256_1r1w.lef",
+        "sram/lef/fakeram_66x64_1r1w.lef",
+        "sram/lef/fakeram_15x80_1r1w.lef",
+        "sram/lef/fakeram_22x60_1r1w.lef",
+        "sram/lef/fakeram_32x128_1r1w.lef",
+        "sram/lef/fakeram_9x80_1r1w.lef",
+    ],
+)
+
+filegroup(
+    name = "sram_libs_o",
+    srcs = [
+        "sram/lib/fakeram_18x128_1r1w.lib",
+        "sram/lib/fakeram_8x256_1r1w.lib",
+        "sram/lib/fakeram_4x256_1r1w.lib",
+        "sram/lib/fakeram_7x256_1r1w.lib",
+        "sram/lib/fakeram_66x64_1r1w.lib",
+        "sram/lib/fakeram_15x80_1r1w.lib",
+        "sram/lib/fakeram_22x60_1r1w.lib",
+        "sram/lib/fakeram_32x128_1r1w.lib",
+        "sram/lib/fakeram_9x80_1r1w.lib",
+    ],
+)
+
+filegroup(
+    name = "sram_lefs_p",
+    srcs = [
+        "sram/lef/fakeram_16x160_1r1w.lef",
+        "sram/lef/fakeram_65x160_1r1w.lef",
+        "sram/lef/fakeram_14x80_1r1w.lef",
+        "sram/lef/fakeram_66x80_1r1w.lef",
+    ],
+)
+
+filegroup(
+    name = "sram_libs_p",
+    srcs = [
+        "sram/lib/fakeram_16x160_1r1w.lib",
+        "sram/lib/fakeram_65x160_1r1w.lib",
+        "sram/lib/fakeram_14x80_1r1w.lib",
+        "sram/lib/fakeram_66x80_1r1w.lib",
+    ],
+)

--- a/designs/sky130hd/NVDLA/partition_a/BUILD.bazel
+++ b/designs/sky130hd/NVDLA/partition_a/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//:defs.bzl", "hightide_design")
+
+hightide_design(
+    name = "partition_a",
+    top = "NV_NVDLA_partition_a",
+    platform = "sky130hd",
+    verilog_files = ["//designs/src/NVDLA:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": ["//designs/sky130hd/NVDLA:sram_lefs_a"],
+        "ADDITIONAL_LIBS": ["//designs/sky130hd/NVDLA:sram_libs_a"],
+    },
+    stage_data = {"synth": ["//designs/src/NVDLA:include"]},
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "VERILOG_INCLUDE_DIRS": "designs/src/NVDLA/vmod/include designs/src/NVDLA/vmod/vlibs",
+        "CORE_UTILIZATION": "35",
+        "PLACE_DENSITY_LB_ADDON": "0.20",
+        "MACRO_PLACE_HALO": "20 20",
+        "TNS_END_PERCENT": "100",
+    },
+)

--- a/designs/sky130hd/NVDLA/partition_a/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_a/constraint.sdc
@@ -1,0 +1,32 @@
+# NVDLA partition_a — sky130hd timing constraints (scaled ~10x from asap7 1500 ps)
+current_design NV_NVDLA_partition_a
+
+set clk_name nvdla_core_clk
+set clk_period 15.0
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_name]
+
+create_clock -name $clk_name -period $clk_period -waveform [list 0 [expr $clk_period / 2]] $clk_port
+set_clock_transition -rise -min 0.1 [get_clocks $clk_name]
+set_clock_transition -rise -max 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -min 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -max 0.1 [get_clocks $clk_name]
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_ideal_network [get_ports direct_reset_]
+set_ideal_network [get_ports dla_reset_rstn]
+set_ideal_network -no_propagate [get_nets nvdla_core_rstn]
+set_ideal_network [get_ports test_mode]
+
+set_false_path -from [get_ports direct_reset_]
+set_false_path -from [get_ports dla_reset_rstn]
+set_false_path -from [get_ports test_mode]
+set_false_path -from [get_ports pwrbus_ram_pd*]
+set_false_path -from [get_ports tmc2slcg_disable_clock_gating]
+set_false_path -from [get_ports global_clk_ovr_on]
+set_false_path -from [get_ports nvdla_clk_ovr_on]

--- a/designs/sky130hd/NVDLA/partition_c/BUILD.bazel
+++ b/designs/sky130hd/NVDLA/partition_c/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//:defs.bzl", "hightide_design")
+
+hightide_design(
+    name = "partition_c",
+    top = "NV_NVDLA_partition_c",
+    platform = "sky130hd",
+    verilog_files = ["//designs/src/NVDLA:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": ["//designs/sky130hd/NVDLA:sram_lefs_c"],
+        "ADDITIONAL_LIBS": ["//designs/sky130hd/NVDLA:sram_libs_c"],
+    },
+    stage_data = {"synth": ["//designs/src/NVDLA:include"]},
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "VERILOG_INCLUDE_DIRS": "designs/src/NVDLA/vmod/include designs/src/NVDLA/vmod/vlibs",
+        "CORE_UTILIZATION": "25",
+        "PLACE_DENSITY_LB_ADDON": "0.30",
+        "MACRO_PLACE_HALO": "30 30",
+        "TNS_END_PERCENT": "100",
+    },
+)

--- a/designs/sky130hd/NVDLA/partition_c/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_c/constraint.sdc
@@ -1,0 +1,35 @@
+# NVDLA partition_c — sky130hd timing constraints (scaled ~10x from asap7 1500 ps)
+current_design NV_NVDLA_partition_c
+
+set clk_name nvdla_core_clk
+set clk_period 15.0
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_name]
+
+create_clock -name $clk_name -period $clk_period -waveform [list 0 [expr $clk_period / 2]] $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_clock_transition -rise -min 0.1 [get_clocks $clk_name]
+set_clock_transition -rise -max 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -min 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -max 0.1 [get_clocks $clk_name]
+
+set_ideal_network [get_ports {global_clk_ovr_on}]
+set_ideal_network [get_ports {test_mode}]
+set_ideal_network [get_ports {direct_reset_}]
+set_ideal_network [get_ports {dla_reset_rstn}]
+set_ideal_network [get_ports {nvdla_core_clk}]
+set_ideal_network [get_ports {nvdla_clk_ovr_on}]
+set_ideal_network [get_ports {tmc2slcg_disable_clock_gating}]
+set_ideal_network [get_ports {pwrbus_ram_pd*}]
+
+set_false_path -to [get_pin */RESETN]
+set_false_path -to [get_pin */SETN]
+
+set_max_fanout 128 [current_design]
+set_wire_load_mode enclosed

--- a/designs/sky130hd/NVDLA/partition_m/BUILD.bazel
+++ b/designs/sky130hd/NVDLA/partition_m/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//:defs.bzl", "hightide_design")
+
+hightide_design(
+    name = "partition_m",
+    top = "NV_NVDLA_partition_m",
+    platform = "sky130hd",
+    verilog_files = ["//designs/src/NVDLA:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+    },
+    stage_data = {"synth": ["//designs/src/NVDLA:include"]},
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "VERILOG_INCLUDE_DIRS": "designs/src/NVDLA/vmod/include designs/src/NVDLA/vmod/vlibs",
+        "CORE_UTILIZATION": "45",
+        "PLACE_DENSITY_LB_ADDON": "0.20",
+        "TNS_END_PERCENT": "100",
+    },
+)

--- a/designs/sky130hd/NVDLA/partition_m/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_m/constraint.sdc
@@ -1,0 +1,36 @@
+# ===================================================================
+# NVDLA partition_m — sky130hd timing constraints
+# Period scaled from asap7 1500 ps -> sky130hd 15 ns (~10x).
+# ===================================================================
+current_design NV_NVDLA_partition_m
+
+set clk_name nvdla_core_clk
+set clk_period 15.0
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_name]
+
+create_clock -name $clk_name -period $clk_period -waveform [list 0 [expr $clk_period / 2]] $clk_port
+set_clock_transition -rise -min 0.1 [get_clocks $clk_name]
+set_clock_transition -rise -max 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -min 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -max 0.1 [get_clocks $clk_name]
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_ideal_network [get_ports direct_reset_]
+set_ideal_network [get_ports dla_reset_rstn]
+set_ideal_network -no_propagate [get_nets nvdla_core_rstn]
+set_ideal_network [get_ports test_mode]
+
+set_false_path -from [get_ports direct_reset_]
+set_false_path -from [get_ports dla_reset_rstn]
+set_false_path -from [get_ports test_mode]
+set_false_path -from [get_ports tmc2slcg_disable_clock_gating]
+set_false_path -from [get_ports global_clk_ovr_on]
+set_false_path -from [get_ports nvdla_clk_ovr_on]
+set_false_path -to [get_pin */RESETN]
+set_false_path -to [get_pin */SETN]

--- a/designs/sky130hd/NVDLA/partition_o/BUILD.bazel
+++ b/designs/sky130hd/NVDLA/partition_o/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//:defs.bzl", "hightide_design")
+
+hightide_design(
+    name = "partition_o",
+    top = "NV_NVDLA_partition_o",
+    platform = "sky130hd",
+    verilog_files = ["//designs/src/NVDLA:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": ["//designs/sky130hd/NVDLA:sram_lefs_o"],
+        "ADDITIONAL_LIBS": ["//designs/sky130hd/NVDLA:sram_libs_o"],
+    },
+    stage_data = {"synth": ["//designs/src/NVDLA:include"]},
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "VERILOG_INCLUDE_DIRS": "designs/src/NVDLA/vmod/include designs/src/NVDLA/vmod/vlibs",
+        "CORE_UTILIZATION": "20",
+        "PLACE_DENSITY_LB_ADDON": "0.15",
+        "MACRO_PLACE_HALO": "60 60",
+        "TNS_END_PERCENT": "100",
+    },
+)

--- a/designs/sky130hd/NVDLA/partition_o/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_o/constraint.sdc
@@ -1,0 +1,43 @@
+# NVDLA partition_o — sky130hd timing constraints
+# Periods scaled from asap7 2000/2500 ps -> sky130hd 20/25 ns (~10x).
+current_design NV_NVDLA_partition_o
+
+set clk_name nvdla_core_clk
+set clk_falcon_name nvdla_falcon_clk
+set clk_period 20.0
+set clk_falcon_period 25.0
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_name]
+set clk_falcon_port [get_ports $clk_falcon_name]
+
+create_clock -name $clk_name -period $clk_period -waveform [list 0 [expr $clk_period / 2]] $clk_port
+set_clock_transition -rise -min 0.1 [get_clocks $clk_name]
+set_clock_transition -rise -max 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -min 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -max 0.1 [get_clocks $clk_name]
+
+create_clock -name $clk_falcon_name -period $clk_falcon_period -waveform [list 0 [expr $clk_falcon_period / 2]] $clk_falcon_port
+set_clock_transition -rise -min 0.1 [get_clocks $clk_falcon_name]
+set_clock_transition -rise -max 0.1 [get_clocks $clk_falcon_name]
+set_clock_transition -fall -min 0.1 [get_clocks $clk_falcon_name]
+set_clock_transition -fall -max 0.1 [get_clocks $clk_falcon_name]
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] "^($clk_port|$clk_falcon_port)$"]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_ideal_network [get_ports test_mode]
+set_ideal_network [get_ports direct_reset_]
+set_ideal_network [get_ports dla_reset_rstn]
+set_ideal_network [get_nets nvdla_core_rstn]
+
+set_false_path -from [get_ports direct_reset_]
+set_false_path -from [get_ports dla_reset_rstn]
+set_false_path -from [get_ports test_mode]
+set_false_path -from [get_ports pwrbus_ram_pd*]
+set_false_path -from [get_ports tmc2slcg_disable_clock_gating]
+set_false_path -from [get_ports global_clk_ovr_on]
+set_false_path -from [get_clocks nvdla_core_clk] -to [get_clocks nvdla_falcon_clk]
+set_false_path -from [get_clocks nvdla_falcon_clk] -to [get_clocks nvdla_core_clk]

--- a/designs/sky130hd/NVDLA/partition_p/BUILD.bazel
+++ b/designs/sky130hd/NVDLA/partition_p/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//:defs.bzl", "hightide_design")
+
+hightide_design(
+    name = "partition_p",
+    top = "NV_NVDLA_partition_p",
+    platform = "sky130hd",
+    verilog_files = ["//designs/src/NVDLA:rtl"],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": ["//designs/sky130hd/NVDLA:sram_lefs_p"],
+        "ADDITIONAL_LIBS": ["//designs/sky130hd/NVDLA:sram_libs_p"],
+    },
+    stage_data = {"synth": ["//designs/src/NVDLA:include"]},
+    arguments = {
+        "SYNTH_HIERARCHICAL": "1",
+        "VERILOG_INCLUDE_DIRS": "designs/src/NVDLA/vmod/include designs/src/NVDLA/vmod/vlibs",
+        "CORE_UTILIZATION": "20",
+        "PLACE_DENSITY_LB_ADDON": "0.25",
+        "MACRO_PLACE_HALO": "40 40",
+        "TNS_END_PERCENT": "100",
+    },
+)

--- a/designs/sky130hd/NVDLA/partition_p/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_p/constraint.sdc
@@ -1,0 +1,32 @@
+# NVDLA partition_p — sky130hd timing constraints (scaled ~10x from asap7 1500 ps)
+current_design NV_NVDLA_partition_p
+
+set clk_name nvdla_core_clk
+set clk_period 15.0
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_name]
+
+create_clock -name $clk_name -period $clk_period -waveform [list 0 [expr $clk_period / 2]] $clk_port
+set_clock_transition -rise -min 0.1 [get_clocks $clk_name]
+set_clock_transition -rise -max 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -min 0.1 [get_clocks $clk_name]
+set_clock_transition -fall -max 0.1 [get_clocks $clk_name]
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_ideal_network [get_ports direct_reset_]
+set_ideal_network [get_ports dla_reset_rstn]
+set_ideal_network -no_propagate [get_nets nvdla_core_rstn]
+set_ideal_network [get_ports test_mode]
+
+set_false_path -from [get_ports direct_reset_]
+set_false_path -from [get_ports dla_reset_rstn]
+set_false_path -from [get_ports test_mode]
+set_false_path -from [get_ports pwrbus_ram_pd*]
+set_false_path -from [get_ports tmc2slcg_disable_clock_gating]
+set_false_path -from [get_ports global_clk_ovr_on]
+set_false_path -from [get_ports nvdla_clk_ovr_on]

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_11x128_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_11x128_1r1w.lef
@@ -1,0 +1,422 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_11x128_1r1w
+  FOREIGN fakeram_11x128_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 167.900 BY 84.320 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 81.600 ;
+      RECT 22.480 2.720 23.680 81.600 ;
+      RECT 37.200 2.720 38.400 81.600 ;
+      RECT 51.920 2.720 53.120 81.600 ;
+      RECT 66.640 2.720 67.840 81.600 ;
+      RECT 81.360 2.720 82.560 81.600 ;
+      RECT 96.080 2.720 97.280 81.600 ;
+      RECT 110.800 2.720 112.000 81.600 ;
+      RECT 125.520 2.720 126.720 81.600 ;
+      RECT 140.240 2.720 141.440 81.600 ;
+      RECT 154.960 2.720 156.160 81.600 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 81.600 ;
+      RECT 29.840 2.720 31.040 81.600 ;
+      RECT 44.560 2.720 45.760 81.600 ;
+      RECT 59.280 2.720 60.480 81.600 ;
+      RECT 74.000 2.720 75.200 81.600 ;
+      RECT 88.720 2.720 89.920 81.600 ;
+      RECT 103.440 2.720 104.640 81.600 ;
+      RECT 118.160 2.720 119.360 81.600 ;
+      RECT 132.880 2.720 134.080 81.600 ;
+      RECT 147.600 2.720 148.800 81.600 ;
+      RECT 162.320 2.720 163.520 81.600 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 167.900 84.320 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 167.900 84.320 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 167.900 84.320 ;
+  END
+END fakeram_11x128_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_14x80_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_14x80_1r1w.lef
@@ -1,0 +1,474 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_14x80_1r1w
+  FOREIGN fakeram_14x80_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 149.960 BY 76.160 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 73.440 ;
+      RECT 22.480 2.720 23.680 73.440 ;
+      RECT 37.200 2.720 38.400 73.440 ;
+      RECT 51.920 2.720 53.120 73.440 ;
+      RECT 66.640 2.720 67.840 73.440 ;
+      RECT 81.360 2.720 82.560 73.440 ;
+      RECT 96.080 2.720 97.280 73.440 ;
+      RECT 110.800 2.720 112.000 73.440 ;
+      RECT 125.520 2.720 126.720 73.440 ;
+      RECT 140.240 2.720 141.440 73.440 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 73.440 ;
+      RECT 29.840 2.720 31.040 73.440 ;
+      RECT 44.560 2.720 45.760 73.440 ;
+      RECT 59.280 2.720 60.480 73.440 ;
+      RECT 74.000 2.720 75.200 73.440 ;
+      RECT 88.720 2.720 89.920 73.440 ;
+      RECT 103.440 2.720 104.640 73.440 ;
+      RECT 118.160 2.720 119.360 73.440 ;
+      RECT 132.880 2.720 134.080 73.440 ;
+      RECT 147.600 2.720 148.800 73.440 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 149.960 76.160 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 149.960 76.160 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 149.960 76.160 ;
+  END
+END fakeram_14x80_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_15x80_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_15x80_1r1w.lef
@@ -1,0 +1,492 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_15x80_1r1w
+  FOREIGN fakeram_15x80_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 155.020 BY 78.880 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 76.160 ;
+      RECT 22.480 2.720 23.680 76.160 ;
+      RECT 37.200 2.720 38.400 76.160 ;
+      RECT 51.920 2.720 53.120 76.160 ;
+      RECT 66.640 2.720 67.840 76.160 ;
+      RECT 81.360 2.720 82.560 76.160 ;
+      RECT 96.080 2.720 97.280 76.160 ;
+      RECT 110.800 2.720 112.000 76.160 ;
+      RECT 125.520 2.720 126.720 76.160 ;
+      RECT 140.240 2.720 141.440 76.160 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 76.160 ;
+      RECT 29.840 2.720 31.040 76.160 ;
+      RECT 44.560 2.720 45.760 76.160 ;
+      RECT 59.280 2.720 60.480 76.160 ;
+      RECT 74.000 2.720 75.200 76.160 ;
+      RECT 88.720 2.720 89.920 76.160 ;
+      RECT 103.440 2.720 104.640 76.160 ;
+      RECT 118.160 2.720 119.360 76.160 ;
+      RECT 132.880 2.720 134.080 76.160 ;
+      RECT 147.600 2.720 148.800 76.160 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 155.020 78.880 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 155.020 78.880 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 155.020 78.880 ;
+  END
+END fakeram_15x80_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_16x160_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_16x160_1r1w.lef
@@ -1,0 +1,538 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_16x160_1r1w
+  FOREIGN fakeram_16x160_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 226.320 BY 114.240 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_addr_in[7]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END r0_addr_in[7]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 111.520 ;
+      RECT 22.480 2.720 23.680 111.520 ;
+      RECT 37.200 2.720 38.400 111.520 ;
+      RECT 51.920 2.720 53.120 111.520 ;
+      RECT 66.640 2.720 67.840 111.520 ;
+      RECT 81.360 2.720 82.560 111.520 ;
+      RECT 96.080 2.720 97.280 111.520 ;
+      RECT 110.800 2.720 112.000 111.520 ;
+      RECT 125.520 2.720 126.720 111.520 ;
+      RECT 140.240 2.720 141.440 111.520 ;
+      RECT 154.960 2.720 156.160 111.520 ;
+      RECT 169.680 2.720 170.880 111.520 ;
+      RECT 184.400 2.720 185.600 111.520 ;
+      RECT 199.120 2.720 200.320 111.520 ;
+      RECT 213.840 2.720 215.040 111.520 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 111.520 ;
+      RECT 29.840 2.720 31.040 111.520 ;
+      RECT 44.560 2.720 45.760 111.520 ;
+      RECT 59.280 2.720 60.480 111.520 ;
+      RECT 74.000 2.720 75.200 111.520 ;
+      RECT 88.720 2.720 89.920 111.520 ;
+      RECT 103.440 2.720 104.640 111.520 ;
+      RECT 118.160 2.720 119.360 111.520 ;
+      RECT 132.880 2.720 134.080 111.520 ;
+      RECT 147.600 2.720 148.800 111.520 ;
+      RECT 162.320 2.720 163.520 111.520 ;
+      RECT 177.040 2.720 178.240 111.520 ;
+      RECT 191.760 2.720 192.960 111.520 ;
+      RECT 206.480 2.720 207.680 111.520 ;
+      RECT 221.200 2.720 222.400 111.520 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 226.320 114.240 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 226.320 114.240 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 226.320 114.240 ;
+  END
+END fakeram_16x160_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_18x128_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_18x128_1r1w.lef
@@ -1,0 +1,554 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_18x128_1r1w
+  FOREIGN fakeram_18x128_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 214.820 BY 108.800 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 106.080 ;
+      RECT 22.480 2.720 23.680 106.080 ;
+      RECT 37.200 2.720 38.400 106.080 ;
+      RECT 51.920 2.720 53.120 106.080 ;
+      RECT 66.640 2.720 67.840 106.080 ;
+      RECT 81.360 2.720 82.560 106.080 ;
+      RECT 96.080 2.720 97.280 106.080 ;
+      RECT 110.800 2.720 112.000 106.080 ;
+      RECT 125.520 2.720 126.720 106.080 ;
+      RECT 140.240 2.720 141.440 106.080 ;
+      RECT 154.960 2.720 156.160 106.080 ;
+      RECT 169.680 2.720 170.880 106.080 ;
+      RECT 184.400 2.720 185.600 106.080 ;
+      RECT 199.120 2.720 200.320 106.080 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 106.080 ;
+      RECT 29.840 2.720 31.040 106.080 ;
+      RECT 44.560 2.720 45.760 106.080 ;
+      RECT 59.280 2.720 60.480 106.080 ;
+      RECT 74.000 2.720 75.200 106.080 ;
+      RECT 88.720 2.720 89.920 106.080 ;
+      RECT 103.440 2.720 104.640 106.080 ;
+      RECT 118.160 2.720 119.360 106.080 ;
+      RECT 132.880 2.720 134.080 106.080 ;
+      RECT 147.600 2.720 148.800 106.080 ;
+      RECT 162.320 2.720 163.520 106.080 ;
+      RECT 177.040 2.720 178.240 106.080 ;
+      RECT 191.760 2.720 192.960 106.080 ;
+      RECT 206.480 2.720 207.680 106.080 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 214.820 108.800 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 214.820 108.800 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 214.820 108.800 ;
+  END
+END fakeram_18x128_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_22x60_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_22x60_1r1w.lef
@@ -1,0 +1,601 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_22x60_1r1w
+  FOREIGN fakeram_22x60_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 162.840 BY 81.600 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 78.880 ;
+      RECT 22.480 2.720 23.680 78.880 ;
+      RECT 37.200 2.720 38.400 78.880 ;
+      RECT 51.920 2.720 53.120 78.880 ;
+      RECT 66.640 2.720 67.840 78.880 ;
+      RECT 81.360 2.720 82.560 78.880 ;
+      RECT 96.080 2.720 97.280 78.880 ;
+      RECT 110.800 2.720 112.000 78.880 ;
+      RECT 125.520 2.720 126.720 78.880 ;
+      RECT 140.240 2.720 141.440 78.880 ;
+      RECT 154.960 2.720 156.160 78.880 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 78.880 ;
+      RECT 29.840 2.720 31.040 78.880 ;
+      RECT 44.560 2.720 45.760 78.880 ;
+      RECT 59.280 2.720 60.480 78.880 ;
+      RECT 74.000 2.720 75.200 78.880 ;
+      RECT 88.720 2.720 89.920 78.880 ;
+      RECT 103.440 2.720 104.640 78.880 ;
+      RECT 118.160 2.720 119.360 78.880 ;
+      RECT 132.880 2.720 134.080 78.880 ;
+      RECT 147.600 2.720 148.800 78.880 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 162.840 81.600 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 162.840 81.600 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 162.840 81.600 ;
+  END
+END fakeram_22x60_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_256x16_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_256x16_1r1w.lef
@@ -1,0 +1,4794 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_256x16_1r1w
+  FOREIGN fakeram_256x16_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 286.580 BY 486.880 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_wd_in[32]
+  PIN w0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_wd_in[33]
+  PIN w0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_wd_in[34]
+  PIN w0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_wd_in[35]
+  PIN w0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_wd_in[36]
+  PIN w0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_wd_in[37]
+  PIN w0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_wd_in[38]
+  PIN w0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_wd_in[39]
+  PIN w0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_wd_in[40]
+  PIN w0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_wd_in[41]
+  PIN w0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END w0_wd_in[42]
+  PIN w0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END w0_wd_in[43]
+  PIN w0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END w0_wd_in[44]
+  PIN w0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END w0_wd_in[45]
+  PIN w0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END w0_wd_in[46]
+  PIN w0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END w0_wd_in[47]
+  PIN w0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END w0_wd_in[48]
+  PIN w0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END w0_wd_in[49]
+  PIN w0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END w0_wd_in[50]
+  PIN w0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END w0_wd_in[51]
+  PIN w0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END w0_wd_in[52]
+  PIN w0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END w0_wd_in[53]
+  PIN w0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END w0_wd_in[54]
+  PIN w0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END w0_wd_in[55]
+  PIN w0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END w0_wd_in[56]
+  PIN w0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END w0_wd_in[57]
+  PIN w0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END w0_wd_in[58]
+  PIN w0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END w0_wd_in[59]
+  PIN w0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END w0_wd_in[60]
+  PIN w0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END w0_wd_in[61]
+  PIN w0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END w0_wd_in[62]
+  PIN w0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END w0_wd_in[63]
+  PIN w0_wd_in[64]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END w0_wd_in[64]
+  PIN w0_wd_in[65]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END w0_wd_in[65]
+  PIN w0_wd_in[66]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END w0_wd_in[66]
+  PIN w0_wd_in[67]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END w0_wd_in[67]
+  PIN w0_wd_in[68]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END w0_wd_in[68]
+  PIN w0_wd_in[69]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END w0_wd_in[69]
+  PIN w0_wd_in[70]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END w0_wd_in[70]
+  PIN w0_wd_in[71]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END w0_wd_in[71]
+  PIN w0_wd_in[72]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END w0_wd_in[72]
+  PIN w0_wd_in[73]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END w0_wd_in[73]
+  PIN w0_wd_in[74]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END w0_wd_in[74]
+  PIN w0_wd_in[75]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END w0_wd_in[75]
+  PIN w0_wd_in[76]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END w0_wd_in[76]
+  PIN w0_wd_in[77]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END w0_wd_in[77]
+  PIN w0_wd_in[78]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END w0_wd_in[78]
+  PIN w0_wd_in[79]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END w0_wd_in[79]
+  PIN w0_wd_in[80]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END w0_wd_in[80]
+  PIN w0_wd_in[81]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END w0_wd_in[81]
+  PIN w0_wd_in[82]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END w0_wd_in[82]
+  PIN w0_wd_in[83]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.280 0.500 77.780 ;
+    END
+  END w0_wd_in[83]
+  PIN w0_wd_in[84]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.200 0.500 78.700 ;
+    END
+  END w0_wd_in[84]
+  PIN w0_wd_in[85]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 79.120 0.500 79.620 ;
+    END
+  END w0_wd_in[85]
+  PIN w0_wd_in[86]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.040 0.500 80.540 ;
+    END
+  END w0_wd_in[86]
+  PIN w0_wd_in[87]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.960 0.500 81.460 ;
+    END
+  END w0_wd_in[87]
+  PIN w0_wd_in[88]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.880 0.500 82.380 ;
+    END
+  END w0_wd_in[88]
+  PIN w0_wd_in[89]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 82.800 0.500 83.300 ;
+    END
+  END w0_wd_in[89]
+  PIN w0_wd_in[90]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.720 0.500 84.220 ;
+    END
+  END w0_wd_in[90]
+  PIN w0_wd_in[91]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.640 0.500 85.140 ;
+    END
+  END w0_wd_in[91]
+  PIN w0_wd_in[92]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.560 0.500 86.060 ;
+    END
+  END w0_wd_in[92]
+  PIN w0_wd_in[93]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 86.480 0.500 86.980 ;
+    END
+  END w0_wd_in[93]
+  PIN w0_wd_in[94]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.400 0.500 87.900 ;
+    END
+  END w0_wd_in[94]
+  PIN w0_wd_in[95]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 88.320 0.500 88.820 ;
+    END
+  END w0_wd_in[95]
+  PIN w0_wd_in[96]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.240 0.500 89.740 ;
+    END
+  END w0_wd_in[96]
+  PIN w0_wd_in[97]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 90.160 0.500 90.660 ;
+    END
+  END w0_wd_in[97]
+  PIN w0_wd_in[98]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 91.080 0.500 91.580 ;
+    END
+  END w0_wd_in[98]
+  PIN w0_wd_in[99]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.000 0.500 92.500 ;
+    END
+  END w0_wd_in[99]
+  PIN w0_wd_in[100]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.920 0.500 93.420 ;
+    END
+  END w0_wd_in[100]
+  PIN w0_wd_in[101]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.840 0.500 94.340 ;
+    END
+  END w0_wd_in[101]
+  PIN w0_wd_in[102]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 94.760 0.500 95.260 ;
+    END
+  END w0_wd_in[102]
+  PIN w0_wd_in[103]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.680 0.500 96.180 ;
+    END
+  END w0_wd_in[103]
+  PIN w0_wd_in[104]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 96.600 0.500 97.100 ;
+    END
+  END w0_wd_in[104]
+  PIN w0_wd_in[105]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.520 0.500 98.020 ;
+    END
+  END w0_wd_in[105]
+  PIN w0_wd_in[106]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 98.440 0.500 98.940 ;
+    END
+  END w0_wd_in[106]
+  PIN w0_wd_in[107]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 99.360 0.500 99.860 ;
+    END
+  END w0_wd_in[107]
+  PIN w0_wd_in[108]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.280 0.500 100.780 ;
+    END
+  END w0_wd_in[108]
+  PIN w0_wd_in[109]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.200 0.500 101.700 ;
+    END
+  END w0_wd_in[109]
+  PIN w0_wd_in[110]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 102.120 0.500 102.620 ;
+    END
+  END w0_wd_in[110]
+  PIN w0_wd_in[111]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.040 0.500 103.540 ;
+    END
+  END w0_wd_in[111]
+  PIN w0_wd_in[112]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.960 0.500 104.460 ;
+    END
+  END w0_wd_in[112]
+  PIN w0_wd_in[113]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 104.880 0.500 105.380 ;
+    END
+  END w0_wd_in[113]
+  PIN w0_wd_in[114]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.800 0.500 106.300 ;
+    END
+  END w0_wd_in[114]
+  PIN w0_wd_in[115]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.720 0.500 107.220 ;
+    END
+  END w0_wd_in[115]
+  PIN w0_wd_in[116]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 107.640 0.500 108.140 ;
+    END
+  END w0_wd_in[116]
+  PIN w0_wd_in[117]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.560 0.500 109.060 ;
+    END
+  END w0_wd_in[117]
+  PIN w0_wd_in[118]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 109.480 0.500 109.980 ;
+    END
+  END w0_wd_in[118]
+  PIN w0_wd_in[119]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.400 0.500 110.900 ;
+    END
+  END w0_wd_in[119]
+  PIN w0_wd_in[120]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.320 0.500 111.820 ;
+    END
+  END w0_wd_in[120]
+  PIN w0_wd_in[121]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 112.240 0.500 112.740 ;
+    END
+  END w0_wd_in[121]
+  PIN w0_wd_in[122]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 113.160 0.500 113.660 ;
+    END
+  END w0_wd_in[122]
+  PIN w0_wd_in[123]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.080 0.500 114.580 ;
+    END
+  END w0_wd_in[123]
+  PIN w0_wd_in[124]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.000 0.500 115.500 ;
+    END
+  END w0_wd_in[124]
+  PIN w0_wd_in[125]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.920 0.500 116.420 ;
+    END
+  END w0_wd_in[125]
+  PIN w0_wd_in[126]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.840 0.500 117.340 ;
+    END
+  END w0_wd_in[126]
+  PIN w0_wd_in[127]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 117.760 0.500 118.260 ;
+    END
+  END w0_wd_in[127]
+  PIN w0_wd_in[128]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.680 0.500 119.180 ;
+    END
+  END w0_wd_in[128]
+  PIN w0_wd_in[129]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.600 0.500 120.100 ;
+    END
+  END w0_wd_in[129]
+  PIN w0_wd_in[130]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 120.520 0.500 121.020 ;
+    END
+  END w0_wd_in[130]
+  PIN w0_wd_in[131]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 121.440 0.500 121.940 ;
+    END
+  END w0_wd_in[131]
+  PIN w0_wd_in[132]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.360 0.500 122.860 ;
+    END
+  END w0_wd_in[132]
+  PIN w0_wd_in[133]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.280 0.500 123.780 ;
+    END
+  END w0_wd_in[133]
+  PIN w0_wd_in[134]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 124.200 0.500 124.700 ;
+    END
+  END w0_wd_in[134]
+  PIN w0_wd_in[135]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.500 125.620 ;
+    END
+  END w0_wd_in[135]
+  PIN w0_wd_in[136]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.040 0.500 126.540 ;
+    END
+  END w0_wd_in[136]
+  PIN w0_wd_in[137]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.960 0.500 127.460 ;
+    END
+  END w0_wd_in[137]
+  PIN w0_wd_in[138]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.880 0.500 128.380 ;
+    END
+  END w0_wd_in[138]
+  PIN w0_wd_in[139]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 128.800 0.500 129.300 ;
+    END
+  END w0_wd_in[139]
+  PIN w0_wd_in[140]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 129.720 0.500 130.220 ;
+    END
+  END w0_wd_in[140]
+  PIN w0_wd_in[141]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.640 0.500 131.140 ;
+    END
+  END w0_wd_in[141]
+  PIN w0_wd_in[142]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 131.560 0.500 132.060 ;
+    END
+  END w0_wd_in[142]
+  PIN w0_wd_in[143]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 132.480 0.500 132.980 ;
+    END
+  END w0_wd_in[143]
+  PIN w0_wd_in[144]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.400 0.500 133.900 ;
+    END
+  END w0_wd_in[144]
+  PIN w0_wd_in[145]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 134.320 0.500 134.820 ;
+    END
+  END w0_wd_in[145]
+  PIN w0_wd_in[146]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 135.240 0.500 135.740 ;
+    END
+  END w0_wd_in[146]
+  PIN w0_wd_in[147]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.160 0.500 136.660 ;
+    END
+  END w0_wd_in[147]
+  PIN w0_wd_in[148]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 137.080 0.500 137.580 ;
+    END
+  END w0_wd_in[148]
+  PIN w0_wd_in[149]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.000 0.500 138.500 ;
+    END
+  END w0_wd_in[149]
+  PIN w0_wd_in[150]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.920 0.500 139.420 ;
+    END
+  END w0_wd_in[150]
+  PIN w0_wd_in[151]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 139.840 0.500 140.340 ;
+    END
+  END w0_wd_in[151]
+  PIN w0_wd_in[152]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 140.760 0.500 141.260 ;
+    END
+  END w0_wd_in[152]
+  PIN w0_wd_in[153]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 141.680 0.500 142.180 ;
+    END
+  END w0_wd_in[153]
+  PIN w0_wd_in[154]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 142.600 0.500 143.100 ;
+    END
+  END w0_wd_in[154]
+  PIN w0_wd_in[155]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 143.520 0.500 144.020 ;
+    END
+  END w0_wd_in[155]
+  PIN w0_wd_in[156]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 144.440 0.500 144.940 ;
+    END
+  END w0_wd_in[156]
+  PIN w0_wd_in[157]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 145.360 0.500 145.860 ;
+    END
+  END w0_wd_in[157]
+  PIN w0_wd_in[158]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 146.280 0.500 146.780 ;
+    END
+  END w0_wd_in[158]
+  PIN w0_wd_in[159]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 147.200 0.500 147.700 ;
+    END
+  END w0_wd_in[159]
+  PIN w0_wd_in[160]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 148.120 0.500 148.620 ;
+    END
+  END w0_wd_in[160]
+  PIN w0_wd_in[161]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 149.040 0.500 149.540 ;
+    END
+  END w0_wd_in[161]
+  PIN w0_wd_in[162]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 149.960 0.500 150.460 ;
+    END
+  END w0_wd_in[162]
+  PIN w0_wd_in[163]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 150.880 0.500 151.380 ;
+    END
+  END w0_wd_in[163]
+  PIN w0_wd_in[164]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 151.800 0.500 152.300 ;
+    END
+  END w0_wd_in[164]
+  PIN w0_wd_in[165]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 152.720 0.500 153.220 ;
+    END
+  END w0_wd_in[165]
+  PIN w0_wd_in[166]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 153.640 0.500 154.140 ;
+    END
+  END w0_wd_in[166]
+  PIN w0_wd_in[167]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 154.560 0.500 155.060 ;
+    END
+  END w0_wd_in[167]
+  PIN w0_wd_in[168]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 155.480 0.500 155.980 ;
+    END
+  END w0_wd_in[168]
+  PIN w0_wd_in[169]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 156.400 0.500 156.900 ;
+    END
+  END w0_wd_in[169]
+  PIN w0_wd_in[170]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 157.320 0.500 157.820 ;
+    END
+  END w0_wd_in[170]
+  PIN w0_wd_in[171]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 158.240 0.500 158.740 ;
+    END
+  END w0_wd_in[171]
+  PIN w0_wd_in[172]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 159.160 0.500 159.660 ;
+    END
+  END w0_wd_in[172]
+  PIN w0_wd_in[173]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 160.080 0.500 160.580 ;
+    END
+  END w0_wd_in[173]
+  PIN w0_wd_in[174]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 161.000 0.500 161.500 ;
+    END
+  END w0_wd_in[174]
+  PIN w0_wd_in[175]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 161.920 0.500 162.420 ;
+    END
+  END w0_wd_in[175]
+  PIN w0_wd_in[176]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 162.840 0.500 163.340 ;
+    END
+  END w0_wd_in[176]
+  PIN w0_wd_in[177]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 163.760 0.500 164.260 ;
+    END
+  END w0_wd_in[177]
+  PIN w0_wd_in[178]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 164.680 0.500 165.180 ;
+    END
+  END w0_wd_in[178]
+  PIN w0_wd_in[179]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 165.600 0.500 166.100 ;
+    END
+  END w0_wd_in[179]
+  PIN w0_wd_in[180]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 166.520 0.500 167.020 ;
+    END
+  END w0_wd_in[180]
+  PIN w0_wd_in[181]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 167.440 0.500 167.940 ;
+    END
+  END w0_wd_in[181]
+  PIN w0_wd_in[182]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 168.360 0.500 168.860 ;
+    END
+  END w0_wd_in[182]
+  PIN w0_wd_in[183]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 169.280 0.500 169.780 ;
+    END
+  END w0_wd_in[183]
+  PIN w0_wd_in[184]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 170.200 0.500 170.700 ;
+    END
+  END w0_wd_in[184]
+  PIN w0_wd_in[185]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 171.120 0.500 171.620 ;
+    END
+  END w0_wd_in[185]
+  PIN w0_wd_in[186]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 172.040 0.500 172.540 ;
+    END
+  END w0_wd_in[186]
+  PIN w0_wd_in[187]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 172.960 0.500 173.460 ;
+    END
+  END w0_wd_in[187]
+  PIN w0_wd_in[188]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 173.880 0.500 174.380 ;
+    END
+  END w0_wd_in[188]
+  PIN w0_wd_in[189]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 174.800 0.500 175.300 ;
+    END
+  END w0_wd_in[189]
+  PIN w0_wd_in[190]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 175.720 0.500 176.220 ;
+    END
+  END w0_wd_in[190]
+  PIN w0_wd_in[191]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 176.640 0.500 177.140 ;
+    END
+  END w0_wd_in[191]
+  PIN w0_wd_in[192]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 177.560 0.500 178.060 ;
+    END
+  END w0_wd_in[192]
+  PIN w0_wd_in[193]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 178.480 0.500 178.980 ;
+    END
+  END w0_wd_in[193]
+  PIN w0_wd_in[194]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 179.400 0.500 179.900 ;
+    END
+  END w0_wd_in[194]
+  PIN w0_wd_in[195]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 180.320 0.500 180.820 ;
+    END
+  END w0_wd_in[195]
+  PIN w0_wd_in[196]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 181.240 0.500 181.740 ;
+    END
+  END w0_wd_in[196]
+  PIN w0_wd_in[197]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 182.160 0.500 182.660 ;
+    END
+  END w0_wd_in[197]
+  PIN w0_wd_in[198]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 183.080 0.500 183.580 ;
+    END
+  END w0_wd_in[198]
+  PIN w0_wd_in[199]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 184.000 0.500 184.500 ;
+    END
+  END w0_wd_in[199]
+  PIN w0_wd_in[200]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 184.920 0.500 185.420 ;
+    END
+  END w0_wd_in[200]
+  PIN w0_wd_in[201]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 185.840 0.500 186.340 ;
+    END
+  END w0_wd_in[201]
+  PIN w0_wd_in[202]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 186.760 0.500 187.260 ;
+    END
+  END w0_wd_in[202]
+  PIN w0_wd_in[203]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 187.680 0.500 188.180 ;
+    END
+  END w0_wd_in[203]
+  PIN w0_wd_in[204]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 188.600 0.500 189.100 ;
+    END
+  END w0_wd_in[204]
+  PIN w0_wd_in[205]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 189.520 0.500 190.020 ;
+    END
+  END w0_wd_in[205]
+  PIN w0_wd_in[206]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 190.440 0.500 190.940 ;
+    END
+  END w0_wd_in[206]
+  PIN w0_wd_in[207]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 191.360 0.500 191.860 ;
+    END
+  END w0_wd_in[207]
+  PIN w0_wd_in[208]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 192.280 0.500 192.780 ;
+    END
+  END w0_wd_in[208]
+  PIN w0_wd_in[209]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 193.200 0.500 193.700 ;
+    END
+  END w0_wd_in[209]
+  PIN w0_wd_in[210]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 194.120 0.500 194.620 ;
+    END
+  END w0_wd_in[210]
+  PIN w0_wd_in[211]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 195.040 0.500 195.540 ;
+    END
+  END w0_wd_in[211]
+  PIN w0_wd_in[212]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 195.960 0.500 196.460 ;
+    END
+  END w0_wd_in[212]
+  PIN w0_wd_in[213]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 196.880 0.500 197.380 ;
+    END
+  END w0_wd_in[213]
+  PIN w0_wd_in[214]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 197.800 0.500 198.300 ;
+    END
+  END w0_wd_in[214]
+  PIN w0_wd_in[215]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 198.720 0.500 199.220 ;
+    END
+  END w0_wd_in[215]
+  PIN w0_wd_in[216]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 199.640 0.500 200.140 ;
+    END
+  END w0_wd_in[216]
+  PIN w0_wd_in[217]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 200.560 0.500 201.060 ;
+    END
+  END w0_wd_in[217]
+  PIN w0_wd_in[218]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 201.480 0.500 201.980 ;
+    END
+  END w0_wd_in[218]
+  PIN w0_wd_in[219]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 202.400 0.500 202.900 ;
+    END
+  END w0_wd_in[219]
+  PIN w0_wd_in[220]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 203.320 0.500 203.820 ;
+    END
+  END w0_wd_in[220]
+  PIN w0_wd_in[221]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 204.240 0.500 204.740 ;
+    END
+  END w0_wd_in[221]
+  PIN w0_wd_in[222]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 205.160 0.500 205.660 ;
+    END
+  END w0_wd_in[222]
+  PIN w0_wd_in[223]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 206.080 0.500 206.580 ;
+    END
+  END w0_wd_in[223]
+  PIN w0_wd_in[224]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 207.000 0.500 207.500 ;
+    END
+  END w0_wd_in[224]
+  PIN w0_wd_in[225]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 207.920 0.500 208.420 ;
+    END
+  END w0_wd_in[225]
+  PIN w0_wd_in[226]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 208.840 0.500 209.340 ;
+    END
+  END w0_wd_in[226]
+  PIN w0_wd_in[227]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 209.760 0.500 210.260 ;
+    END
+  END w0_wd_in[227]
+  PIN w0_wd_in[228]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 210.680 0.500 211.180 ;
+    END
+  END w0_wd_in[228]
+  PIN w0_wd_in[229]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 211.600 0.500 212.100 ;
+    END
+  END w0_wd_in[229]
+  PIN w0_wd_in[230]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 212.520 0.500 213.020 ;
+    END
+  END w0_wd_in[230]
+  PIN w0_wd_in[231]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 213.440 0.500 213.940 ;
+    END
+  END w0_wd_in[231]
+  PIN w0_wd_in[232]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 214.360 0.500 214.860 ;
+    END
+  END w0_wd_in[232]
+  PIN w0_wd_in[233]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 215.280 0.500 215.780 ;
+    END
+  END w0_wd_in[233]
+  PIN w0_wd_in[234]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 216.200 0.500 216.700 ;
+    END
+  END w0_wd_in[234]
+  PIN w0_wd_in[235]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 217.120 0.500 217.620 ;
+    END
+  END w0_wd_in[235]
+  PIN w0_wd_in[236]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 218.040 0.500 218.540 ;
+    END
+  END w0_wd_in[236]
+  PIN w0_wd_in[237]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 218.960 0.500 219.460 ;
+    END
+  END w0_wd_in[237]
+  PIN w0_wd_in[238]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 219.880 0.500 220.380 ;
+    END
+  END w0_wd_in[238]
+  PIN w0_wd_in[239]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 220.800 0.500 221.300 ;
+    END
+  END w0_wd_in[239]
+  PIN w0_wd_in[240]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 221.720 0.500 222.220 ;
+    END
+  END w0_wd_in[240]
+  PIN w0_wd_in[241]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 222.640 0.500 223.140 ;
+    END
+  END w0_wd_in[241]
+  PIN w0_wd_in[242]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 223.560 0.500 224.060 ;
+    END
+  END w0_wd_in[242]
+  PIN w0_wd_in[243]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 224.480 0.500 224.980 ;
+    END
+  END w0_wd_in[243]
+  PIN w0_wd_in[244]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 225.400 0.500 225.900 ;
+    END
+  END w0_wd_in[244]
+  PIN w0_wd_in[245]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 226.320 0.500 226.820 ;
+    END
+  END w0_wd_in[245]
+  PIN w0_wd_in[246]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 227.240 0.500 227.740 ;
+    END
+  END w0_wd_in[246]
+  PIN w0_wd_in[247]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 228.160 0.500 228.660 ;
+    END
+  END w0_wd_in[247]
+  PIN w0_wd_in[248]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 229.080 0.500 229.580 ;
+    END
+  END w0_wd_in[248]
+  PIN w0_wd_in[249]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 230.000 0.500 230.500 ;
+    END
+  END w0_wd_in[249]
+  PIN w0_wd_in[250]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 230.920 0.500 231.420 ;
+    END
+  END w0_wd_in[250]
+  PIN w0_wd_in[251]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 231.840 0.500 232.340 ;
+    END
+  END w0_wd_in[251]
+  PIN w0_wd_in[252]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 232.760 0.500 233.260 ;
+    END
+  END w0_wd_in[252]
+  PIN w0_wd_in[253]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 233.680 0.500 234.180 ;
+    END
+  END w0_wd_in[253]
+  PIN w0_wd_in[254]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 234.600 0.500 235.100 ;
+    END
+  END w0_wd_in[254]
+  PIN w0_wd_in[255]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 235.520 0.500 236.020 ;
+    END
+  END w0_wd_in[255]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 236.440 0.500 236.940 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 237.360 0.500 237.860 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 238.280 0.500 238.780 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 239.200 0.500 239.700 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 240.120 0.500 240.620 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 241.040 0.500 241.540 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 241.960 0.500 242.460 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 242.880 0.500 243.380 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 243.800 0.500 244.300 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 244.720 0.500 245.220 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 245.640 0.500 246.140 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 246.560 0.500 247.060 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 247.480 0.500 247.980 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 248.400 0.500 248.900 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 249.320 0.500 249.820 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 250.240 0.500 250.740 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 251.160 0.500 251.660 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 252.080 0.500 252.580 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 253.000 0.500 253.500 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 253.920 0.500 254.420 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 254.840 0.500 255.340 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 255.760 0.500 256.260 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 256.680 0.500 257.180 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 257.600 0.500 258.100 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 258.520 0.500 259.020 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 259.440 0.500 259.940 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 260.360 0.500 260.860 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 261.280 0.500 261.780 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 262.200 0.500 262.700 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 263.120 0.500 263.620 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 264.040 0.500 264.540 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 264.960 0.500 265.460 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 265.880 0.500 266.380 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 266.800 0.500 267.300 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 267.720 0.500 268.220 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 268.640 0.500 269.140 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 269.560 0.500 270.060 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 270.480 0.500 270.980 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 271.400 0.500 271.900 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 272.320 0.500 272.820 ;
+    END
+  END r0_rd_out[32]
+  PIN r0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 273.240 0.500 273.740 ;
+    END
+  END r0_rd_out[33]
+  PIN r0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 274.160 0.500 274.660 ;
+    END
+  END r0_rd_out[34]
+  PIN r0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 275.080 0.500 275.580 ;
+    END
+  END r0_rd_out[35]
+  PIN r0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 276.000 0.500 276.500 ;
+    END
+  END r0_rd_out[36]
+  PIN r0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 276.920 0.500 277.420 ;
+    END
+  END r0_rd_out[37]
+  PIN r0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 277.840 0.500 278.340 ;
+    END
+  END r0_rd_out[38]
+  PIN r0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 278.760 0.500 279.260 ;
+    END
+  END r0_rd_out[39]
+  PIN r0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 279.680 0.500 280.180 ;
+    END
+  END r0_rd_out[40]
+  PIN r0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 280.600 0.500 281.100 ;
+    END
+  END r0_rd_out[41]
+  PIN r0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 281.520 0.500 282.020 ;
+    END
+  END r0_rd_out[42]
+  PIN r0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 282.440 0.500 282.940 ;
+    END
+  END r0_rd_out[43]
+  PIN r0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 283.360 0.500 283.860 ;
+    END
+  END r0_rd_out[44]
+  PIN r0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 284.280 0.500 284.780 ;
+    END
+  END r0_rd_out[45]
+  PIN r0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 285.200 0.500 285.700 ;
+    END
+  END r0_rd_out[46]
+  PIN r0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 286.120 0.500 286.620 ;
+    END
+  END r0_rd_out[47]
+  PIN r0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 287.040 0.500 287.540 ;
+    END
+  END r0_rd_out[48]
+  PIN r0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 287.960 0.500 288.460 ;
+    END
+  END r0_rd_out[49]
+  PIN r0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 288.880 0.500 289.380 ;
+    END
+  END r0_rd_out[50]
+  PIN r0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 289.800 0.500 290.300 ;
+    END
+  END r0_rd_out[51]
+  PIN r0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 290.720 0.500 291.220 ;
+    END
+  END r0_rd_out[52]
+  PIN r0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 291.640 0.500 292.140 ;
+    END
+  END r0_rd_out[53]
+  PIN r0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 292.560 0.500 293.060 ;
+    END
+  END r0_rd_out[54]
+  PIN r0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 293.480 0.500 293.980 ;
+    END
+  END r0_rd_out[55]
+  PIN r0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 294.400 0.500 294.900 ;
+    END
+  END r0_rd_out[56]
+  PIN r0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 295.320 0.500 295.820 ;
+    END
+  END r0_rd_out[57]
+  PIN r0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 296.240 0.500 296.740 ;
+    END
+  END r0_rd_out[58]
+  PIN r0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 297.160 0.500 297.660 ;
+    END
+  END r0_rd_out[59]
+  PIN r0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 298.080 0.500 298.580 ;
+    END
+  END r0_rd_out[60]
+  PIN r0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 299.000 0.500 299.500 ;
+    END
+  END r0_rd_out[61]
+  PIN r0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 299.920 0.500 300.420 ;
+    END
+  END r0_rd_out[62]
+  PIN r0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 300.840 0.500 301.340 ;
+    END
+  END r0_rd_out[63]
+  PIN r0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 301.760 0.500 302.260 ;
+    END
+  END r0_rd_out[64]
+  PIN r0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 302.680 0.500 303.180 ;
+    END
+  END r0_rd_out[65]
+  PIN r0_rd_out[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 303.600 0.500 304.100 ;
+    END
+  END r0_rd_out[66]
+  PIN r0_rd_out[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 304.520 0.500 305.020 ;
+    END
+  END r0_rd_out[67]
+  PIN r0_rd_out[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 305.440 0.500 305.940 ;
+    END
+  END r0_rd_out[68]
+  PIN r0_rd_out[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 306.360 0.500 306.860 ;
+    END
+  END r0_rd_out[69]
+  PIN r0_rd_out[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 307.280 0.500 307.780 ;
+    END
+  END r0_rd_out[70]
+  PIN r0_rd_out[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 308.200 0.500 308.700 ;
+    END
+  END r0_rd_out[71]
+  PIN r0_rd_out[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 309.120 0.500 309.620 ;
+    END
+  END r0_rd_out[72]
+  PIN r0_rd_out[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 310.040 0.500 310.540 ;
+    END
+  END r0_rd_out[73]
+  PIN r0_rd_out[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 310.960 0.500 311.460 ;
+    END
+  END r0_rd_out[74]
+  PIN r0_rd_out[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 311.880 0.500 312.380 ;
+    END
+  END r0_rd_out[75]
+  PIN r0_rd_out[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 312.800 0.500 313.300 ;
+    END
+  END r0_rd_out[76]
+  PIN r0_rd_out[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 313.720 0.500 314.220 ;
+    END
+  END r0_rd_out[77]
+  PIN r0_rd_out[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 314.640 0.500 315.140 ;
+    END
+  END r0_rd_out[78]
+  PIN r0_rd_out[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 315.560 0.500 316.060 ;
+    END
+  END r0_rd_out[79]
+  PIN r0_rd_out[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 316.480 0.500 316.980 ;
+    END
+  END r0_rd_out[80]
+  PIN r0_rd_out[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 317.400 0.500 317.900 ;
+    END
+  END r0_rd_out[81]
+  PIN r0_rd_out[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 318.320 0.500 318.820 ;
+    END
+  END r0_rd_out[82]
+  PIN r0_rd_out[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 319.240 0.500 319.740 ;
+    END
+  END r0_rd_out[83]
+  PIN r0_rd_out[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 320.160 0.500 320.660 ;
+    END
+  END r0_rd_out[84]
+  PIN r0_rd_out[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 321.080 0.500 321.580 ;
+    END
+  END r0_rd_out[85]
+  PIN r0_rd_out[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 322.000 0.500 322.500 ;
+    END
+  END r0_rd_out[86]
+  PIN r0_rd_out[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 322.920 0.500 323.420 ;
+    END
+  END r0_rd_out[87]
+  PIN r0_rd_out[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 323.840 0.500 324.340 ;
+    END
+  END r0_rd_out[88]
+  PIN r0_rd_out[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 324.760 0.500 325.260 ;
+    END
+  END r0_rd_out[89]
+  PIN r0_rd_out[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 325.680 0.500 326.180 ;
+    END
+  END r0_rd_out[90]
+  PIN r0_rd_out[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 326.600 0.500 327.100 ;
+    END
+  END r0_rd_out[91]
+  PIN r0_rd_out[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 327.520 0.500 328.020 ;
+    END
+  END r0_rd_out[92]
+  PIN r0_rd_out[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 328.440 0.500 328.940 ;
+    END
+  END r0_rd_out[93]
+  PIN r0_rd_out[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 329.360 0.500 329.860 ;
+    END
+  END r0_rd_out[94]
+  PIN r0_rd_out[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 330.280 0.500 330.780 ;
+    END
+  END r0_rd_out[95]
+  PIN r0_rd_out[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 331.200 0.500 331.700 ;
+    END
+  END r0_rd_out[96]
+  PIN r0_rd_out[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 332.120 0.500 332.620 ;
+    END
+  END r0_rd_out[97]
+  PIN r0_rd_out[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 333.040 0.500 333.540 ;
+    END
+  END r0_rd_out[98]
+  PIN r0_rd_out[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 333.960 0.500 334.460 ;
+    END
+  END r0_rd_out[99]
+  PIN r0_rd_out[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 334.880 0.500 335.380 ;
+    END
+  END r0_rd_out[100]
+  PIN r0_rd_out[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 335.800 0.500 336.300 ;
+    END
+  END r0_rd_out[101]
+  PIN r0_rd_out[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 336.720 0.500 337.220 ;
+    END
+  END r0_rd_out[102]
+  PIN r0_rd_out[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 337.640 0.500 338.140 ;
+    END
+  END r0_rd_out[103]
+  PIN r0_rd_out[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 338.560 0.500 339.060 ;
+    END
+  END r0_rd_out[104]
+  PIN r0_rd_out[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 339.480 0.500 339.980 ;
+    END
+  END r0_rd_out[105]
+  PIN r0_rd_out[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 340.400 0.500 340.900 ;
+    END
+  END r0_rd_out[106]
+  PIN r0_rd_out[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 341.320 0.500 341.820 ;
+    END
+  END r0_rd_out[107]
+  PIN r0_rd_out[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 342.240 0.500 342.740 ;
+    END
+  END r0_rd_out[108]
+  PIN r0_rd_out[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 343.160 0.500 343.660 ;
+    END
+  END r0_rd_out[109]
+  PIN r0_rd_out[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 344.080 0.500 344.580 ;
+    END
+  END r0_rd_out[110]
+  PIN r0_rd_out[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 345.000 0.500 345.500 ;
+    END
+  END r0_rd_out[111]
+  PIN r0_rd_out[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 345.920 0.500 346.420 ;
+    END
+  END r0_rd_out[112]
+  PIN r0_rd_out[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 346.840 0.500 347.340 ;
+    END
+  END r0_rd_out[113]
+  PIN r0_rd_out[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 347.760 0.500 348.260 ;
+    END
+  END r0_rd_out[114]
+  PIN r0_rd_out[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 348.680 0.500 349.180 ;
+    END
+  END r0_rd_out[115]
+  PIN r0_rd_out[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 349.600 0.500 350.100 ;
+    END
+  END r0_rd_out[116]
+  PIN r0_rd_out[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 350.520 0.500 351.020 ;
+    END
+  END r0_rd_out[117]
+  PIN r0_rd_out[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 351.440 0.500 351.940 ;
+    END
+  END r0_rd_out[118]
+  PIN r0_rd_out[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 352.360 0.500 352.860 ;
+    END
+  END r0_rd_out[119]
+  PIN r0_rd_out[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 353.280 0.500 353.780 ;
+    END
+  END r0_rd_out[120]
+  PIN r0_rd_out[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 354.200 0.500 354.700 ;
+    END
+  END r0_rd_out[121]
+  PIN r0_rd_out[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 355.120 0.500 355.620 ;
+    END
+  END r0_rd_out[122]
+  PIN r0_rd_out[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 356.040 0.500 356.540 ;
+    END
+  END r0_rd_out[123]
+  PIN r0_rd_out[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 356.960 0.500 357.460 ;
+    END
+  END r0_rd_out[124]
+  PIN r0_rd_out[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 357.880 0.500 358.380 ;
+    END
+  END r0_rd_out[125]
+  PIN r0_rd_out[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 358.800 0.500 359.300 ;
+    END
+  END r0_rd_out[126]
+  PIN r0_rd_out[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 359.720 0.500 360.220 ;
+    END
+  END r0_rd_out[127]
+  PIN r0_rd_out[128]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 360.640 0.500 361.140 ;
+    END
+  END r0_rd_out[128]
+  PIN r0_rd_out[129]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 361.560 0.500 362.060 ;
+    END
+  END r0_rd_out[129]
+  PIN r0_rd_out[130]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 362.480 0.500 362.980 ;
+    END
+  END r0_rd_out[130]
+  PIN r0_rd_out[131]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 363.400 0.500 363.900 ;
+    END
+  END r0_rd_out[131]
+  PIN r0_rd_out[132]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 364.320 0.500 364.820 ;
+    END
+  END r0_rd_out[132]
+  PIN r0_rd_out[133]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 365.240 0.500 365.740 ;
+    END
+  END r0_rd_out[133]
+  PIN r0_rd_out[134]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 366.160 0.500 366.660 ;
+    END
+  END r0_rd_out[134]
+  PIN r0_rd_out[135]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 367.080 0.500 367.580 ;
+    END
+  END r0_rd_out[135]
+  PIN r0_rd_out[136]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 368.000 0.500 368.500 ;
+    END
+  END r0_rd_out[136]
+  PIN r0_rd_out[137]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 368.920 0.500 369.420 ;
+    END
+  END r0_rd_out[137]
+  PIN r0_rd_out[138]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 369.840 0.500 370.340 ;
+    END
+  END r0_rd_out[138]
+  PIN r0_rd_out[139]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 370.760 0.500 371.260 ;
+    END
+  END r0_rd_out[139]
+  PIN r0_rd_out[140]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 371.680 0.500 372.180 ;
+    END
+  END r0_rd_out[140]
+  PIN r0_rd_out[141]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 372.600 0.500 373.100 ;
+    END
+  END r0_rd_out[141]
+  PIN r0_rd_out[142]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 373.520 0.500 374.020 ;
+    END
+  END r0_rd_out[142]
+  PIN r0_rd_out[143]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 374.440 0.500 374.940 ;
+    END
+  END r0_rd_out[143]
+  PIN r0_rd_out[144]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 375.360 0.500 375.860 ;
+    END
+  END r0_rd_out[144]
+  PIN r0_rd_out[145]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 376.280 0.500 376.780 ;
+    END
+  END r0_rd_out[145]
+  PIN r0_rd_out[146]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 377.200 0.500 377.700 ;
+    END
+  END r0_rd_out[146]
+  PIN r0_rd_out[147]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 378.120 0.500 378.620 ;
+    END
+  END r0_rd_out[147]
+  PIN r0_rd_out[148]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 379.040 0.500 379.540 ;
+    END
+  END r0_rd_out[148]
+  PIN r0_rd_out[149]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 379.960 0.500 380.460 ;
+    END
+  END r0_rd_out[149]
+  PIN r0_rd_out[150]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 380.880 0.500 381.380 ;
+    END
+  END r0_rd_out[150]
+  PIN r0_rd_out[151]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 381.800 0.500 382.300 ;
+    END
+  END r0_rd_out[151]
+  PIN r0_rd_out[152]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 382.720 0.500 383.220 ;
+    END
+  END r0_rd_out[152]
+  PIN r0_rd_out[153]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 383.640 0.500 384.140 ;
+    END
+  END r0_rd_out[153]
+  PIN r0_rd_out[154]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 384.560 0.500 385.060 ;
+    END
+  END r0_rd_out[154]
+  PIN r0_rd_out[155]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 385.480 0.500 385.980 ;
+    END
+  END r0_rd_out[155]
+  PIN r0_rd_out[156]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 386.400 0.500 386.900 ;
+    END
+  END r0_rd_out[156]
+  PIN r0_rd_out[157]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 387.320 0.500 387.820 ;
+    END
+  END r0_rd_out[157]
+  PIN r0_rd_out[158]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 388.240 0.500 388.740 ;
+    END
+  END r0_rd_out[158]
+  PIN r0_rd_out[159]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 389.160 0.500 389.660 ;
+    END
+  END r0_rd_out[159]
+  PIN r0_rd_out[160]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 390.080 0.500 390.580 ;
+    END
+  END r0_rd_out[160]
+  PIN r0_rd_out[161]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 391.000 0.500 391.500 ;
+    END
+  END r0_rd_out[161]
+  PIN r0_rd_out[162]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 391.920 0.500 392.420 ;
+    END
+  END r0_rd_out[162]
+  PIN r0_rd_out[163]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 392.840 0.500 393.340 ;
+    END
+  END r0_rd_out[163]
+  PIN r0_rd_out[164]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 393.760 0.500 394.260 ;
+    END
+  END r0_rd_out[164]
+  PIN r0_rd_out[165]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 394.680 0.500 395.180 ;
+    END
+  END r0_rd_out[165]
+  PIN r0_rd_out[166]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 395.600 0.500 396.100 ;
+    END
+  END r0_rd_out[166]
+  PIN r0_rd_out[167]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 396.520 0.500 397.020 ;
+    END
+  END r0_rd_out[167]
+  PIN r0_rd_out[168]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 397.440 0.500 397.940 ;
+    END
+  END r0_rd_out[168]
+  PIN r0_rd_out[169]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 398.360 0.500 398.860 ;
+    END
+  END r0_rd_out[169]
+  PIN r0_rd_out[170]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 399.280 0.500 399.780 ;
+    END
+  END r0_rd_out[170]
+  PIN r0_rd_out[171]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 400.200 0.500 400.700 ;
+    END
+  END r0_rd_out[171]
+  PIN r0_rd_out[172]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 401.120 0.500 401.620 ;
+    END
+  END r0_rd_out[172]
+  PIN r0_rd_out[173]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 402.040 0.500 402.540 ;
+    END
+  END r0_rd_out[173]
+  PIN r0_rd_out[174]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 402.960 0.500 403.460 ;
+    END
+  END r0_rd_out[174]
+  PIN r0_rd_out[175]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 403.880 0.500 404.380 ;
+    END
+  END r0_rd_out[175]
+  PIN r0_rd_out[176]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 404.800 0.500 405.300 ;
+    END
+  END r0_rd_out[176]
+  PIN r0_rd_out[177]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 405.720 0.500 406.220 ;
+    END
+  END r0_rd_out[177]
+  PIN r0_rd_out[178]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 406.640 0.500 407.140 ;
+    END
+  END r0_rd_out[178]
+  PIN r0_rd_out[179]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 407.560 0.500 408.060 ;
+    END
+  END r0_rd_out[179]
+  PIN r0_rd_out[180]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 408.480 0.500 408.980 ;
+    END
+  END r0_rd_out[180]
+  PIN r0_rd_out[181]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 409.400 0.500 409.900 ;
+    END
+  END r0_rd_out[181]
+  PIN r0_rd_out[182]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 410.320 0.500 410.820 ;
+    END
+  END r0_rd_out[182]
+  PIN r0_rd_out[183]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 411.240 0.500 411.740 ;
+    END
+  END r0_rd_out[183]
+  PIN r0_rd_out[184]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 412.160 0.500 412.660 ;
+    END
+  END r0_rd_out[184]
+  PIN r0_rd_out[185]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 413.080 0.500 413.580 ;
+    END
+  END r0_rd_out[185]
+  PIN r0_rd_out[186]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 414.000 0.500 414.500 ;
+    END
+  END r0_rd_out[186]
+  PIN r0_rd_out[187]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 414.920 0.500 415.420 ;
+    END
+  END r0_rd_out[187]
+  PIN r0_rd_out[188]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 415.840 0.500 416.340 ;
+    END
+  END r0_rd_out[188]
+  PIN r0_rd_out[189]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 416.760 0.500 417.260 ;
+    END
+  END r0_rd_out[189]
+  PIN r0_rd_out[190]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 417.680 0.500 418.180 ;
+    END
+  END r0_rd_out[190]
+  PIN r0_rd_out[191]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 418.600 0.500 419.100 ;
+    END
+  END r0_rd_out[191]
+  PIN r0_rd_out[192]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 419.520 0.500 420.020 ;
+    END
+  END r0_rd_out[192]
+  PIN r0_rd_out[193]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 420.440 0.500 420.940 ;
+    END
+  END r0_rd_out[193]
+  PIN r0_rd_out[194]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 421.360 0.500 421.860 ;
+    END
+  END r0_rd_out[194]
+  PIN r0_rd_out[195]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 422.280 0.500 422.780 ;
+    END
+  END r0_rd_out[195]
+  PIN r0_rd_out[196]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 423.200 0.500 423.700 ;
+    END
+  END r0_rd_out[196]
+  PIN r0_rd_out[197]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 424.120 0.500 424.620 ;
+    END
+  END r0_rd_out[197]
+  PIN r0_rd_out[198]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 425.040 0.500 425.540 ;
+    END
+  END r0_rd_out[198]
+  PIN r0_rd_out[199]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 425.960 0.500 426.460 ;
+    END
+  END r0_rd_out[199]
+  PIN r0_rd_out[200]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 426.880 0.500 427.380 ;
+    END
+  END r0_rd_out[200]
+  PIN r0_rd_out[201]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 427.800 0.500 428.300 ;
+    END
+  END r0_rd_out[201]
+  PIN r0_rd_out[202]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 428.720 0.500 429.220 ;
+    END
+  END r0_rd_out[202]
+  PIN r0_rd_out[203]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 429.640 0.500 430.140 ;
+    END
+  END r0_rd_out[203]
+  PIN r0_rd_out[204]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 430.560 0.500 431.060 ;
+    END
+  END r0_rd_out[204]
+  PIN r0_rd_out[205]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 431.480 0.500 431.980 ;
+    END
+  END r0_rd_out[205]
+  PIN r0_rd_out[206]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 432.400 0.500 432.900 ;
+    END
+  END r0_rd_out[206]
+  PIN r0_rd_out[207]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 433.320 0.500 433.820 ;
+    END
+  END r0_rd_out[207]
+  PIN r0_rd_out[208]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 434.240 0.500 434.740 ;
+    END
+  END r0_rd_out[208]
+  PIN r0_rd_out[209]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 435.160 0.500 435.660 ;
+    END
+  END r0_rd_out[209]
+  PIN r0_rd_out[210]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 436.080 0.500 436.580 ;
+    END
+  END r0_rd_out[210]
+  PIN r0_rd_out[211]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 437.000 0.500 437.500 ;
+    END
+  END r0_rd_out[211]
+  PIN r0_rd_out[212]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 437.920 0.500 438.420 ;
+    END
+  END r0_rd_out[212]
+  PIN r0_rd_out[213]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 438.840 0.500 439.340 ;
+    END
+  END r0_rd_out[213]
+  PIN r0_rd_out[214]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 439.760 0.500 440.260 ;
+    END
+  END r0_rd_out[214]
+  PIN r0_rd_out[215]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 440.680 0.500 441.180 ;
+    END
+  END r0_rd_out[215]
+  PIN r0_rd_out[216]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 441.600 0.500 442.100 ;
+    END
+  END r0_rd_out[216]
+  PIN r0_rd_out[217]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 442.520 0.500 443.020 ;
+    END
+  END r0_rd_out[217]
+  PIN r0_rd_out[218]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 443.440 0.500 443.940 ;
+    END
+  END r0_rd_out[218]
+  PIN r0_rd_out[219]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 444.360 0.500 444.860 ;
+    END
+  END r0_rd_out[219]
+  PIN r0_rd_out[220]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 445.280 0.500 445.780 ;
+    END
+  END r0_rd_out[220]
+  PIN r0_rd_out[221]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 446.200 0.500 446.700 ;
+    END
+  END r0_rd_out[221]
+  PIN r0_rd_out[222]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 447.120 0.500 447.620 ;
+    END
+  END r0_rd_out[222]
+  PIN r0_rd_out[223]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 448.040 0.500 448.540 ;
+    END
+  END r0_rd_out[223]
+  PIN r0_rd_out[224]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 448.960 0.500 449.460 ;
+    END
+  END r0_rd_out[224]
+  PIN r0_rd_out[225]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 449.880 0.500 450.380 ;
+    END
+  END r0_rd_out[225]
+  PIN r0_rd_out[226]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 450.800 0.500 451.300 ;
+    END
+  END r0_rd_out[226]
+  PIN r0_rd_out[227]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 451.720 0.500 452.220 ;
+    END
+  END r0_rd_out[227]
+  PIN r0_rd_out[228]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 452.640 0.500 453.140 ;
+    END
+  END r0_rd_out[228]
+  PIN r0_rd_out[229]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 453.560 0.500 454.060 ;
+    END
+  END r0_rd_out[229]
+  PIN r0_rd_out[230]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 454.480 0.500 454.980 ;
+    END
+  END r0_rd_out[230]
+  PIN r0_rd_out[231]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 455.400 0.500 455.900 ;
+    END
+  END r0_rd_out[231]
+  PIN r0_rd_out[232]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 456.320 0.500 456.820 ;
+    END
+  END r0_rd_out[232]
+  PIN r0_rd_out[233]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 457.240 0.500 457.740 ;
+    END
+  END r0_rd_out[233]
+  PIN r0_rd_out[234]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 458.160 0.500 458.660 ;
+    END
+  END r0_rd_out[234]
+  PIN r0_rd_out[235]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 459.080 0.500 459.580 ;
+    END
+  END r0_rd_out[235]
+  PIN r0_rd_out[236]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 460.000 0.500 460.500 ;
+    END
+  END r0_rd_out[236]
+  PIN r0_rd_out[237]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 460.920 0.500 461.420 ;
+    END
+  END r0_rd_out[237]
+  PIN r0_rd_out[238]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 461.840 0.500 462.340 ;
+    END
+  END r0_rd_out[238]
+  PIN r0_rd_out[239]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 462.760 0.500 463.260 ;
+    END
+  END r0_rd_out[239]
+  PIN r0_rd_out[240]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 463.680 0.500 464.180 ;
+    END
+  END r0_rd_out[240]
+  PIN r0_rd_out[241]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 464.600 0.500 465.100 ;
+    END
+  END r0_rd_out[241]
+  PIN r0_rd_out[242]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 465.520 0.500 466.020 ;
+    END
+  END r0_rd_out[242]
+  PIN r0_rd_out[243]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 466.440 0.500 466.940 ;
+    END
+  END r0_rd_out[243]
+  PIN r0_rd_out[244]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 467.360 0.500 467.860 ;
+    END
+  END r0_rd_out[244]
+  PIN r0_rd_out[245]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 468.280 0.500 468.780 ;
+    END
+  END r0_rd_out[245]
+  PIN r0_rd_out[246]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 469.200 0.500 469.700 ;
+    END
+  END r0_rd_out[246]
+  PIN r0_rd_out[247]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 470.120 0.500 470.620 ;
+    END
+  END r0_rd_out[247]
+  PIN r0_rd_out[248]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 471.040 0.500 471.540 ;
+    END
+  END r0_rd_out[248]
+  PIN r0_rd_out[249]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 471.960 0.500 472.460 ;
+    END
+  END r0_rd_out[249]
+  PIN r0_rd_out[250]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 472.880 0.500 473.380 ;
+    END
+  END r0_rd_out[250]
+  PIN r0_rd_out[251]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 473.800 0.500 474.300 ;
+    END
+  END r0_rd_out[251]
+  PIN r0_rd_out[252]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 474.720 0.500 475.220 ;
+    END
+  END r0_rd_out[252]
+  PIN r0_rd_out[253]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 475.640 0.500 476.140 ;
+    END
+  END r0_rd_out[253]
+  PIN r0_rd_out[254]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 476.560 0.500 477.060 ;
+    END
+  END r0_rd_out[254]
+  PIN r0_rd_out[255]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 477.480 0.500 477.980 ;
+    END
+  END r0_rd_out[255]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 478.400 0.500 478.900 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 479.320 0.500 479.820 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 480.240 0.500 480.740 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 481.160 0.500 481.660 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 482.080 0.500 482.580 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 483.000 0.500 483.500 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 484.160 ;
+      RECT 22.480 2.720 23.680 484.160 ;
+      RECT 37.200 2.720 38.400 484.160 ;
+      RECT 51.920 2.720 53.120 484.160 ;
+      RECT 66.640 2.720 67.840 484.160 ;
+      RECT 81.360 2.720 82.560 484.160 ;
+      RECT 96.080 2.720 97.280 484.160 ;
+      RECT 110.800 2.720 112.000 484.160 ;
+      RECT 125.520 2.720 126.720 484.160 ;
+      RECT 140.240 2.720 141.440 484.160 ;
+      RECT 154.960 2.720 156.160 484.160 ;
+      RECT 169.680 2.720 170.880 484.160 ;
+      RECT 184.400 2.720 185.600 484.160 ;
+      RECT 199.120 2.720 200.320 484.160 ;
+      RECT 213.840 2.720 215.040 484.160 ;
+      RECT 228.560 2.720 229.760 484.160 ;
+      RECT 243.280 2.720 244.480 484.160 ;
+      RECT 258.000 2.720 259.200 484.160 ;
+      RECT 272.720 2.720 273.920 484.160 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 484.160 ;
+      RECT 29.840 2.720 31.040 484.160 ;
+      RECT 44.560 2.720 45.760 484.160 ;
+      RECT 59.280 2.720 60.480 484.160 ;
+      RECT 74.000 2.720 75.200 484.160 ;
+      RECT 88.720 2.720 89.920 484.160 ;
+      RECT 103.440 2.720 104.640 484.160 ;
+      RECT 118.160 2.720 119.360 484.160 ;
+      RECT 132.880 2.720 134.080 484.160 ;
+      RECT 147.600 2.720 148.800 484.160 ;
+      RECT 162.320 2.720 163.520 484.160 ;
+      RECT 177.040 2.720 178.240 484.160 ;
+      RECT 191.760 2.720 192.960 484.160 ;
+      RECT 206.480 2.720 207.680 484.160 ;
+      RECT 221.200 2.720 222.400 484.160 ;
+      RECT 235.920 2.720 237.120 484.160 ;
+      RECT 250.640 2.720 251.840 484.160 ;
+      RECT 265.360 2.720 266.560 484.160 ;
+      RECT 280.080 2.720 281.280 484.160 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 286.580 486.880 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 286.580 486.880 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 286.580 486.880 ;
+  END
+END fakeram_256x16_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_272x16_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_272x16_1r1w.lef
@@ -1,0 +1,5083 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_272x16_1r1w
+  FOREIGN fakeram_272x16_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 295.320 BY 516.800 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_wd_in[32]
+  PIN w0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_wd_in[33]
+  PIN w0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_wd_in[34]
+  PIN w0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_wd_in[35]
+  PIN w0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_wd_in[36]
+  PIN w0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_wd_in[37]
+  PIN w0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_wd_in[38]
+  PIN w0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_wd_in[39]
+  PIN w0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_wd_in[40]
+  PIN w0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_wd_in[41]
+  PIN w0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END w0_wd_in[42]
+  PIN w0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END w0_wd_in[43]
+  PIN w0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END w0_wd_in[44]
+  PIN w0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END w0_wd_in[45]
+  PIN w0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END w0_wd_in[46]
+  PIN w0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END w0_wd_in[47]
+  PIN w0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END w0_wd_in[48]
+  PIN w0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END w0_wd_in[49]
+  PIN w0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END w0_wd_in[50]
+  PIN w0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END w0_wd_in[51]
+  PIN w0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END w0_wd_in[52]
+  PIN w0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END w0_wd_in[53]
+  PIN w0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END w0_wd_in[54]
+  PIN w0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END w0_wd_in[55]
+  PIN w0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END w0_wd_in[56]
+  PIN w0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END w0_wd_in[57]
+  PIN w0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END w0_wd_in[58]
+  PIN w0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END w0_wd_in[59]
+  PIN w0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END w0_wd_in[60]
+  PIN w0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END w0_wd_in[61]
+  PIN w0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END w0_wd_in[62]
+  PIN w0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END w0_wd_in[63]
+  PIN w0_wd_in[64]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END w0_wd_in[64]
+  PIN w0_wd_in[65]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END w0_wd_in[65]
+  PIN w0_wd_in[66]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END w0_wd_in[66]
+  PIN w0_wd_in[67]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END w0_wd_in[67]
+  PIN w0_wd_in[68]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END w0_wd_in[68]
+  PIN w0_wd_in[69]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END w0_wd_in[69]
+  PIN w0_wd_in[70]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END w0_wd_in[70]
+  PIN w0_wd_in[71]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END w0_wd_in[71]
+  PIN w0_wd_in[72]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END w0_wd_in[72]
+  PIN w0_wd_in[73]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END w0_wd_in[73]
+  PIN w0_wd_in[74]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END w0_wd_in[74]
+  PIN w0_wd_in[75]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END w0_wd_in[75]
+  PIN w0_wd_in[76]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END w0_wd_in[76]
+  PIN w0_wd_in[77]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END w0_wd_in[77]
+  PIN w0_wd_in[78]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END w0_wd_in[78]
+  PIN w0_wd_in[79]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END w0_wd_in[79]
+  PIN w0_wd_in[80]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END w0_wd_in[80]
+  PIN w0_wd_in[81]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END w0_wd_in[81]
+  PIN w0_wd_in[82]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END w0_wd_in[82]
+  PIN w0_wd_in[83]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.280 0.500 77.780 ;
+    END
+  END w0_wd_in[83]
+  PIN w0_wd_in[84]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.200 0.500 78.700 ;
+    END
+  END w0_wd_in[84]
+  PIN w0_wd_in[85]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 79.120 0.500 79.620 ;
+    END
+  END w0_wd_in[85]
+  PIN w0_wd_in[86]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.040 0.500 80.540 ;
+    END
+  END w0_wd_in[86]
+  PIN w0_wd_in[87]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.960 0.500 81.460 ;
+    END
+  END w0_wd_in[87]
+  PIN w0_wd_in[88]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.880 0.500 82.380 ;
+    END
+  END w0_wd_in[88]
+  PIN w0_wd_in[89]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 82.800 0.500 83.300 ;
+    END
+  END w0_wd_in[89]
+  PIN w0_wd_in[90]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.720 0.500 84.220 ;
+    END
+  END w0_wd_in[90]
+  PIN w0_wd_in[91]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.640 0.500 85.140 ;
+    END
+  END w0_wd_in[91]
+  PIN w0_wd_in[92]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.560 0.500 86.060 ;
+    END
+  END w0_wd_in[92]
+  PIN w0_wd_in[93]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 86.480 0.500 86.980 ;
+    END
+  END w0_wd_in[93]
+  PIN w0_wd_in[94]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.400 0.500 87.900 ;
+    END
+  END w0_wd_in[94]
+  PIN w0_wd_in[95]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 88.320 0.500 88.820 ;
+    END
+  END w0_wd_in[95]
+  PIN w0_wd_in[96]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.240 0.500 89.740 ;
+    END
+  END w0_wd_in[96]
+  PIN w0_wd_in[97]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 90.160 0.500 90.660 ;
+    END
+  END w0_wd_in[97]
+  PIN w0_wd_in[98]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 91.080 0.500 91.580 ;
+    END
+  END w0_wd_in[98]
+  PIN w0_wd_in[99]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.000 0.500 92.500 ;
+    END
+  END w0_wd_in[99]
+  PIN w0_wd_in[100]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.920 0.500 93.420 ;
+    END
+  END w0_wd_in[100]
+  PIN w0_wd_in[101]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.840 0.500 94.340 ;
+    END
+  END w0_wd_in[101]
+  PIN w0_wd_in[102]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 94.760 0.500 95.260 ;
+    END
+  END w0_wd_in[102]
+  PIN w0_wd_in[103]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.680 0.500 96.180 ;
+    END
+  END w0_wd_in[103]
+  PIN w0_wd_in[104]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 96.600 0.500 97.100 ;
+    END
+  END w0_wd_in[104]
+  PIN w0_wd_in[105]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.520 0.500 98.020 ;
+    END
+  END w0_wd_in[105]
+  PIN w0_wd_in[106]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 98.440 0.500 98.940 ;
+    END
+  END w0_wd_in[106]
+  PIN w0_wd_in[107]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 99.360 0.500 99.860 ;
+    END
+  END w0_wd_in[107]
+  PIN w0_wd_in[108]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.280 0.500 100.780 ;
+    END
+  END w0_wd_in[108]
+  PIN w0_wd_in[109]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.200 0.500 101.700 ;
+    END
+  END w0_wd_in[109]
+  PIN w0_wd_in[110]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 102.120 0.500 102.620 ;
+    END
+  END w0_wd_in[110]
+  PIN w0_wd_in[111]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.040 0.500 103.540 ;
+    END
+  END w0_wd_in[111]
+  PIN w0_wd_in[112]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.960 0.500 104.460 ;
+    END
+  END w0_wd_in[112]
+  PIN w0_wd_in[113]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 104.880 0.500 105.380 ;
+    END
+  END w0_wd_in[113]
+  PIN w0_wd_in[114]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.800 0.500 106.300 ;
+    END
+  END w0_wd_in[114]
+  PIN w0_wd_in[115]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.720 0.500 107.220 ;
+    END
+  END w0_wd_in[115]
+  PIN w0_wd_in[116]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 107.640 0.500 108.140 ;
+    END
+  END w0_wd_in[116]
+  PIN w0_wd_in[117]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.560 0.500 109.060 ;
+    END
+  END w0_wd_in[117]
+  PIN w0_wd_in[118]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 109.480 0.500 109.980 ;
+    END
+  END w0_wd_in[118]
+  PIN w0_wd_in[119]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.400 0.500 110.900 ;
+    END
+  END w0_wd_in[119]
+  PIN w0_wd_in[120]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.320 0.500 111.820 ;
+    END
+  END w0_wd_in[120]
+  PIN w0_wd_in[121]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 112.240 0.500 112.740 ;
+    END
+  END w0_wd_in[121]
+  PIN w0_wd_in[122]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 113.160 0.500 113.660 ;
+    END
+  END w0_wd_in[122]
+  PIN w0_wd_in[123]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.080 0.500 114.580 ;
+    END
+  END w0_wd_in[123]
+  PIN w0_wd_in[124]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.000 0.500 115.500 ;
+    END
+  END w0_wd_in[124]
+  PIN w0_wd_in[125]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.920 0.500 116.420 ;
+    END
+  END w0_wd_in[125]
+  PIN w0_wd_in[126]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.840 0.500 117.340 ;
+    END
+  END w0_wd_in[126]
+  PIN w0_wd_in[127]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 117.760 0.500 118.260 ;
+    END
+  END w0_wd_in[127]
+  PIN w0_wd_in[128]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.680 0.500 119.180 ;
+    END
+  END w0_wd_in[128]
+  PIN w0_wd_in[129]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.600 0.500 120.100 ;
+    END
+  END w0_wd_in[129]
+  PIN w0_wd_in[130]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 120.520 0.500 121.020 ;
+    END
+  END w0_wd_in[130]
+  PIN w0_wd_in[131]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 121.440 0.500 121.940 ;
+    END
+  END w0_wd_in[131]
+  PIN w0_wd_in[132]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.360 0.500 122.860 ;
+    END
+  END w0_wd_in[132]
+  PIN w0_wd_in[133]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.280 0.500 123.780 ;
+    END
+  END w0_wd_in[133]
+  PIN w0_wd_in[134]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 124.200 0.500 124.700 ;
+    END
+  END w0_wd_in[134]
+  PIN w0_wd_in[135]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.500 125.620 ;
+    END
+  END w0_wd_in[135]
+  PIN w0_wd_in[136]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.040 0.500 126.540 ;
+    END
+  END w0_wd_in[136]
+  PIN w0_wd_in[137]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.960 0.500 127.460 ;
+    END
+  END w0_wd_in[137]
+  PIN w0_wd_in[138]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.880 0.500 128.380 ;
+    END
+  END w0_wd_in[138]
+  PIN w0_wd_in[139]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 128.800 0.500 129.300 ;
+    END
+  END w0_wd_in[139]
+  PIN w0_wd_in[140]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 129.720 0.500 130.220 ;
+    END
+  END w0_wd_in[140]
+  PIN w0_wd_in[141]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.640 0.500 131.140 ;
+    END
+  END w0_wd_in[141]
+  PIN w0_wd_in[142]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 131.560 0.500 132.060 ;
+    END
+  END w0_wd_in[142]
+  PIN w0_wd_in[143]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 132.480 0.500 132.980 ;
+    END
+  END w0_wd_in[143]
+  PIN w0_wd_in[144]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.400 0.500 133.900 ;
+    END
+  END w0_wd_in[144]
+  PIN w0_wd_in[145]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 134.320 0.500 134.820 ;
+    END
+  END w0_wd_in[145]
+  PIN w0_wd_in[146]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 135.240 0.500 135.740 ;
+    END
+  END w0_wd_in[146]
+  PIN w0_wd_in[147]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.160 0.500 136.660 ;
+    END
+  END w0_wd_in[147]
+  PIN w0_wd_in[148]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 137.080 0.500 137.580 ;
+    END
+  END w0_wd_in[148]
+  PIN w0_wd_in[149]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.000 0.500 138.500 ;
+    END
+  END w0_wd_in[149]
+  PIN w0_wd_in[150]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.920 0.500 139.420 ;
+    END
+  END w0_wd_in[150]
+  PIN w0_wd_in[151]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 139.840 0.500 140.340 ;
+    END
+  END w0_wd_in[151]
+  PIN w0_wd_in[152]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 140.760 0.500 141.260 ;
+    END
+  END w0_wd_in[152]
+  PIN w0_wd_in[153]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 141.680 0.500 142.180 ;
+    END
+  END w0_wd_in[153]
+  PIN w0_wd_in[154]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 142.600 0.500 143.100 ;
+    END
+  END w0_wd_in[154]
+  PIN w0_wd_in[155]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 143.520 0.500 144.020 ;
+    END
+  END w0_wd_in[155]
+  PIN w0_wd_in[156]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 144.440 0.500 144.940 ;
+    END
+  END w0_wd_in[156]
+  PIN w0_wd_in[157]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 145.360 0.500 145.860 ;
+    END
+  END w0_wd_in[157]
+  PIN w0_wd_in[158]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 146.280 0.500 146.780 ;
+    END
+  END w0_wd_in[158]
+  PIN w0_wd_in[159]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 147.200 0.500 147.700 ;
+    END
+  END w0_wd_in[159]
+  PIN w0_wd_in[160]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 148.120 0.500 148.620 ;
+    END
+  END w0_wd_in[160]
+  PIN w0_wd_in[161]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 149.040 0.500 149.540 ;
+    END
+  END w0_wd_in[161]
+  PIN w0_wd_in[162]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 149.960 0.500 150.460 ;
+    END
+  END w0_wd_in[162]
+  PIN w0_wd_in[163]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 150.880 0.500 151.380 ;
+    END
+  END w0_wd_in[163]
+  PIN w0_wd_in[164]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 151.800 0.500 152.300 ;
+    END
+  END w0_wd_in[164]
+  PIN w0_wd_in[165]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 152.720 0.500 153.220 ;
+    END
+  END w0_wd_in[165]
+  PIN w0_wd_in[166]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 153.640 0.500 154.140 ;
+    END
+  END w0_wd_in[166]
+  PIN w0_wd_in[167]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 154.560 0.500 155.060 ;
+    END
+  END w0_wd_in[167]
+  PIN w0_wd_in[168]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 155.480 0.500 155.980 ;
+    END
+  END w0_wd_in[168]
+  PIN w0_wd_in[169]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 156.400 0.500 156.900 ;
+    END
+  END w0_wd_in[169]
+  PIN w0_wd_in[170]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 157.320 0.500 157.820 ;
+    END
+  END w0_wd_in[170]
+  PIN w0_wd_in[171]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 158.240 0.500 158.740 ;
+    END
+  END w0_wd_in[171]
+  PIN w0_wd_in[172]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 159.160 0.500 159.660 ;
+    END
+  END w0_wd_in[172]
+  PIN w0_wd_in[173]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 160.080 0.500 160.580 ;
+    END
+  END w0_wd_in[173]
+  PIN w0_wd_in[174]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 161.000 0.500 161.500 ;
+    END
+  END w0_wd_in[174]
+  PIN w0_wd_in[175]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 161.920 0.500 162.420 ;
+    END
+  END w0_wd_in[175]
+  PIN w0_wd_in[176]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 162.840 0.500 163.340 ;
+    END
+  END w0_wd_in[176]
+  PIN w0_wd_in[177]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 163.760 0.500 164.260 ;
+    END
+  END w0_wd_in[177]
+  PIN w0_wd_in[178]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 164.680 0.500 165.180 ;
+    END
+  END w0_wd_in[178]
+  PIN w0_wd_in[179]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 165.600 0.500 166.100 ;
+    END
+  END w0_wd_in[179]
+  PIN w0_wd_in[180]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 166.520 0.500 167.020 ;
+    END
+  END w0_wd_in[180]
+  PIN w0_wd_in[181]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 167.440 0.500 167.940 ;
+    END
+  END w0_wd_in[181]
+  PIN w0_wd_in[182]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 168.360 0.500 168.860 ;
+    END
+  END w0_wd_in[182]
+  PIN w0_wd_in[183]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 169.280 0.500 169.780 ;
+    END
+  END w0_wd_in[183]
+  PIN w0_wd_in[184]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 170.200 0.500 170.700 ;
+    END
+  END w0_wd_in[184]
+  PIN w0_wd_in[185]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 171.120 0.500 171.620 ;
+    END
+  END w0_wd_in[185]
+  PIN w0_wd_in[186]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 172.040 0.500 172.540 ;
+    END
+  END w0_wd_in[186]
+  PIN w0_wd_in[187]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 172.960 0.500 173.460 ;
+    END
+  END w0_wd_in[187]
+  PIN w0_wd_in[188]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 173.880 0.500 174.380 ;
+    END
+  END w0_wd_in[188]
+  PIN w0_wd_in[189]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 174.800 0.500 175.300 ;
+    END
+  END w0_wd_in[189]
+  PIN w0_wd_in[190]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 175.720 0.500 176.220 ;
+    END
+  END w0_wd_in[190]
+  PIN w0_wd_in[191]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 176.640 0.500 177.140 ;
+    END
+  END w0_wd_in[191]
+  PIN w0_wd_in[192]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 177.560 0.500 178.060 ;
+    END
+  END w0_wd_in[192]
+  PIN w0_wd_in[193]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 178.480 0.500 178.980 ;
+    END
+  END w0_wd_in[193]
+  PIN w0_wd_in[194]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 179.400 0.500 179.900 ;
+    END
+  END w0_wd_in[194]
+  PIN w0_wd_in[195]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 180.320 0.500 180.820 ;
+    END
+  END w0_wd_in[195]
+  PIN w0_wd_in[196]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 181.240 0.500 181.740 ;
+    END
+  END w0_wd_in[196]
+  PIN w0_wd_in[197]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 182.160 0.500 182.660 ;
+    END
+  END w0_wd_in[197]
+  PIN w0_wd_in[198]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 183.080 0.500 183.580 ;
+    END
+  END w0_wd_in[198]
+  PIN w0_wd_in[199]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 184.000 0.500 184.500 ;
+    END
+  END w0_wd_in[199]
+  PIN w0_wd_in[200]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 184.920 0.500 185.420 ;
+    END
+  END w0_wd_in[200]
+  PIN w0_wd_in[201]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 185.840 0.500 186.340 ;
+    END
+  END w0_wd_in[201]
+  PIN w0_wd_in[202]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 186.760 0.500 187.260 ;
+    END
+  END w0_wd_in[202]
+  PIN w0_wd_in[203]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 187.680 0.500 188.180 ;
+    END
+  END w0_wd_in[203]
+  PIN w0_wd_in[204]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 188.600 0.500 189.100 ;
+    END
+  END w0_wd_in[204]
+  PIN w0_wd_in[205]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 189.520 0.500 190.020 ;
+    END
+  END w0_wd_in[205]
+  PIN w0_wd_in[206]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 190.440 0.500 190.940 ;
+    END
+  END w0_wd_in[206]
+  PIN w0_wd_in[207]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 191.360 0.500 191.860 ;
+    END
+  END w0_wd_in[207]
+  PIN w0_wd_in[208]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 192.280 0.500 192.780 ;
+    END
+  END w0_wd_in[208]
+  PIN w0_wd_in[209]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 193.200 0.500 193.700 ;
+    END
+  END w0_wd_in[209]
+  PIN w0_wd_in[210]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 194.120 0.500 194.620 ;
+    END
+  END w0_wd_in[210]
+  PIN w0_wd_in[211]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 195.040 0.500 195.540 ;
+    END
+  END w0_wd_in[211]
+  PIN w0_wd_in[212]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 195.960 0.500 196.460 ;
+    END
+  END w0_wd_in[212]
+  PIN w0_wd_in[213]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 196.880 0.500 197.380 ;
+    END
+  END w0_wd_in[213]
+  PIN w0_wd_in[214]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 197.800 0.500 198.300 ;
+    END
+  END w0_wd_in[214]
+  PIN w0_wd_in[215]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 198.720 0.500 199.220 ;
+    END
+  END w0_wd_in[215]
+  PIN w0_wd_in[216]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 199.640 0.500 200.140 ;
+    END
+  END w0_wd_in[216]
+  PIN w0_wd_in[217]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 200.560 0.500 201.060 ;
+    END
+  END w0_wd_in[217]
+  PIN w0_wd_in[218]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 201.480 0.500 201.980 ;
+    END
+  END w0_wd_in[218]
+  PIN w0_wd_in[219]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 202.400 0.500 202.900 ;
+    END
+  END w0_wd_in[219]
+  PIN w0_wd_in[220]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 203.320 0.500 203.820 ;
+    END
+  END w0_wd_in[220]
+  PIN w0_wd_in[221]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 204.240 0.500 204.740 ;
+    END
+  END w0_wd_in[221]
+  PIN w0_wd_in[222]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 205.160 0.500 205.660 ;
+    END
+  END w0_wd_in[222]
+  PIN w0_wd_in[223]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 206.080 0.500 206.580 ;
+    END
+  END w0_wd_in[223]
+  PIN w0_wd_in[224]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 207.000 0.500 207.500 ;
+    END
+  END w0_wd_in[224]
+  PIN w0_wd_in[225]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 207.920 0.500 208.420 ;
+    END
+  END w0_wd_in[225]
+  PIN w0_wd_in[226]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 208.840 0.500 209.340 ;
+    END
+  END w0_wd_in[226]
+  PIN w0_wd_in[227]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 209.760 0.500 210.260 ;
+    END
+  END w0_wd_in[227]
+  PIN w0_wd_in[228]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 210.680 0.500 211.180 ;
+    END
+  END w0_wd_in[228]
+  PIN w0_wd_in[229]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 211.600 0.500 212.100 ;
+    END
+  END w0_wd_in[229]
+  PIN w0_wd_in[230]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 212.520 0.500 213.020 ;
+    END
+  END w0_wd_in[230]
+  PIN w0_wd_in[231]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 213.440 0.500 213.940 ;
+    END
+  END w0_wd_in[231]
+  PIN w0_wd_in[232]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 214.360 0.500 214.860 ;
+    END
+  END w0_wd_in[232]
+  PIN w0_wd_in[233]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 215.280 0.500 215.780 ;
+    END
+  END w0_wd_in[233]
+  PIN w0_wd_in[234]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 216.200 0.500 216.700 ;
+    END
+  END w0_wd_in[234]
+  PIN w0_wd_in[235]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 217.120 0.500 217.620 ;
+    END
+  END w0_wd_in[235]
+  PIN w0_wd_in[236]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 218.040 0.500 218.540 ;
+    END
+  END w0_wd_in[236]
+  PIN w0_wd_in[237]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 218.960 0.500 219.460 ;
+    END
+  END w0_wd_in[237]
+  PIN w0_wd_in[238]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 219.880 0.500 220.380 ;
+    END
+  END w0_wd_in[238]
+  PIN w0_wd_in[239]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 220.800 0.500 221.300 ;
+    END
+  END w0_wd_in[239]
+  PIN w0_wd_in[240]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 221.720 0.500 222.220 ;
+    END
+  END w0_wd_in[240]
+  PIN w0_wd_in[241]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 222.640 0.500 223.140 ;
+    END
+  END w0_wd_in[241]
+  PIN w0_wd_in[242]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 223.560 0.500 224.060 ;
+    END
+  END w0_wd_in[242]
+  PIN w0_wd_in[243]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 224.480 0.500 224.980 ;
+    END
+  END w0_wd_in[243]
+  PIN w0_wd_in[244]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 225.400 0.500 225.900 ;
+    END
+  END w0_wd_in[244]
+  PIN w0_wd_in[245]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 226.320 0.500 226.820 ;
+    END
+  END w0_wd_in[245]
+  PIN w0_wd_in[246]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 227.240 0.500 227.740 ;
+    END
+  END w0_wd_in[246]
+  PIN w0_wd_in[247]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 228.160 0.500 228.660 ;
+    END
+  END w0_wd_in[247]
+  PIN w0_wd_in[248]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 229.080 0.500 229.580 ;
+    END
+  END w0_wd_in[248]
+  PIN w0_wd_in[249]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 230.000 0.500 230.500 ;
+    END
+  END w0_wd_in[249]
+  PIN w0_wd_in[250]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 230.920 0.500 231.420 ;
+    END
+  END w0_wd_in[250]
+  PIN w0_wd_in[251]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 231.840 0.500 232.340 ;
+    END
+  END w0_wd_in[251]
+  PIN w0_wd_in[252]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 232.760 0.500 233.260 ;
+    END
+  END w0_wd_in[252]
+  PIN w0_wd_in[253]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 233.680 0.500 234.180 ;
+    END
+  END w0_wd_in[253]
+  PIN w0_wd_in[254]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 234.600 0.500 235.100 ;
+    END
+  END w0_wd_in[254]
+  PIN w0_wd_in[255]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 235.520 0.500 236.020 ;
+    END
+  END w0_wd_in[255]
+  PIN w0_wd_in[256]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 236.440 0.500 236.940 ;
+    END
+  END w0_wd_in[256]
+  PIN w0_wd_in[257]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 237.360 0.500 237.860 ;
+    END
+  END w0_wd_in[257]
+  PIN w0_wd_in[258]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 238.280 0.500 238.780 ;
+    END
+  END w0_wd_in[258]
+  PIN w0_wd_in[259]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 239.200 0.500 239.700 ;
+    END
+  END w0_wd_in[259]
+  PIN w0_wd_in[260]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 240.120 0.500 240.620 ;
+    END
+  END w0_wd_in[260]
+  PIN w0_wd_in[261]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 241.040 0.500 241.540 ;
+    END
+  END w0_wd_in[261]
+  PIN w0_wd_in[262]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 241.960 0.500 242.460 ;
+    END
+  END w0_wd_in[262]
+  PIN w0_wd_in[263]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 242.880 0.500 243.380 ;
+    END
+  END w0_wd_in[263]
+  PIN w0_wd_in[264]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 243.800 0.500 244.300 ;
+    END
+  END w0_wd_in[264]
+  PIN w0_wd_in[265]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 244.720 0.500 245.220 ;
+    END
+  END w0_wd_in[265]
+  PIN w0_wd_in[266]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 245.640 0.500 246.140 ;
+    END
+  END w0_wd_in[266]
+  PIN w0_wd_in[267]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 246.560 0.500 247.060 ;
+    END
+  END w0_wd_in[267]
+  PIN w0_wd_in[268]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 247.480 0.500 247.980 ;
+    END
+  END w0_wd_in[268]
+  PIN w0_wd_in[269]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 248.400 0.500 248.900 ;
+    END
+  END w0_wd_in[269]
+  PIN w0_wd_in[270]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 249.320 0.500 249.820 ;
+    END
+  END w0_wd_in[270]
+  PIN w0_wd_in[271]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 250.240 0.500 250.740 ;
+    END
+  END w0_wd_in[271]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 251.160 0.500 251.660 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 252.080 0.500 252.580 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 253.000 0.500 253.500 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 253.920 0.500 254.420 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 254.840 0.500 255.340 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 255.760 0.500 256.260 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 256.680 0.500 257.180 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 257.600 0.500 258.100 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 258.520 0.500 259.020 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 259.440 0.500 259.940 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 260.360 0.500 260.860 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 261.280 0.500 261.780 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 262.200 0.500 262.700 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 263.120 0.500 263.620 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 264.040 0.500 264.540 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 264.960 0.500 265.460 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 265.880 0.500 266.380 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 266.800 0.500 267.300 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 267.720 0.500 268.220 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 268.640 0.500 269.140 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 269.560 0.500 270.060 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 270.480 0.500 270.980 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 271.400 0.500 271.900 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 272.320 0.500 272.820 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 273.240 0.500 273.740 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 274.160 0.500 274.660 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 275.080 0.500 275.580 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 276.000 0.500 276.500 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 276.920 0.500 277.420 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 277.840 0.500 278.340 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 278.760 0.500 279.260 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 279.680 0.500 280.180 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 280.600 0.500 281.100 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 281.520 0.500 282.020 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 282.440 0.500 282.940 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 283.360 0.500 283.860 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 284.280 0.500 284.780 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 285.200 0.500 285.700 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 286.120 0.500 286.620 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 287.040 0.500 287.540 ;
+    END
+  END r0_rd_out[32]
+  PIN r0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 287.960 0.500 288.460 ;
+    END
+  END r0_rd_out[33]
+  PIN r0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 288.880 0.500 289.380 ;
+    END
+  END r0_rd_out[34]
+  PIN r0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 289.800 0.500 290.300 ;
+    END
+  END r0_rd_out[35]
+  PIN r0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 290.720 0.500 291.220 ;
+    END
+  END r0_rd_out[36]
+  PIN r0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 291.640 0.500 292.140 ;
+    END
+  END r0_rd_out[37]
+  PIN r0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 292.560 0.500 293.060 ;
+    END
+  END r0_rd_out[38]
+  PIN r0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 293.480 0.500 293.980 ;
+    END
+  END r0_rd_out[39]
+  PIN r0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 294.400 0.500 294.900 ;
+    END
+  END r0_rd_out[40]
+  PIN r0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 295.320 0.500 295.820 ;
+    END
+  END r0_rd_out[41]
+  PIN r0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 296.240 0.500 296.740 ;
+    END
+  END r0_rd_out[42]
+  PIN r0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 297.160 0.500 297.660 ;
+    END
+  END r0_rd_out[43]
+  PIN r0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 298.080 0.500 298.580 ;
+    END
+  END r0_rd_out[44]
+  PIN r0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 299.000 0.500 299.500 ;
+    END
+  END r0_rd_out[45]
+  PIN r0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 299.920 0.500 300.420 ;
+    END
+  END r0_rd_out[46]
+  PIN r0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 300.840 0.500 301.340 ;
+    END
+  END r0_rd_out[47]
+  PIN r0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 301.760 0.500 302.260 ;
+    END
+  END r0_rd_out[48]
+  PIN r0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 302.680 0.500 303.180 ;
+    END
+  END r0_rd_out[49]
+  PIN r0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 303.600 0.500 304.100 ;
+    END
+  END r0_rd_out[50]
+  PIN r0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 304.520 0.500 305.020 ;
+    END
+  END r0_rd_out[51]
+  PIN r0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 305.440 0.500 305.940 ;
+    END
+  END r0_rd_out[52]
+  PIN r0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 306.360 0.500 306.860 ;
+    END
+  END r0_rd_out[53]
+  PIN r0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 307.280 0.500 307.780 ;
+    END
+  END r0_rd_out[54]
+  PIN r0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 308.200 0.500 308.700 ;
+    END
+  END r0_rd_out[55]
+  PIN r0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 309.120 0.500 309.620 ;
+    END
+  END r0_rd_out[56]
+  PIN r0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 310.040 0.500 310.540 ;
+    END
+  END r0_rd_out[57]
+  PIN r0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 310.960 0.500 311.460 ;
+    END
+  END r0_rd_out[58]
+  PIN r0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 311.880 0.500 312.380 ;
+    END
+  END r0_rd_out[59]
+  PIN r0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 312.800 0.500 313.300 ;
+    END
+  END r0_rd_out[60]
+  PIN r0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 313.720 0.500 314.220 ;
+    END
+  END r0_rd_out[61]
+  PIN r0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 314.640 0.500 315.140 ;
+    END
+  END r0_rd_out[62]
+  PIN r0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 315.560 0.500 316.060 ;
+    END
+  END r0_rd_out[63]
+  PIN r0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 316.480 0.500 316.980 ;
+    END
+  END r0_rd_out[64]
+  PIN r0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 317.400 0.500 317.900 ;
+    END
+  END r0_rd_out[65]
+  PIN r0_rd_out[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 318.320 0.500 318.820 ;
+    END
+  END r0_rd_out[66]
+  PIN r0_rd_out[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 319.240 0.500 319.740 ;
+    END
+  END r0_rd_out[67]
+  PIN r0_rd_out[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 320.160 0.500 320.660 ;
+    END
+  END r0_rd_out[68]
+  PIN r0_rd_out[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 321.080 0.500 321.580 ;
+    END
+  END r0_rd_out[69]
+  PIN r0_rd_out[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 322.000 0.500 322.500 ;
+    END
+  END r0_rd_out[70]
+  PIN r0_rd_out[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 322.920 0.500 323.420 ;
+    END
+  END r0_rd_out[71]
+  PIN r0_rd_out[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 323.840 0.500 324.340 ;
+    END
+  END r0_rd_out[72]
+  PIN r0_rd_out[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 324.760 0.500 325.260 ;
+    END
+  END r0_rd_out[73]
+  PIN r0_rd_out[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 325.680 0.500 326.180 ;
+    END
+  END r0_rd_out[74]
+  PIN r0_rd_out[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 326.600 0.500 327.100 ;
+    END
+  END r0_rd_out[75]
+  PIN r0_rd_out[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 327.520 0.500 328.020 ;
+    END
+  END r0_rd_out[76]
+  PIN r0_rd_out[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 328.440 0.500 328.940 ;
+    END
+  END r0_rd_out[77]
+  PIN r0_rd_out[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 329.360 0.500 329.860 ;
+    END
+  END r0_rd_out[78]
+  PIN r0_rd_out[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 330.280 0.500 330.780 ;
+    END
+  END r0_rd_out[79]
+  PIN r0_rd_out[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 331.200 0.500 331.700 ;
+    END
+  END r0_rd_out[80]
+  PIN r0_rd_out[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 332.120 0.500 332.620 ;
+    END
+  END r0_rd_out[81]
+  PIN r0_rd_out[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 333.040 0.500 333.540 ;
+    END
+  END r0_rd_out[82]
+  PIN r0_rd_out[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 333.960 0.500 334.460 ;
+    END
+  END r0_rd_out[83]
+  PIN r0_rd_out[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 334.880 0.500 335.380 ;
+    END
+  END r0_rd_out[84]
+  PIN r0_rd_out[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 335.800 0.500 336.300 ;
+    END
+  END r0_rd_out[85]
+  PIN r0_rd_out[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 336.720 0.500 337.220 ;
+    END
+  END r0_rd_out[86]
+  PIN r0_rd_out[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 337.640 0.500 338.140 ;
+    END
+  END r0_rd_out[87]
+  PIN r0_rd_out[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 338.560 0.500 339.060 ;
+    END
+  END r0_rd_out[88]
+  PIN r0_rd_out[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 339.480 0.500 339.980 ;
+    END
+  END r0_rd_out[89]
+  PIN r0_rd_out[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 340.400 0.500 340.900 ;
+    END
+  END r0_rd_out[90]
+  PIN r0_rd_out[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 341.320 0.500 341.820 ;
+    END
+  END r0_rd_out[91]
+  PIN r0_rd_out[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 342.240 0.500 342.740 ;
+    END
+  END r0_rd_out[92]
+  PIN r0_rd_out[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 343.160 0.500 343.660 ;
+    END
+  END r0_rd_out[93]
+  PIN r0_rd_out[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 344.080 0.500 344.580 ;
+    END
+  END r0_rd_out[94]
+  PIN r0_rd_out[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 345.000 0.500 345.500 ;
+    END
+  END r0_rd_out[95]
+  PIN r0_rd_out[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 345.920 0.500 346.420 ;
+    END
+  END r0_rd_out[96]
+  PIN r0_rd_out[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 346.840 0.500 347.340 ;
+    END
+  END r0_rd_out[97]
+  PIN r0_rd_out[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 347.760 0.500 348.260 ;
+    END
+  END r0_rd_out[98]
+  PIN r0_rd_out[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 348.680 0.500 349.180 ;
+    END
+  END r0_rd_out[99]
+  PIN r0_rd_out[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 349.600 0.500 350.100 ;
+    END
+  END r0_rd_out[100]
+  PIN r0_rd_out[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 350.520 0.500 351.020 ;
+    END
+  END r0_rd_out[101]
+  PIN r0_rd_out[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 351.440 0.500 351.940 ;
+    END
+  END r0_rd_out[102]
+  PIN r0_rd_out[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 352.360 0.500 352.860 ;
+    END
+  END r0_rd_out[103]
+  PIN r0_rd_out[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 353.280 0.500 353.780 ;
+    END
+  END r0_rd_out[104]
+  PIN r0_rd_out[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 354.200 0.500 354.700 ;
+    END
+  END r0_rd_out[105]
+  PIN r0_rd_out[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 355.120 0.500 355.620 ;
+    END
+  END r0_rd_out[106]
+  PIN r0_rd_out[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 356.040 0.500 356.540 ;
+    END
+  END r0_rd_out[107]
+  PIN r0_rd_out[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 356.960 0.500 357.460 ;
+    END
+  END r0_rd_out[108]
+  PIN r0_rd_out[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 357.880 0.500 358.380 ;
+    END
+  END r0_rd_out[109]
+  PIN r0_rd_out[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 358.800 0.500 359.300 ;
+    END
+  END r0_rd_out[110]
+  PIN r0_rd_out[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 359.720 0.500 360.220 ;
+    END
+  END r0_rd_out[111]
+  PIN r0_rd_out[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 360.640 0.500 361.140 ;
+    END
+  END r0_rd_out[112]
+  PIN r0_rd_out[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 361.560 0.500 362.060 ;
+    END
+  END r0_rd_out[113]
+  PIN r0_rd_out[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 362.480 0.500 362.980 ;
+    END
+  END r0_rd_out[114]
+  PIN r0_rd_out[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 363.400 0.500 363.900 ;
+    END
+  END r0_rd_out[115]
+  PIN r0_rd_out[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 364.320 0.500 364.820 ;
+    END
+  END r0_rd_out[116]
+  PIN r0_rd_out[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 365.240 0.500 365.740 ;
+    END
+  END r0_rd_out[117]
+  PIN r0_rd_out[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 366.160 0.500 366.660 ;
+    END
+  END r0_rd_out[118]
+  PIN r0_rd_out[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 367.080 0.500 367.580 ;
+    END
+  END r0_rd_out[119]
+  PIN r0_rd_out[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 368.000 0.500 368.500 ;
+    END
+  END r0_rd_out[120]
+  PIN r0_rd_out[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 368.920 0.500 369.420 ;
+    END
+  END r0_rd_out[121]
+  PIN r0_rd_out[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 369.840 0.500 370.340 ;
+    END
+  END r0_rd_out[122]
+  PIN r0_rd_out[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 370.760 0.500 371.260 ;
+    END
+  END r0_rd_out[123]
+  PIN r0_rd_out[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 371.680 0.500 372.180 ;
+    END
+  END r0_rd_out[124]
+  PIN r0_rd_out[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 372.600 0.500 373.100 ;
+    END
+  END r0_rd_out[125]
+  PIN r0_rd_out[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 373.520 0.500 374.020 ;
+    END
+  END r0_rd_out[126]
+  PIN r0_rd_out[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 374.440 0.500 374.940 ;
+    END
+  END r0_rd_out[127]
+  PIN r0_rd_out[128]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 375.360 0.500 375.860 ;
+    END
+  END r0_rd_out[128]
+  PIN r0_rd_out[129]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 376.280 0.500 376.780 ;
+    END
+  END r0_rd_out[129]
+  PIN r0_rd_out[130]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 377.200 0.500 377.700 ;
+    END
+  END r0_rd_out[130]
+  PIN r0_rd_out[131]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 378.120 0.500 378.620 ;
+    END
+  END r0_rd_out[131]
+  PIN r0_rd_out[132]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 379.040 0.500 379.540 ;
+    END
+  END r0_rd_out[132]
+  PIN r0_rd_out[133]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 379.960 0.500 380.460 ;
+    END
+  END r0_rd_out[133]
+  PIN r0_rd_out[134]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 380.880 0.500 381.380 ;
+    END
+  END r0_rd_out[134]
+  PIN r0_rd_out[135]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 381.800 0.500 382.300 ;
+    END
+  END r0_rd_out[135]
+  PIN r0_rd_out[136]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 382.720 0.500 383.220 ;
+    END
+  END r0_rd_out[136]
+  PIN r0_rd_out[137]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 383.640 0.500 384.140 ;
+    END
+  END r0_rd_out[137]
+  PIN r0_rd_out[138]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 384.560 0.500 385.060 ;
+    END
+  END r0_rd_out[138]
+  PIN r0_rd_out[139]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 385.480 0.500 385.980 ;
+    END
+  END r0_rd_out[139]
+  PIN r0_rd_out[140]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 386.400 0.500 386.900 ;
+    END
+  END r0_rd_out[140]
+  PIN r0_rd_out[141]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 387.320 0.500 387.820 ;
+    END
+  END r0_rd_out[141]
+  PIN r0_rd_out[142]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 388.240 0.500 388.740 ;
+    END
+  END r0_rd_out[142]
+  PIN r0_rd_out[143]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 389.160 0.500 389.660 ;
+    END
+  END r0_rd_out[143]
+  PIN r0_rd_out[144]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 390.080 0.500 390.580 ;
+    END
+  END r0_rd_out[144]
+  PIN r0_rd_out[145]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 391.000 0.500 391.500 ;
+    END
+  END r0_rd_out[145]
+  PIN r0_rd_out[146]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 391.920 0.500 392.420 ;
+    END
+  END r0_rd_out[146]
+  PIN r0_rd_out[147]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 392.840 0.500 393.340 ;
+    END
+  END r0_rd_out[147]
+  PIN r0_rd_out[148]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 393.760 0.500 394.260 ;
+    END
+  END r0_rd_out[148]
+  PIN r0_rd_out[149]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 394.680 0.500 395.180 ;
+    END
+  END r0_rd_out[149]
+  PIN r0_rd_out[150]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 395.600 0.500 396.100 ;
+    END
+  END r0_rd_out[150]
+  PIN r0_rd_out[151]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 396.520 0.500 397.020 ;
+    END
+  END r0_rd_out[151]
+  PIN r0_rd_out[152]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 397.440 0.500 397.940 ;
+    END
+  END r0_rd_out[152]
+  PIN r0_rd_out[153]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 398.360 0.500 398.860 ;
+    END
+  END r0_rd_out[153]
+  PIN r0_rd_out[154]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 399.280 0.500 399.780 ;
+    END
+  END r0_rd_out[154]
+  PIN r0_rd_out[155]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 400.200 0.500 400.700 ;
+    END
+  END r0_rd_out[155]
+  PIN r0_rd_out[156]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 401.120 0.500 401.620 ;
+    END
+  END r0_rd_out[156]
+  PIN r0_rd_out[157]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 402.040 0.500 402.540 ;
+    END
+  END r0_rd_out[157]
+  PIN r0_rd_out[158]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 402.960 0.500 403.460 ;
+    END
+  END r0_rd_out[158]
+  PIN r0_rd_out[159]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 403.880 0.500 404.380 ;
+    END
+  END r0_rd_out[159]
+  PIN r0_rd_out[160]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 404.800 0.500 405.300 ;
+    END
+  END r0_rd_out[160]
+  PIN r0_rd_out[161]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 405.720 0.500 406.220 ;
+    END
+  END r0_rd_out[161]
+  PIN r0_rd_out[162]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 406.640 0.500 407.140 ;
+    END
+  END r0_rd_out[162]
+  PIN r0_rd_out[163]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 407.560 0.500 408.060 ;
+    END
+  END r0_rd_out[163]
+  PIN r0_rd_out[164]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 408.480 0.500 408.980 ;
+    END
+  END r0_rd_out[164]
+  PIN r0_rd_out[165]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 409.400 0.500 409.900 ;
+    END
+  END r0_rd_out[165]
+  PIN r0_rd_out[166]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 410.320 0.500 410.820 ;
+    END
+  END r0_rd_out[166]
+  PIN r0_rd_out[167]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 411.240 0.500 411.740 ;
+    END
+  END r0_rd_out[167]
+  PIN r0_rd_out[168]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 412.160 0.500 412.660 ;
+    END
+  END r0_rd_out[168]
+  PIN r0_rd_out[169]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 413.080 0.500 413.580 ;
+    END
+  END r0_rd_out[169]
+  PIN r0_rd_out[170]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 414.000 0.500 414.500 ;
+    END
+  END r0_rd_out[170]
+  PIN r0_rd_out[171]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 414.920 0.500 415.420 ;
+    END
+  END r0_rd_out[171]
+  PIN r0_rd_out[172]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 415.840 0.500 416.340 ;
+    END
+  END r0_rd_out[172]
+  PIN r0_rd_out[173]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 416.760 0.500 417.260 ;
+    END
+  END r0_rd_out[173]
+  PIN r0_rd_out[174]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 417.680 0.500 418.180 ;
+    END
+  END r0_rd_out[174]
+  PIN r0_rd_out[175]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 418.600 0.500 419.100 ;
+    END
+  END r0_rd_out[175]
+  PIN r0_rd_out[176]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 419.520 0.500 420.020 ;
+    END
+  END r0_rd_out[176]
+  PIN r0_rd_out[177]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 420.440 0.500 420.940 ;
+    END
+  END r0_rd_out[177]
+  PIN r0_rd_out[178]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 421.360 0.500 421.860 ;
+    END
+  END r0_rd_out[178]
+  PIN r0_rd_out[179]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 422.280 0.500 422.780 ;
+    END
+  END r0_rd_out[179]
+  PIN r0_rd_out[180]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 423.200 0.500 423.700 ;
+    END
+  END r0_rd_out[180]
+  PIN r0_rd_out[181]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 424.120 0.500 424.620 ;
+    END
+  END r0_rd_out[181]
+  PIN r0_rd_out[182]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 425.040 0.500 425.540 ;
+    END
+  END r0_rd_out[182]
+  PIN r0_rd_out[183]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 425.960 0.500 426.460 ;
+    END
+  END r0_rd_out[183]
+  PIN r0_rd_out[184]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 426.880 0.500 427.380 ;
+    END
+  END r0_rd_out[184]
+  PIN r0_rd_out[185]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 427.800 0.500 428.300 ;
+    END
+  END r0_rd_out[185]
+  PIN r0_rd_out[186]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 428.720 0.500 429.220 ;
+    END
+  END r0_rd_out[186]
+  PIN r0_rd_out[187]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 429.640 0.500 430.140 ;
+    END
+  END r0_rd_out[187]
+  PIN r0_rd_out[188]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 430.560 0.500 431.060 ;
+    END
+  END r0_rd_out[188]
+  PIN r0_rd_out[189]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 431.480 0.500 431.980 ;
+    END
+  END r0_rd_out[189]
+  PIN r0_rd_out[190]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 432.400 0.500 432.900 ;
+    END
+  END r0_rd_out[190]
+  PIN r0_rd_out[191]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 433.320 0.500 433.820 ;
+    END
+  END r0_rd_out[191]
+  PIN r0_rd_out[192]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 434.240 0.500 434.740 ;
+    END
+  END r0_rd_out[192]
+  PIN r0_rd_out[193]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 435.160 0.500 435.660 ;
+    END
+  END r0_rd_out[193]
+  PIN r0_rd_out[194]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 436.080 0.500 436.580 ;
+    END
+  END r0_rd_out[194]
+  PIN r0_rd_out[195]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 437.000 0.500 437.500 ;
+    END
+  END r0_rd_out[195]
+  PIN r0_rd_out[196]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 437.920 0.500 438.420 ;
+    END
+  END r0_rd_out[196]
+  PIN r0_rd_out[197]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 438.840 0.500 439.340 ;
+    END
+  END r0_rd_out[197]
+  PIN r0_rd_out[198]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 439.760 0.500 440.260 ;
+    END
+  END r0_rd_out[198]
+  PIN r0_rd_out[199]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 440.680 0.500 441.180 ;
+    END
+  END r0_rd_out[199]
+  PIN r0_rd_out[200]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 441.600 0.500 442.100 ;
+    END
+  END r0_rd_out[200]
+  PIN r0_rd_out[201]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 442.520 0.500 443.020 ;
+    END
+  END r0_rd_out[201]
+  PIN r0_rd_out[202]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 443.440 0.500 443.940 ;
+    END
+  END r0_rd_out[202]
+  PIN r0_rd_out[203]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 444.360 0.500 444.860 ;
+    END
+  END r0_rd_out[203]
+  PIN r0_rd_out[204]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 445.280 0.500 445.780 ;
+    END
+  END r0_rd_out[204]
+  PIN r0_rd_out[205]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 446.200 0.500 446.700 ;
+    END
+  END r0_rd_out[205]
+  PIN r0_rd_out[206]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 447.120 0.500 447.620 ;
+    END
+  END r0_rd_out[206]
+  PIN r0_rd_out[207]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 448.040 0.500 448.540 ;
+    END
+  END r0_rd_out[207]
+  PIN r0_rd_out[208]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 448.960 0.500 449.460 ;
+    END
+  END r0_rd_out[208]
+  PIN r0_rd_out[209]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 449.880 0.500 450.380 ;
+    END
+  END r0_rd_out[209]
+  PIN r0_rd_out[210]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 450.800 0.500 451.300 ;
+    END
+  END r0_rd_out[210]
+  PIN r0_rd_out[211]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 451.720 0.500 452.220 ;
+    END
+  END r0_rd_out[211]
+  PIN r0_rd_out[212]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 452.640 0.500 453.140 ;
+    END
+  END r0_rd_out[212]
+  PIN r0_rd_out[213]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 453.560 0.500 454.060 ;
+    END
+  END r0_rd_out[213]
+  PIN r0_rd_out[214]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 454.480 0.500 454.980 ;
+    END
+  END r0_rd_out[214]
+  PIN r0_rd_out[215]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 455.400 0.500 455.900 ;
+    END
+  END r0_rd_out[215]
+  PIN r0_rd_out[216]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 456.320 0.500 456.820 ;
+    END
+  END r0_rd_out[216]
+  PIN r0_rd_out[217]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 457.240 0.500 457.740 ;
+    END
+  END r0_rd_out[217]
+  PIN r0_rd_out[218]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 458.160 0.500 458.660 ;
+    END
+  END r0_rd_out[218]
+  PIN r0_rd_out[219]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 459.080 0.500 459.580 ;
+    END
+  END r0_rd_out[219]
+  PIN r0_rd_out[220]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 460.000 0.500 460.500 ;
+    END
+  END r0_rd_out[220]
+  PIN r0_rd_out[221]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 460.920 0.500 461.420 ;
+    END
+  END r0_rd_out[221]
+  PIN r0_rd_out[222]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 461.840 0.500 462.340 ;
+    END
+  END r0_rd_out[222]
+  PIN r0_rd_out[223]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 462.760 0.500 463.260 ;
+    END
+  END r0_rd_out[223]
+  PIN r0_rd_out[224]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 463.680 0.500 464.180 ;
+    END
+  END r0_rd_out[224]
+  PIN r0_rd_out[225]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 464.600 0.500 465.100 ;
+    END
+  END r0_rd_out[225]
+  PIN r0_rd_out[226]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 465.520 0.500 466.020 ;
+    END
+  END r0_rd_out[226]
+  PIN r0_rd_out[227]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 466.440 0.500 466.940 ;
+    END
+  END r0_rd_out[227]
+  PIN r0_rd_out[228]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 467.360 0.500 467.860 ;
+    END
+  END r0_rd_out[228]
+  PIN r0_rd_out[229]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 468.280 0.500 468.780 ;
+    END
+  END r0_rd_out[229]
+  PIN r0_rd_out[230]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 469.200 0.500 469.700 ;
+    END
+  END r0_rd_out[230]
+  PIN r0_rd_out[231]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 470.120 0.500 470.620 ;
+    END
+  END r0_rd_out[231]
+  PIN r0_rd_out[232]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 471.040 0.500 471.540 ;
+    END
+  END r0_rd_out[232]
+  PIN r0_rd_out[233]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 471.960 0.500 472.460 ;
+    END
+  END r0_rd_out[233]
+  PIN r0_rd_out[234]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 472.880 0.500 473.380 ;
+    END
+  END r0_rd_out[234]
+  PIN r0_rd_out[235]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 473.800 0.500 474.300 ;
+    END
+  END r0_rd_out[235]
+  PIN r0_rd_out[236]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 474.720 0.500 475.220 ;
+    END
+  END r0_rd_out[236]
+  PIN r0_rd_out[237]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 475.640 0.500 476.140 ;
+    END
+  END r0_rd_out[237]
+  PIN r0_rd_out[238]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 476.560 0.500 477.060 ;
+    END
+  END r0_rd_out[238]
+  PIN r0_rd_out[239]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 477.480 0.500 477.980 ;
+    END
+  END r0_rd_out[239]
+  PIN r0_rd_out[240]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 478.400 0.500 478.900 ;
+    END
+  END r0_rd_out[240]
+  PIN r0_rd_out[241]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 479.320 0.500 479.820 ;
+    END
+  END r0_rd_out[241]
+  PIN r0_rd_out[242]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 480.240 0.500 480.740 ;
+    END
+  END r0_rd_out[242]
+  PIN r0_rd_out[243]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 481.160 0.500 481.660 ;
+    END
+  END r0_rd_out[243]
+  PIN r0_rd_out[244]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 482.080 0.500 482.580 ;
+    END
+  END r0_rd_out[244]
+  PIN r0_rd_out[245]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 483.000 0.500 483.500 ;
+    END
+  END r0_rd_out[245]
+  PIN r0_rd_out[246]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 483.920 0.500 484.420 ;
+    END
+  END r0_rd_out[246]
+  PIN r0_rd_out[247]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 484.840 0.500 485.340 ;
+    END
+  END r0_rd_out[247]
+  PIN r0_rd_out[248]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 485.760 0.500 486.260 ;
+    END
+  END r0_rd_out[248]
+  PIN r0_rd_out[249]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 486.680 0.500 487.180 ;
+    END
+  END r0_rd_out[249]
+  PIN r0_rd_out[250]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 487.600 0.500 488.100 ;
+    END
+  END r0_rd_out[250]
+  PIN r0_rd_out[251]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 488.520 0.500 489.020 ;
+    END
+  END r0_rd_out[251]
+  PIN r0_rd_out[252]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 489.440 0.500 489.940 ;
+    END
+  END r0_rd_out[252]
+  PIN r0_rd_out[253]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 490.360 0.500 490.860 ;
+    END
+  END r0_rd_out[253]
+  PIN r0_rd_out[254]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 491.280 0.500 491.780 ;
+    END
+  END r0_rd_out[254]
+  PIN r0_rd_out[255]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 492.200 0.500 492.700 ;
+    END
+  END r0_rd_out[255]
+  PIN r0_rd_out[256]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 493.120 0.500 493.620 ;
+    END
+  END r0_rd_out[256]
+  PIN r0_rd_out[257]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 494.040 0.500 494.540 ;
+    END
+  END r0_rd_out[257]
+  PIN r0_rd_out[258]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 494.960 0.500 495.460 ;
+    END
+  END r0_rd_out[258]
+  PIN r0_rd_out[259]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 495.880 0.500 496.380 ;
+    END
+  END r0_rd_out[259]
+  PIN r0_rd_out[260]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 496.800 0.500 497.300 ;
+    END
+  END r0_rd_out[260]
+  PIN r0_rd_out[261]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 497.720 0.500 498.220 ;
+    END
+  END r0_rd_out[261]
+  PIN r0_rd_out[262]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 498.640 0.500 499.140 ;
+    END
+  END r0_rd_out[262]
+  PIN r0_rd_out[263]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 499.560 0.500 500.060 ;
+    END
+  END r0_rd_out[263]
+  PIN r0_rd_out[264]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 500.480 0.500 500.980 ;
+    END
+  END r0_rd_out[264]
+  PIN r0_rd_out[265]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 501.400 0.500 501.900 ;
+    END
+  END r0_rd_out[265]
+  PIN r0_rd_out[266]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 502.320 0.500 502.820 ;
+    END
+  END r0_rd_out[266]
+  PIN r0_rd_out[267]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 503.240 0.500 503.740 ;
+    END
+  END r0_rd_out[267]
+  PIN r0_rd_out[268]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 504.160 0.500 504.660 ;
+    END
+  END r0_rd_out[268]
+  PIN r0_rd_out[269]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 505.080 0.500 505.580 ;
+    END
+  END r0_rd_out[269]
+  PIN r0_rd_out[270]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 506.000 0.500 506.500 ;
+    END
+  END r0_rd_out[270]
+  PIN r0_rd_out[271]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 506.920 0.500 507.420 ;
+    END
+  END r0_rd_out[271]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 507.840 0.500 508.340 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 508.760 0.500 509.260 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 509.680 0.500 510.180 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 510.600 0.500 511.100 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 511.520 0.500 512.020 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 512.440 0.500 512.940 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 514.080 ;
+      RECT 22.480 2.720 23.680 514.080 ;
+      RECT 37.200 2.720 38.400 514.080 ;
+      RECT 51.920 2.720 53.120 514.080 ;
+      RECT 66.640 2.720 67.840 514.080 ;
+      RECT 81.360 2.720 82.560 514.080 ;
+      RECT 96.080 2.720 97.280 514.080 ;
+      RECT 110.800 2.720 112.000 514.080 ;
+      RECT 125.520 2.720 126.720 514.080 ;
+      RECT 140.240 2.720 141.440 514.080 ;
+      RECT 154.960 2.720 156.160 514.080 ;
+      RECT 169.680 2.720 170.880 514.080 ;
+      RECT 184.400 2.720 185.600 514.080 ;
+      RECT 199.120 2.720 200.320 514.080 ;
+      RECT 213.840 2.720 215.040 514.080 ;
+      RECT 228.560 2.720 229.760 514.080 ;
+      RECT 243.280 2.720 244.480 514.080 ;
+      RECT 258.000 2.720 259.200 514.080 ;
+      RECT 272.720 2.720 273.920 514.080 ;
+      RECT 287.440 2.720 288.640 514.080 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 514.080 ;
+      RECT 29.840 2.720 31.040 514.080 ;
+      RECT 44.560 2.720 45.760 514.080 ;
+      RECT 59.280 2.720 60.480 514.080 ;
+      RECT 74.000 2.720 75.200 514.080 ;
+      RECT 88.720 2.720 89.920 514.080 ;
+      RECT 103.440 2.720 104.640 514.080 ;
+      RECT 118.160 2.720 119.360 514.080 ;
+      RECT 132.880 2.720 134.080 514.080 ;
+      RECT 147.600 2.720 148.800 514.080 ;
+      RECT 162.320 2.720 163.520 514.080 ;
+      RECT 177.040 2.720 178.240 514.080 ;
+      RECT 191.760 2.720 192.960 514.080 ;
+      RECT 206.480 2.720 207.680 514.080 ;
+      RECT 221.200 2.720 222.400 514.080 ;
+      RECT 235.920 2.720 237.120 514.080 ;
+      RECT 250.640 2.720 251.840 514.080 ;
+      RECT 265.360 2.720 266.560 514.080 ;
+      RECT 280.080 2.720 281.280 514.080 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 295.320 516.800 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 295.320 516.800 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 295.320 516.800 ;
+  END
+END fakeram_272x16_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_32x128_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_32x128_1r1w.lef
@@ -1,0 +1,816 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_32x128_1r1w
+  FOREIGN fakeram_32x128_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 286.580 BY 144.160 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 141.440 ;
+      RECT 22.480 2.720 23.680 141.440 ;
+      RECT 37.200 2.720 38.400 141.440 ;
+      RECT 51.920 2.720 53.120 141.440 ;
+      RECT 66.640 2.720 67.840 141.440 ;
+      RECT 81.360 2.720 82.560 141.440 ;
+      RECT 96.080 2.720 97.280 141.440 ;
+      RECT 110.800 2.720 112.000 141.440 ;
+      RECT 125.520 2.720 126.720 141.440 ;
+      RECT 140.240 2.720 141.440 141.440 ;
+      RECT 154.960 2.720 156.160 141.440 ;
+      RECT 169.680 2.720 170.880 141.440 ;
+      RECT 184.400 2.720 185.600 141.440 ;
+      RECT 199.120 2.720 200.320 141.440 ;
+      RECT 213.840 2.720 215.040 141.440 ;
+      RECT 228.560 2.720 229.760 141.440 ;
+      RECT 243.280 2.720 244.480 141.440 ;
+      RECT 258.000 2.720 259.200 141.440 ;
+      RECT 272.720 2.720 273.920 141.440 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 141.440 ;
+      RECT 29.840 2.720 31.040 141.440 ;
+      RECT 44.560 2.720 45.760 141.440 ;
+      RECT 59.280 2.720 60.480 141.440 ;
+      RECT 74.000 2.720 75.200 141.440 ;
+      RECT 88.720 2.720 89.920 141.440 ;
+      RECT 103.440 2.720 104.640 141.440 ;
+      RECT 118.160 2.720 119.360 141.440 ;
+      RECT 132.880 2.720 134.080 141.440 ;
+      RECT 147.600 2.720 148.800 141.440 ;
+      RECT 162.320 2.720 163.520 141.440 ;
+      RECT 177.040 2.720 178.240 141.440 ;
+      RECT 191.760 2.720 192.960 141.440 ;
+      RECT 206.480 2.720 207.680 141.440 ;
+      RECT 221.200 2.720 222.400 141.440 ;
+      RECT 235.920 2.720 237.120 141.440 ;
+      RECT 250.640 2.720 251.840 141.440 ;
+      RECT 265.360 2.720 266.560 141.440 ;
+      RECT 280.080 2.720 281.280 141.440 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 286.580 144.160 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 286.580 144.160 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 286.580 144.160 ;
+  END
+END fakeram_32x128_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_4x256_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_4x256_1r1w.lef
@@ -1,0 +1,311 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_4x256_1r1w
+  FOREIGN fakeram_4x256_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 143.520 BY 73.440 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_addr_in[7]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END r0_addr_in[7]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 70.720 ;
+      RECT 22.480 2.720 23.680 70.720 ;
+      RECT 37.200 2.720 38.400 70.720 ;
+      RECT 51.920 2.720 53.120 70.720 ;
+      RECT 66.640 2.720 67.840 70.720 ;
+      RECT 81.360 2.720 82.560 70.720 ;
+      RECT 96.080 2.720 97.280 70.720 ;
+      RECT 110.800 2.720 112.000 70.720 ;
+      RECT 125.520 2.720 126.720 70.720 ;
+      RECT 140.240 2.720 141.440 70.720 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 70.720 ;
+      RECT 29.840 2.720 31.040 70.720 ;
+      RECT 44.560 2.720 45.760 70.720 ;
+      RECT 59.280 2.720 60.480 70.720 ;
+      RECT 74.000 2.720 75.200 70.720 ;
+      RECT 88.720 2.720 89.920 70.720 ;
+      RECT 103.440 2.720 104.640 70.720 ;
+      RECT 118.160 2.720 119.360 70.720 ;
+      RECT 132.880 2.720 134.080 70.720 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 143.520 73.440 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 143.520 73.440 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 143.520 73.440 ;
+  END
+END fakeram_4x256_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_64x16_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_64x16_1r1w.lef
@@ -1,0 +1,1319 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_64x16_1r1w
+  FOREIGN fakeram_64x16_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 143.520 BY 136.000 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_wd_in[32]
+  PIN w0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_wd_in[33]
+  PIN w0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_wd_in[34]
+  PIN w0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_wd_in[35]
+  PIN w0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_wd_in[36]
+  PIN w0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_wd_in[37]
+  PIN w0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_wd_in[38]
+  PIN w0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_wd_in[39]
+  PIN w0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_wd_in[40]
+  PIN w0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_wd_in[41]
+  PIN w0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END w0_wd_in[42]
+  PIN w0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END w0_wd_in[43]
+  PIN w0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END w0_wd_in[44]
+  PIN w0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END w0_wd_in[45]
+  PIN w0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END w0_wd_in[46]
+  PIN w0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END w0_wd_in[47]
+  PIN w0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END w0_wd_in[48]
+  PIN w0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END w0_wd_in[49]
+  PIN w0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END w0_wd_in[50]
+  PIN w0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END w0_wd_in[51]
+  PIN w0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END w0_wd_in[52]
+  PIN w0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END w0_wd_in[53]
+  PIN w0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END w0_wd_in[54]
+  PIN w0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END w0_wd_in[55]
+  PIN w0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END w0_wd_in[56]
+  PIN w0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END w0_wd_in[57]
+  PIN w0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END w0_wd_in[58]
+  PIN w0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END w0_wd_in[59]
+  PIN w0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END w0_wd_in[60]
+  PIN w0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END w0_wd_in[61]
+  PIN w0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END w0_wd_in[62]
+  PIN w0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END w0_wd_in[63]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.280 0.500 77.780 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.200 0.500 78.700 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 79.120 0.500 79.620 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.040 0.500 80.540 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.960 0.500 81.460 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.880 0.500 82.380 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 82.800 0.500 83.300 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.720 0.500 84.220 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.640 0.500 85.140 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.560 0.500 86.060 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 86.480 0.500 86.980 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.400 0.500 87.900 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 88.320 0.500 88.820 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.240 0.500 89.740 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 90.160 0.500 90.660 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 91.080 0.500 91.580 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.000 0.500 92.500 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.920 0.500 93.420 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.840 0.500 94.340 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 94.760 0.500 95.260 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.680 0.500 96.180 ;
+    END
+  END r0_rd_out[32]
+  PIN r0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 96.600 0.500 97.100 ;
+    END
+  END r0_rd_out[33]
+  PIN r0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.520 0.500 98.020 ;
+    END
+  END r0_rd_out[34]
+  PIN r0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 98.440 0.500 98.940 ;
+    END
+  END r0_rd_out[35]
+  PIN r0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 99.360 0.500 99.860 ;
+    END
+  END r0_rd_out[36]
+  PIN r0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.280 0.500 100.780 ;
+    END
+  END r0_rd_out[37]
+  PIN r0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.200 0.500 101.700 ;
+    END
+  END r0_rd_out[38]
+  PIN r0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 102.120 0.500 102.620 ;
+    END
+  END r0_rd_out[39]
+  PIN r0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.040 0.500 103.540 ;
+    END
+  END r0_rd_out[40]
+  PIN r0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.960 0.500 104.460 ;
+    END
+  END r0_rd_out[41]
+  PIN r0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 104.880 0.500 105.380 ;
+    END
+  END r0_rd_out[42]
+  PIN r0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.800 0.500 106.300 ;
+    END
+  END r0_rd_out[43]
+  PIN r0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.720 0.500 107.220 ;
+    END
+  END r0_rd_out[44]
+  PIN r0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 107.640 0.500 108.140 ;
+    END
+  END r0_rd_out[45]
+  PIN r0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.560 0.500 109.060 ;
+    END
+  END r0_rd_out[46]
+  PIN r0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 109.480 0.500 109.980 ;
+    END
+  END r0_rd_out[47]
+  PIN r0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.400 0.500 110.900 ;
+    END
+  END r0_rd_out[48]
+  PIN r0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.320 0.500 111.820 ;
+    END
+  END r0_rd_out[49]
+  PIN r0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 112.240 0.500 112.740 ;
+    END
+  END r0_rd_out[50]
+  PIN r0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 113.160 0.500 113.660 ;
+    END
+  END r0_rd_out[51]
+  PIN r0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.080 0.500 114.580 ;
+    END
+  END r0_rd_out[52]
+  PIN r0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.000 0.500 115.500 ;
+    END
+  END r0_rd_out[53]
+  PIN r0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.920 0.500 116.420 ;
+    END
+  END r0_rd_out[54]
+  PIN r0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.840 0.500 117.340 ;
+    END
+  END r0_rd_out[55]
+  PIN r0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 117.760 0.500 118.260 ;
+    END
+  END r0_rd_out[56]
+  PIN r0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.680 0.500 119.180 ;
+    END
+  END r0_rd_out[57]
+  PIN r0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.600 0.500 120.100 ;
+    END
+  END r0_rd_out[58]
+  PIN r0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 120.520 0.500 121.020 ;
+    END
+  END r0_rd_out[59]
+  PIN r0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 121.440 0.500 121.940 ;
+    END
+  END r0_rd_out[60]
+  PIN r0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.360 0.500 122.860 ;
+    END
+  END r0_rd_out[61]
+  PIN r0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.280 0.500 123.780 ;
+    END
+  END r0_rd_out[62]
+  PIN r0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 124.200 0.500 124.700 ;
+    END
+  END r0_rd_out[63]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.500 125.620 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.040 0.500 126.540 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.960 0.500 127.460 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.880 0.500 128.380 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 128.800 0.500 129.300 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 129.720 0.500 130.220 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 133.280 ;
+      RECT 22.480 2.720 23.680 133.280 ;
+      RECT 37.200 2.720 38.400 133.280 ;
+      RECT 51.920 2.720 53.120 133.280 ;
+      RECT 66.640 2.720 67.840 133.280 ;
+      RECT 81.360 2.720 82.560 133.280 ;
+      RECT 96.080 2.720 97.280 133.280 ;
+      RECT 110.800 2.720 112.000 133.280 ;
+      RECT 125.520 2.720 126.720 133.280 ;
+      RECT 140.240 2.720 141.440 133.280 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 133.280 ;
+      RECT 29.840 2.720 31.040 133.280 ;
+      RECT 44.560 2.720 45.760 133.280 ;
+      RECT 59.280 2.720 60.480 133.280 ;
+      RECT 74.000 2.720 75.200 133.280 ;
+      RECT 88.720 2.720 89.920 133.280 ;
+      RECT 103.440 2.720 104.640 133.280 ;
+      RECT 118.160 2.720 119.360 133.280 ;
+      RECT 132.880 2.720 134.080 133.280 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 143.520 136.000 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 143.520 136.000 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 143.520 136.000 ;
+  END
+END fakeram_64x16_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_64x256_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_64x256_1r1w.lef
@@ -1,0 +1,1449 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_64x256_1r1w
+  FOREIGN fakeram_64x256_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 572.700 BY 288.320 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_wd_in[32]
+  PIN w0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_wd_in[33]
+  PIN w0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_wd_in[34]
+  PIN w0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_wd_in[35]
+  PIN w0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_wd_in[36]
+  PIN w0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_wd_in[37]
+  PIN w0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_wd_in[38]
+  PIN w0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_wd_in[39]
+  PIN w0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_wd_in[40]
+  PIN w0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_wd_in[41]
+  PIN w0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END w0_wd_in[42]
+  PIN w0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END w0_wd_in[43]
+  PIN w0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END w0_wd_in[44]
+  PIN w0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END w0_wd_in[45]
+  PIN w0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END w0_wd_in[46]
+  PIN w0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END w0_wd_in[47]
+  PIN w0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END w0_wd_in[48]
+  PIN w0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END w0_wd_in[49]
+  PIN w0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END w0_wd_in[50]
+  PIN w0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END w0_wd_in[51]
+  PIN w0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END w0_wd_in[52]
+  PIN w0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END w0_wd_in[53]
+  PIN w0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END w0_wd_in[54]
+  PIN w0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END w0_wd_in[55]
+  PIN w0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END w0_wd_in[56]
+  PIN w0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END w0_wd_in[57]
+  PIN w0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END w0_wd_in[58]
+  PIN w0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END w0_wd_in[59]
+  PIN w0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END w0_wd_in[60]
+  PIN w0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END w0_wd_in[61]
+  PIN w0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END w0_wd_in[62]
+  PIN w0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END w0_wd_in[63]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END w0_addr_in[7]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.280 0.500 77.780 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.200 0.500 78.700 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 79.120 0.500 79.620 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.040 0.500 80.540 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.960 0.500 81.460 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.880 0.500 82.380 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 82.800 0.500 83.300 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.720 0.500 84.220 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.640 0.500 85.140 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.560 0.500 86.060 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 86.480 0.500 86.980 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.400 0.500 87.900 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 88.320 0.500 88.820 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.240 0.500 89.740 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 90.160 0.500 90.660 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 91.080 0.500 91.580 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.000 0.500 92.500 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.920 0.500 93.420 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.840 0.500 94.340 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 94.760 0.500 95.260 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.680 0.500 96.180 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 96.600 0.500 97.100 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.520 0.500 98.020 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 98.440 0.500 98.940 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 99.360 0.500 99.860 ;
+    END
+  END r0_rd_out[32]
+  PIN r0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.280 0.500 100.780 ;
+    END
+  END r0_rd_out[33]
+  PIN r0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.200 0.500 101.700 ;
+    END
+  END r0_rd_out[34]
+  PIN r0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 102.120 0.500 102.620 ;
+    END
+  END r0_rd_out[35]
+  PIN r0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.040 0.500 103.540 ;
+    END
+  END r0_rd_out[36]
+  PIN r0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.960 0.500 104.460 ;
+    END
+  END r0_rd_out[37]
+  PIN r0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 104.880 0.500 105.380 ;
+    END
+  END r0_rd_out[38]
+  PIN r0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.800 0.500 106.300 ;
+    END
+  END r0_rd_out[39]
+  PIN r0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.720 0.500 107.220 ;
+    END
+  END r0_rd_out[40]
+  PIN r0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 107.640 0.500 108.140 ;
+    END
+  END r0_rd_out[41]
+  PIN r0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.560 0.500 109.060 ;
+    END
+  END r0_rd_out[42]
+  PIN r0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 109.480 0.500 109.980 ;
+    END
+  END r0_rd_out[43]
+  PIN r0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.400 0.500 110.900 ;
+    END
+  END r0_rd_out[44]
+  PIN r0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.320 0.500 111.820 ;
+    END
+  END r0_rd_out[45]
+  PIN r0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 112.240 0.500 112.740 ;
+    END
+  END r0_rd_out[46]
+  PIN r0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 113.160 0.500 113.660 ;
+    END
+  END r0_rd_out[47]
+  PIN r0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.080 0.500 114.580 ;
+    END
+  END r0_rd_out[48]
+  PIN r0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.000 0.500 115.500 ;
+    END
+  END r0_rd_out[49]
+  PIN r0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.920 0.500 116.420 ;
+    END
+  END r0_rd_out[50]
+  PIN r0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.840 0.500 117.340 ;
+    END
+  END r0_rd_out[51]
+  PIN r0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 117.760 0.500 118.260 ;
+    END
+  END r0_rd_out[52]
+  PIN r0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.680 0.500 119.180 ;
+    END
+  END r0_rd_out[53]
+  PIN r0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.600 0.500 120.100 ;
+    END
+  END r0_rd_out[54]
+  PIN r0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 120.520 0.500 121.020 ;
+    END
+  END r0_rd_out[55]
+  PIN r0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 121.440 0.500 121.940 ;
+    END
+  END r0_rd_out[56]
+  PIN r0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.360 0.500 122.860 ;
+    END
+  END r0_rd_out[57]
+  PIN r0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.280 0.500 123.780 ;
+    END
+  END r0_rd_out[58]
+  PIN r0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 124.200 0.500 124.700 ;
+    END
+  END r0_rd_out[59]
+  PIN r0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.500 125.620 ;
+    END
+  END r0_rd_out[60]
+  PIN r0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.040 0.500 126.540 ;
+    END
+  END r0_rd_out[61]
+  PIN r0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.960 0.500 127.460 ;
+    END
+  END r0_rd_out[62]
+  PIN r0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.880 0.500 128.380 ;
+    END
+  END r0_rd_out[63]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 128.800 0.500 129.300 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 129.720 0.500 130.220 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.640 0.500 131.140 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 131.560 0.500 132.060 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 132.480 0.500 132.980 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.400 0.500 133.900 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 134.320 0.500 134.820 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 135.240 0.500 135.740 ;
+    END
+  END r0_addr_in[7]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.160 0.500 136.660 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 137.080 0.500 137.580 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 285.600 ;
+      RECT 22.480 2.720 23.680 285.600 ;
+      RECT 37.200 2.720 38.400 285.600 ;
+      RECT 51.920 2.720 53.120 285.600 ;
+      RECT 66.640 2.720 67.840 285.600 ;
+      RECT 81.360 2.720 82.560 285.600 ;
+      RECT 96.080 2.720 97.280 285.600 ;
+      RECT 110.800 2.720 112.000 285.600 ;
+      RECT 125.520 2.720 126.720 285.600 ;
+      RECT 140.240 2.720 141.440 285.600 ;
+      RECT 154.960 2.720 156.160 285.600 ;
+      RECT 169.680 2.720 170.880 285.600 ;
+      RECT 184.400 2.720 185.600 285.600 ;
+      RECT 199.120 2.720 200.320 285.600 ;
+      RECT 213.840 2.720 215.040 285.600 ;
+      RECT 228.560 2.720 229.760 285.600 ;
+      RECT 243.280 2.720 244.480 285.600 ;
+      RECT 258.000 2.720 259.200 285.600 ;
+      RECT 272.720 2.720 273.920 285.600 ;
+      RECT 287.440 2.720 288.640 285.600 ;
+      RECT 302.160 2.720 303.360 285.600 ;
+      RECT 316.880 2.720 318.080 285.600 ;
+      RECT 331.600 2.720 332.800 285.600 ;
+      RECT 346.320 2.720 347.520 285.600 ;
+      RECT 361.040 2.720 362.240 285.600 ;
+      RECT 375.760 2.720 376.960 285.600 ;
+      RECT 390.480 2.720 391.680 285.600 ;
+      RECT 405.200 2.720 406.400 285.600 ;
+      RECT 419.920 2.720 421.120 285.600 ;
+      RECT 434.640 2.720 435.840 285.600 ;
+      RECT 449.360 2.720 450.560 285.600 ;
+      RECT 464.080 2.720 465.280 285.600 ;
+      RECT 478.800 2.720 480.000 285.600 ;
+      RECT 493.520 2.720 494.720 285.600 ;
+      RECT 508.240 2.720 509.440 285.600 ;
+      RECT 522.960 2.720 524.160 285.600 ;
+      RECT 537.680 2.720 538.880 285.600 ;
+      RECT 552.400 2.720 553.600 285.600 ;
+      RECT 567.120 2.720 568.320 285.600 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 285.600 ;
+      RECT 29.840 2.720 31.040 285.600 ;
+      RECT 44.560 2.720 45.760 285.600 ;
+      RECT 59.280 2.720 60.480 285.600 ;
+      RECT 74.000 2.720 75.200 285.600 ;
+      RECT 88.720 2.720 89.920 285.600 ;
+      RECT 103.440 2.720 104.640 285.600 ;
+      RECT 118.160 2.720 119.360 285.600 ;
+      RECT 132.880 2.720 134.080 285.600 ;
+      RECT 147.600 2.720 148.800 285.600 ;
+      RECT 162.320 2.720 163.520 285.600 ;
+      RECT 177.040 2.720 178.240 285.600 ;
+      RECT 191.760 2.720 192.960 285.600 ;
+      RECT 206.480 2.720 207.680 285.600 ;
+      RECT 221.200 2.720 222.400 285.600 ;
+      RECT 235.920 2.720 237.120 285.600 ;
+      RECT 250.640 2.720 251.840 285.600 ;
+      RECT 265.360 2.720 266.560 285.600 ;
+      RECT 280.080 2.720 281.280 285.600 ;
+      RECT 294.800 2.720 296.000 285.600 ;
+      RECT 309.520 2.720 310.720 285.600 ;
+      RECT 324.240 2.720 325.440 285.600 ;
+      RECT 338.960 2.720 340.160 285.600 ;
+      RECT 353.680 2.720 354.880 285.600 ;
+      RECT 368.400 2.720 369.600 285.600 ;
+      RECT 383.120 2.720 384.320 285.600 ;
+      RECT 397.840 2.720 399.040 285.600 ;
+      RECT 412.560 2.720 413.760 285.600 ;
+      RECT 427.280 2.720 428.480 285.600 ;
+      RECT 442.000 2.720 443.200 285.600 ;
+      RECT 456.720 2.720 457.920 285.600 ;
+      RECT 471.440 2.720 472.640 285.600 ;
+      RECT 486.160 2.720 487.360 285.600 ;
+      RECT 500.880 2.720 502.080 285.600 ;
+      RECT 515.600 2.720 516.800 285.600 ;
+      RECT 530.320 2.720 531.520 285.600 ;
+      RECT 545.040 2.720 546.240 285.600 ;
+      RECT 559.760 2.720 560.960 285.600 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 572.700 288.320 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 572.700 288.320 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 572.700 288.320 ;
+  END
+END fakeram_64x256_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_65x160_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_65x160_1r1w.lef
@@ -1,0 +1,1451 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_65x160_1r1w
+  FOREIGN fakeram_65x160_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 456.320 BY 228.480 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_wd_in[32]
+  PIN w0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_wd_in[33]
+  PIN w0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_wd_in[34]
+  PIN w0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_wd_in[35]
+  PIN w0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_wd_in[36]
+  PIN w0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_wd_in[37]
+  PIN w0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_wd_in[38]
+  PIN w0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_wd_in[39]
+  PIN w0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_wd_in[40]
+  PIN w0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_wd_in[41]
+  PIN w0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END w0_wd_in[42]
+  PIN w0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END w0_wd_in[43]
+  PIN w0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END w0_wd_in[44]
+  PIN w0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END w0_wd_in[45]
+  PIN w0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END w0_wd_in[46]
+  PIN w0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END w0_wd_in[47]
+  PIN w0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END w0_wd_in[48]
+  PIN w0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END w0_wd_in[49]
+  PIN w0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END w0_wd_in[50]
+  PIN w0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END w0_wd_in[51]
+  PIN w0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END w0_wd_in[52]
+  PIN w0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END w0_wd_in[53]
+  PIN w0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END w0_wd_in[54]
+  PIN w0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END w0_wd_in[55]
+  PIN w0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END w0_wd_in[56]
+  PIN w0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END w0_wd_in[57]
+  PIN w0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END w0_wd_in[58]
+  PIN w0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END w0_wd_in[59]
+  PIN w0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END w0_wd_in[60]
+  PIN w0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END w0_wd_in[61]
+  PIN w0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END w0_wd_in[62]
+  PIN w0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END w0_wd_in[63]
+  PIN w0_wd_in[64]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END w0_wd_in[64]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END w0_addr_in[7]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.280 0.500 77.780 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.200 0.500 78.700 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 79.120 0.500 79.620 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.040 0.500 80.540 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.960 0.500 81.460 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.880 0.500 82.380 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 82.800 0.500 83.300 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.720 0.500 84.220 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.640 0.500 85.140 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.560 0.500 86.060 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 86.480 0.500 86.980 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.400 0.500 87.900 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 88.320 0.500 88.820 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.240 0.500 89.740 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 90.160 0.500 90.660 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 91.080 0.500 91.580 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.000 0.500 92.500 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.920 0.500 93.420 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.840 0.500 94.340 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 94.760 0.500 95.260 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.680 0.500 96.180 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 96.600 0.500 97.100 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.520 0.500 98.020 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 98.440 0.500 98.940 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 99.360 0.500 99.860 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.280 0.500 100.780 ;
+    END
+  END r0_rd_out[32]
+  PIN r0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.200 0.500 101.700 ;
+    END
+  END r0_rd_out[33]
+  PIN r0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 102.120 0.500 102.620 ;
+    END
+  END r0_rd_out[34]
+  PIN r0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.040 0.500 103.540 ;
+    END
+  END r0_rd_out[35]
+  PIN r0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.960 0.500 104.460 ;
+    END
+  END r0_rd_out[36]
+  PIN r0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 104.880 0.500 105.380 ;
+    END
+  END r0_rd_out[37]
+  PIN r0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.800 0.500 106.300 ;
+    END
+  END r0_rd_out[38]
+  PIN r0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.720 0.500 107.220 ;
+    END
+  END r0_rd_out[39]
+  PIN r0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 107.640 0.500 108.140 ;
+    END
+  END r0_rd_out[40]
+  PIN r0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.560 0.500 109.060 ;
+    END
+  END r0_rd_out[41]
+  PIN r0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 109.480 0.500 109.980 ;
+    END
+  END r0_rd_out[42]
+  PIN r0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.400 0.500 110.900 ;
+    END
+  END r0_rd_out[43]
+  PIN r0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.320 0.500 111.820 ;
+    END
+  END r0_rd_out[44]
+  PIN r0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 112.240 0.500 112.740 ;
+    END
+  END r0_rd_out[45]
+  PIN r0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 113.160 0.500 113.660 ;
+    END
+  END r0_rd_out[46]
+  PIN r0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.080 0.500 114.580 ;
+    END
+  END r0_rd_out[47]
+  PIN r0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.000 0.500 115.500 ;
+    END
+  END r0_rd_out[48]
+  PIN r0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.920 0.500 116.420 ;
+    END
+  END r0_rd_out[49]
+  PIN r0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.840 0.500 117.340 ;
+    END
+  END r0_rd_out[50]
+  PIN r0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 117.760 0.500 118.260 ;
+    END
+  END r0_rd_out[51]
+  PIN r0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.680 0.500 119.180 ;
+    END
+  END r0_rd_out[52]
+  PIN r0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.600 0.500 120.100 ;
+    END
+  END r0_rd_out[53]
+  PIN r0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 120.520 0.500 121.020 ;
+    END
+  END r0_rd_out[54]
+  PIN r0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 121.440 0.500 121.940 ;
+    END
+  END r0_rd_out[55]
+  PIN r0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.360 0.500 122.860 ;
+    END
+  END r0_rd_out[56]
+  PIN r0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.280 0.500 123.780 ;
+    END
+  END r0_rd_out[57]
+  PIN r0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 124.200 0.500 124.700 ;
+    END
+  END r0_rd_out[58]
+  PIN r0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.500 125.620 ;
+    END
+  END r0_rd_out[59]
+  PIN r0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.040 0.500 126.540 ;
+    END
+  END r0_rd_out[60]
+  PIN r0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.960 0.500 127.460 ;
+    END
+  END r0_rd_out[61]
+  PIN r0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.880 0.500 128.380 ;
+    END
+  END r0_rd_out[62]
+  PIN r0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 128.800 0.500 129.300 ;
+    END
+  END r0_rd_out[63]
+  PIN r0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 129.720 0.500 130.220 ;
+    END
+  END r0_rd_out[64]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.640 0.500 131.140 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 131.560 0.500 132.060 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 132.480 0.500 132.980 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.400 0.500 133.900 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 134.320 0.500 134.820 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 135.240 0.500 135.740 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.160 0.500 136.660 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 137.080 0.500 137.580 ;
+    END
+  END r0_addr_in[7]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.000 0.500 138.500 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.920 0.500 139.420 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 225.760 ;
+      RECT 22.480 2.720 23.680 225.760 ;
+      RECT 37.200 2.720 38.400 225.760 ;
+      RECT 51.920 2.720 53.120 225.760 ;
+      RECT 66.640 2.720 67.840 225.760 ;
+      RECT 81.360 2.720 82.560 225.760 ;
+      RECT 96.080 2.720 97.280 225.760 ;
+      RECT 110.800 2.720 112.000 225.760 ;
+      RECT 125.520 2.720 126.720 225.760 ;
+      RECT 140.240 2.720 141.440 225.760 ;
+      RECT 154.960 2.720 156.160 225.760 ;
+      RECT 169.680 2.720 170.880 225.760 ;
+      RECT 184.400 2.720 185.600 225.760 ;
+      RECT 199.120 2.720 200.320 225.760 ;
+      RECT 213.840 2.720 215.040 225.760 ;
+      RECT 228.560 2.720 229.760 225.760 ;
+      RECT 243.280 2.720 244.480 225.760 ;
+      RECT 258.000 2.720 259.200 225.760 ;
+      RECT 272.720 2.720 273.920 225.760 ;
+      RECT 287.440 2.720 288.640 225.760 ;
+      RECT 302.160 2.720 303.360 225.760 ;
+      RECT 316.880 2.720 318.080 225.760 ;
+      RECT 331.600 2.720 332.800 225.760 ;
+      RECT 346.320 2.720 347.520 225.760 ;
+      RECT 361.040 2.720 362.240 225.760 ;
+      RECT 375.760 2.720 376.960 225.760 ;
+      RECT 390.480 2.720 391.680 225.760 ;
+      RECT 405.200 2.720 406.400 225.760 ;
+      RECT 419.920 2.720 421.120 225.760 ;
+      RECT 434.640 2.720 435.840 225.760 ;
+      RECT 449.360 2.720 450.560 225.760 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 225.760 ;
+      RECT 29.840 2.720 31.040 225.760 ;
+      RECT 44.560 2.720 45.760 225.760 ;
+      RECT 59.280 2.720 60.480 225.760 ;
+      RECT 74.000 2.720 75.200 225.760 ;
+      RECT 88.720 2.720 89.920 225.760 ;
+      RECT 103.440 2.720 104.640 225.760 ;
+      RECT 118.160 2.720 119.360 225.760 ;
+      RECT 132.880 2.720 134.080 225.760 ;
+      RECT 147.600 2.720 148.800 225.760 ;
+      RECT 162.320 2.720 163.520 225.760 ;
+      RECT 177.040 2.720 178.240 225.760 ;
+      RECT 191.760 2.720 192.960 225.760 ;
+      RECT 206.480 2.720 207.680 225.760 ;
+      RECT 221.200 2.720 222.400 225.760 ;
+      RECT 235.920 2.720 237.120 225.760 ;
+      RECT 250.640 2.720 251.840 225.760 ;
+      RECT 265.360 2.720 266.560 225.760 ;
+      RECT 280.080 2.720 281.280 225.760 ;
+      RECT 294.800 2.720 296.000 225.760 ;
+      RECT 309.520 2.720 310.720 225.760 ;
+      RECT 324.240 2.720 325.440 225.760 ;
+      RECT 338.960 2.720 340.160 225.760 ;
+      RECT 353.680 2.720 354.880 225.760 ;
+      RECT 368.400 2.720 369.600 225.760 ;
+      RECT 383.120 2.720 384.320 225.760 ;
+      RECT 397.840 2.720 399.040 225.760 ;
+      RECT 412.560 2.720 413.760 225.760 ;
+      RECT 427.280 2.720 428.480 225.760 ;
+      RECT 442.000 2.720 443.200 225.760 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 456.320 228.480 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 456.320 228.480 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 456.320 228.480 ;
+  END
+END fakeram_65x160_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_66x64_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_66x64_1r1w.lef
@@ -1,0 +1,1411 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_66x64_1r1w
+  FOREIGN fakeram_66x64_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 290.720 BY 146.880 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_wd_in[32]
+  PIN w0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_wd_in[33]
+  PIN w0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_wd_in[34]
+  PIN w0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_wd_in[35]
+  PIN w0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_wd_in[36]
+  PIN w0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_wd_in[37]
+  PIN w0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_wd_in[38]
+  PIN w0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_wd_in[39]
+  PIN w0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_wd_in[40]
+  PIN w0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_wd_in[41]
+  PIN w0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END w0_wd_in[42]
+  PIN w0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END w0_wd_in[43]
+  PIN w0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END w0_wd_in[44]
+  PIN w0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END w0_wd_in[45]
+  PIN w0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END w0_wd_in[46]
+  PIN w0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END w0_wd_in[47]
+  PIN w0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END w0_wd_in[48]
+  PIN w0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END w0_wd_in[49]
+  PIN w0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END w0_wd_in[50]
+  PIN w0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END w0_wd_in[51]
+  PIN w0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END w0_wd_in[52]
+  PIN w0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END w0_wd_in[53]
+  PIN w0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END w0_wd_in[54]
+  PIN w0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END w0_wd_in[55]
+  PIN w0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END w0_wd_in[56]
+  PIN w0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END w0_wd_in[57]
+  PIN w0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END w0_wd_in[58]
+  PIN w0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END w0_wd_in[59]
+  PIN w0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END w0_wd_in[60]
+  PIN w0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END w0_wd_in[61]
+  PIN w0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END w0_wd_in[62]
+  PIN w0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END w0_wd_in[63]
+  PIN w0_wd_in[64]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END w0_wd_in[64]
+  PIN w0_wd_in[65]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END w0_wd_in[65]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.280 0.500 77.780 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.200 0.500 78.700 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 79.120 0.500 79.620 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.040 0.500 80.540 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.960 0.500 81.460 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.880 0.500 82.380 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 82.800 0.500 83.300 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.720 0.500 84.220 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.640 0.500 85.140 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.560 0.500 86.060 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 86.480 0.500 86.980 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.400 0.500 87.900 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 88.320 0.500 88.820 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.240 0.500 89.740 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 90.160 0.500 90.660 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 91.080 0.500 91.580 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.000 0.500 92.500 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.920 0.500 93.420 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.840 0.500 94.340 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 94.760 0.500 95.260 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.680 0.500 96.180 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 96.600 0.500 97.100 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.520 0.500 98.020 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 98.440 0.500 98.940 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 99.360 0.500 99.860 ;
+    END
+  END r0_rd_out[32]
+  PIN r0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.280 0.500 100.780 ;
+    END
+  END r0_rd_out[33]
+  PIN r0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.200 0.500 101.700 ;
+    END
+  END r0_rd_out[34]
+  PIN r0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 102.120 0.500 102.620 ;
+    END
+  END r0_rd_out[35]
+  PIN r0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.040 0.500 103.540 ;
+    END
+  END r0_rd_out[36]
+  PIN r0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.960 0.500 104.460 ;
+    END
+  END r0_rd_out[37]
+  PIN r0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 104.880 0.500 105.380 ;
+    END
+  END r0_rd_out[38]
+  PIN r0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.800 0.500 106.300 ;
+    END
+  END r0_rd_out[39]
+  PIN r0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.720 0.500 107.220 ;
+    END
+  END r0_rd_out[40]
+  PIN r0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 107.640 0.500 108.140 ;
+    END
+  END r0_rd_out[41]
+  PIN r0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.560 0.500 109.060 ;
+    END
+  END r0_rd_out[42]
+  PIN r0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 109.480 0.500 109.980 ;
+    END
+  END r0_rd_out[43]
+  PIN r0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.400 0.500 110.900 ;
+    END
+  END r0_rd_out[44]
+  PIN r0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.320 0.500 111.820 ;
+    END
+  END r0_rd_out[45]
+  PIN r0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 112.240 0.500 112.740 ;
+    END
+  END r0_rd_out[46]
+  PIN r0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 113.160 0.500 113.660 ;
+    END
+  END r0_rd_out[47]
+  PIN r0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.080 0.500 114.580 ;
+    END
+  END r0_rd_out[48]
+  PIN r0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.000 0.500 115.500 ;
+    END
+  END r0_rd_out[49]
+  PIN r0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.920 0.500 116.420 ;
+    END
+  END r0_rd_out[50]
+  PIN r0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.840 0.500 117.340 ;
+    END
+  END r0_rd_out[51]
+  PIN r0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 117.760 0.500 118.260 ;
+    END
+  END r0_rd_out[52]
+  PIN r0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.680 0.500 119.180 ;
+    END
+  END r0_rd_out[53]
+  PIN r0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.600 0.500 120.100 ;
+    END
+  END r0_rd_out[54]
+  PIN r0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 120.520 0.500 121.020 ;
+    END
+  END r0_rd_out[55]
+  PIN r0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 121.440 0.500 121.940 ;
+    END
+  END r0_rd_out[56]
+  PIN r0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.360 0.500 122.860 ;
+    END
+  END r0_rd_out[57]
+  PIN r0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.280 0.500 123.780 ;
+    END
+  END r0_rd_out[58]
+  PIN r0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 124.200 0.500 124.700 ;
+    END
+  END r0_rd_out[59]
+  PIN r0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.500 125.620 ;
+    END
+  END r0_rd_out[60]
+  PIN r0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.040 0.500 126.540 ;
+    END
+  END r0_rd_out[61]
+  PIN r0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.960 0.500 127.460 ;
+    END
+  END r0_rd_out[62]
+  PIN r0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.880 0.500 128.380 ;
+    END
+  END r0_rd_out[63]
+  PIN r0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 128.800 0.500 129.300 ;
+    END
+  END r0_rd_out[64]
+  PIN r0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 129.720 0.500 130.220 ;
+    END
+  END r0_rd_out[65]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.640 0.500 131.140 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 131.560 0.500 132.060 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 132.480 0.500 132.980 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.400 0.500 133.900 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 134.320 0.500 134.820 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 135.240 0.500 135.740 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.160 0.500 136.660 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 137.080 0.500 137.580 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 144.160 ;
+      RECT 22.480 2.720 23.680 144.160 ;
+      RECT 37.200 2.720 38.400 144.160 ;
+      RECT 51.920 2.720 53.120 144.160 ;
+      RECT 66.640 2.720 67.840 144.160 ;
+      RECT 81.360 2.720 82.560 144.160 ;
+      RECT 96.080 2.720 97.280 144.160 ;
+      RECT 110.800 2.720 112.000 144.160 ;
+      RECT 125.520 2.720 126.720 144.160 ;
+      RECT 140.240 2.720 141.440 144.160 ;
+      RECT 154.960 2.720 156.160 144.160 ;
+      RECT 169.680 2.720 170.880 144.160 ;
+      RECT 184.400 2.720 185.600 144.160 ;
+      RECT 199.120 2.720 200.320 144.160 ;
+      RECT 213.840 2.720 215.040 144.160 ;
+      RECT 228.560 2.720 229.760 144.160 ;
+      RECT 243.280 2.720 244.480 144.160 ;
+      RECT 258.000 2.720 259.200 144.160 ;
+      RECT 272.720 2.720 273.920 144.160 ;
+      RECT 287.440 2.720 288.640 144.160 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 144.160 ;
+      RECT 29.840 2.720 31.040 144.160 ;
+      RECT 44.560 2.720 45.760 144.160 ;
+      RECT 59.280 2.720 60.480 144.160 ;
+      RECT 74.000 2.720 75.200 144.160 ;
+      RECT 88.720 2.720 89.920 144.160 ;
+      RECT 103.440 2.720 104.640 144.160 ;
+      RECT 118.160 2.720 119.360 144.160 ;
+      RECT 132.880 2.720 134.080 144.160 ;
+      RECT 147.600 2.720 148.800 144.160 ;
+      RECT 162.320 2.720 163.520 144.160 ;
+      RECT 177.040 2.720 178.240 144.160 ;
+      RECT 191.760 2.720 192.960 144.160 ;
+      RECT 206.480 2.720 207.680 144.160 ;
+      RECT 221.200 2.720 222.400 144.160 ;
+      RECT 235.920 2.720 237.120 144.160 ;
+      RECT 250.640 2.720 251.840 144.160 ;
+      RECT 265.360 2.720 266.560 144.160 ;
+      RECT 280.080 2.720 281.280 144.160 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 290.720 146.880 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 290.720 146.880 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 290.720 146.880 ;
+  END
+END fakeram_66x64_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_66x80_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_66x80_1r1w.lef
@@ -1,0 +1,1433 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_66x80_1r1w
+  FOREIGN fakeram_66x80_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 325.220 BY 163.200 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_wd_in[32]
+  PIN w0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_wd_in[33]
+  PIN w0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_wd_in[34]
+  PIN w0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_wd_in[35]
+  PIN w0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_wd_in[36]
+  PIN w0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_wd_in[37]
+  PIN w0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_wd_in[38]
+  PIN w0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_wd_in[39]
+  PIN w0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_wd_in[40]
+  PIN w0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_wd_in[41]
+  PIN w0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END w0_wd_in[42]
+  PIN w0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END w0_wd_in[43]
+  PIN w0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END w0_wd_in[44]
+  PIN w0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END w0_wd_in[45]
+  PIN w0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END w0_wd_in[46]
+  PIN w0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END w0_wd_in[47]
+  PIN w0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END w0_wd_in[48]
+  PIN w0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END w0_wd_in[49]
+  PIN w0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END w0_wd_in[50]
+  PIN w0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END w0_wd_in[51]
+  PIN w0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END w0_wd_in[52]
+  PIN w0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END w0_wd_in[53]
+  PIN w0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END w0_wd_in[54]
+  PIN w0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END w0_wd_in[55]
+  PIN w0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END w0_wd_in[56]
+  PIN w0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END w0_wd_in[57]
+  PIN w0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END w0_wd_in[58]
+  PIN w0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END w0_wd_in[59]
+  PIN w0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END w0_wd_in[60]
+  PIN w0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END w0_wd_in[61]
+  PIN w0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END w0_wd_in[62]
+  PIN w0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END w0_wd_in[63]
+  PIN w0_wd_in[64]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END w0_wd_in[64]
+  PIN w0_wd_in[65]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END w0_wd_in[65]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.280 0.500 77.780 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.200 0.500 78.700 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 79.120 0.500 79.620 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.040 0.500 80.540 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.960 0.500 81.460 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.880 0.500 82.380 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 82.800 0.500 83.300 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.720 0.500 84.220 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.640 0.500 85.140 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.560 0.500 86.060 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 86.480 0.500 86.980 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.400 0.500 87.900 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 88.320 0.500 88.820 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.240 0.500 89.740 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 90.160 0.500 90.660 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 91.080 0.500 91.580 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.000 0.500 92.500 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.920 0.500 93.420 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.840 0.500 94.340 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 94.760 0.500 95.260 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.680 0.500 96.180 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 96.600 0.500 97.100 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.520 0.500 98.020 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 98.440 0.500 98.940 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 99.360 0.500 99.860 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.280 0.500 100.780 ;
+    END
+  END r0_rd_out[32]
+  PIN r0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.200 0.500 101.700 ;
+    END
+  END r0_rd_out[33]
+  PIN r0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 102.120 0.500 102.620 ;
+    END
+  END r0_rd_out[34]
+  PIN r0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.040 0.500 103.540 ;
+    END
+  END r0_rd_out[35]
+  PIN r0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.960 0.500 104.460 ;
+    END
+  END r0_rd_out[36]
+  PIN r0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 104.880 0.500 105.380 ;
+    END
+  END r0_rd_out[37]
+  PIN r0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.800 0.500 106.300 ;
+    END
+  END r0_rd_out[38]
+  PIN r0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.720 0.500 107.220 ;
+    END
+  END r0_rd_out[39]
+  PIN r0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 107.640 0.500 108.140 ;
+    END
+  END r0_rd_out[40]
+  PIN r0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.560 0.500 109.060 ;
+    END
+  END r0_rd_out[41]
+  PIN r0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 109.480 0.500 109.980 ;
+    END
+  END r0_rd_out[42]
+  PIN r0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.400 0.500 110.900 ;
+    END
+  END r0_rd_out[43]
+  PIN r0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.320 0.500 111.820 ;
+    END
+  END r0_rd_out[44]
+  PIN r0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 112.240 0.500 112.740 ;
+    END
+  END r0_rd_out[45]
+  PIN r0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 113.160 0.500 113.660 ;
+    END
+  END r0_rd_out[46]
+  PIN r0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.080 0.500 114.580 ;
+    END
+  END r0_rd_out[47]
+  PIN r0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.000 0.500 115.500 ;
+    END
+  END r0_rd_out[48]
+  PIN r0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.920 0.500 116.420 ;
+    END
+  END r0_rd_out[49]
+  PIN r0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.840 0.500 117.340 ;
+    END
+  END r0_rd_out[50]
+  PIN r0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 117.760 0.500 118.260 ;
+    END
+  END r0_rd_out[51]
+  PIN r0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.680 0.500 119.180 ;
+    END
+  END r0_rd_out[52]
+  PIN r0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.600 0.500 120.100 ;
+    END
+  END r0_rd_out[53]
+  PIN r0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 120.520 0.500 121.020 ;
+    END
+  END r0_rd_out[54]
+  PIN r0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 121.440 0.500 121.940 ;
+    END
+  END r0_rd_out[55]
+  PIN r0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.360 0.500 122.860 ;
+    END
+  END r0_rd_out[56]
+  PIN r0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.280 0.500 123.780 ;
+    END
+  END r0_rd_out[57]
+  PIN r0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 124.200 0.500 124.700 ;
+    END
+  END r0_rd_out[58]
+  PIN r0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.500 125.620 ;
+    END
+  END r0_rd_out[59]
+  PIN r0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.040 0.500 126.540 ;
+    END
+  END r0_rd_out[60]
+  PIN r0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.960 0.500 127.460 ;
+    END
+  END r0_rd_out[61]
+  PIN r0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.880 0.500 128.380 ;
+    END
+  END r0_rd_out[62]
+  PIN r0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 128.800 0.500 129.300 ;
+    END
+  END r0_rd_out[63]
+  PIN r0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 129.720 0.500 130.220 ;
+    END
+  END r0_rd_out[64]
+  PIN r0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.640 0.500 131.140 ;
+    END
+  END r0_rd_out[65]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 131.560 0.500 132.060 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 132.480 0.500 132.980 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 133.400 0.500 133.900 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 134.320 0.500 134.820 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 135.240 0.500 135.740 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 136.160 0.500 136.660 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 137.080 0.500 137.580 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.000 0.500 138.500 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 138.920 0.500 139.420 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 160.480 ;
+      RECT 22.480 2.720 23.680 160.480 ;
+      RECT 37.200 2.720 38.400 160.480 ;
+      RECT 51.920 2.720 53.120 160.480 ;
+      RECT 66.640 2.720 67.840 160.480 ;
+      RECT 81.360 2.720 82.560 160.480 ;
+      RECT 96.080 2.720 97.280 160.480 ;
+      RECT 110.800 2.720 112.000 160.480 ;
+      RECT 125.520 2.720 126.720 160.480 ;
+      RECT 140.240 2.720 141.440 160.480 ;
+      RECT 154.960 2.720 156.160 160.480 ;
+      RECT 169.680 2.720 170.880 160.480 ;
+      RECT 184.400 2.720 185.600 160.480 ;
+      RECT 199.120 2.720 200.320 160.480 ;
+      RECT 213.840 2.720 215.040 160.480 ;
+      RECT 228.560 2.720 229.760 160.480 ;
+      RECT 243.280 2.720 244.480 160.480 ;
+      RECT 258.000 2.720 259.200 160.480 ;
+      RECT 272.720 2.720 273.920 160.480 ;
+      RECT 287.440 2.720 288.640 160.480 ;
+      RECT 302.160 2.720 303.360 160.480 ;
+      RECT 316.880 2.720 318.080 160.480 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 160.480 ;
+      RECT 29.840 2.720 31.040 160.480 ;
+      RECT 44.560 2.720 45.760 160.480 ;
+      RECT 59.280 2.720 60.480 160.480 ;
+      RECT 74.000 2.720 75.200 160.480 ;
+      RECT 88.720 2.720 89.920 160.480 ;
+      RECT 103.440 2.720 104.640 160.480 ;
+      RECT 118.160 2.720 119.360 160.480 ;
+      RECT 132.880 2.720 134.080 160.480 ;
+      RECT 147.600 2.720 148.800 160.480 ;
+      RECT 162.320 2.720 163.520 160.480 ;
+      RECT 177.040 2.720 178.240 160.480 ;
+      RECT 191.760 2.720 192.960 160.480 ;
+      RECT 206.480 2.720 207.680 160.480 ;
+      RECT 221.200 2.720 222.400 160.480 ;
+      RECT 235.920 2.720 237.120 160.480 ;
+      RECT 250.640 2.720 251.840 160.480 ;
+      RECT 265.360 2.720 266.560 160.480 ;
+      RECT 280.080 2.720 281.280 160.480 ;
+      RECT 294.800 2.720 296.000 160.480 ;
+      RECT 309.520 2.720 310.720 160.480 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 325.220 163.200 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 325.220 163.200 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 325.220 163.200 ;
+  END
+END fakeram_66x80_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_66x8_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_66x8_1r1w.lef
@@ -1,0 +1,1331 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_66x8_1r1w
+  FOREIGN fakeram_66x8_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 103.040 BY 136.000 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_wd_in[9]
+  PIN w0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_wd_in[10]
+  PIN w0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_wd_in[11]
+  PIN w0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_wd_in[12]
+  PIN w0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_wd_in[13]
+  PIN w0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_wd_in[14]
+  PIN w0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_wd_in[15]
+  PIN w0_wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_wd_in[16]
+  PIN w0_wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_wd_in[17]
+  PIN w0_wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_wd_in[18]
+  PIN w0_wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END w0_wd_in[19]
+  PIN w0_wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END w0_wd_in[20]
+  PIN w0_wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END w0_wd_in[21]
+  PIN w0_wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END w0_wd_in[22]
+  PIN w0_wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END w0_wd_in[23]
+  PIN w0_wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END w0_wd_in[24]
+  PIN w0_wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END w0_wd_in[25]
+  PIN w0_wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END w0_wd_in[26]
+  PIN w0_wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END w0_wd_in[27]
+  PIN w0_wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END w0_wd_in[28]
+  PIN w0_wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END w0_wd_in[29]
+  PIN w0_wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END w0_wd_in[30]
+  PIN w0_wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END w0_wd_in[31]
+  PIN w0_wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END w0_wd_in[32]
+  PIN w0_wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END w0_wd_in[33]
+  PIN w0_wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END w0_wd_in[34]
+  PIN w0_wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END w0_wd_in[35]
+  PIN w0_wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END w0_wd_in[36]
+  PIN w0_wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.960 0.500 35.460 ;
+    END
+  END w0_wd_in[37]
+  PIN w0_wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.880 0.500 36.380 ;
+    END
+  END w0_wd_in[38]
+  PIN w0_wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 36.800 0.500 37.300 ;
+    END
+  END w0_wd_in[39]
+  PIN w0_wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.720 0.500 38.220 ;
+    END
+  END w0_wd_in[40]
+  PIN w0_wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 38.640 0.500 39.140 ;
+    END
+  END w0_wd_in[41]
+  PIN w0_wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 39.560 0.500 40.060 ;
+    END
+  END w0_wd_in[42]
+  PIN w0_wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.480 0.500 40.980 ;
+    END
+  END w0_wd_in[43]
+  PIN w0_wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 41.400 0.500 41.900 ;
+    END
+  END w0_wd_in[44]
+  PIN w0_wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 42.320 0.500 42.820 ;
+    END
+  END w0_wd_in[45]
+  PIN w0_wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.240 0.500 43.740 ;
+    END
+  END w0_wd_in[46]
+  PIN w0_wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 44.160 0.500 44.660 ;
+    END
+  END w0_wd_in[47]
+  PIN w0_wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 45.080 0.500 45.580 ;
+    END
+  END w0_wd_in[48]
+  PIN w0_wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.000 0.500 46.500 ;
+    END
+  END w0_wd_in[49]
+  PIN w0_wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.920 0.500 47.420 ;
+    END
+  END w0_wd_in[50]
+  PIN w0_wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 47.840 0.500 48.340 ;
+    END
+  END w0_wd_in[51]
+  PIN w0_wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.760 0.500 49.260 ;
+    END
+  END w0_wd_in[52]
+  PIN w0_wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 49.680 0.500 50.180 ;
+    END
+  END w0_wd_in[53]
+  PIN w0_wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 50.600 0.500 51.100 ;
+    END
+  END w0_wd_in[54]
+  PIN w0_wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.520 0.500 52.020 ;
+    END
+  END w0_wd_in[55]
+  PIN w0_wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 52.440 0.500 52.940 ;
+    END
+  END w0_wd_in[56]
+  PIN w0_wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 53.360 0.500 53.860 ;
+    END
+  END w0_wd_in[57]
+  PIN w0_wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.280 0.500 54.780 ;
+    END
+  END w0_wd_in[58]
+  PIN w0_wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 55.200 0.500 55.700 ;
+    END
+  END w0_wd_in[59]
+  PIN w0_wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.120 0.500 56.620 ;
+    END
+  END w0_wd_in[60]
+  PIN w0_wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.040 0.500 57.540 ;
+    END
+  END w0_wd_in[61]
+  PIN w0_wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 57.960 0.500 58.460 ;
+    END
+  END w0_wd_in[62]
+  PIN w0_wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 58.880 0.500 59.380 ;
+    END
+  END w0_wd_in[63]
+  PIN w0_wd_in[64]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.800 0.500 60.300 ;
+    END
+  END w0_wd_in[64]
+  PIN w0_wd_in[65]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 60.720 0.500 61.220 ;
+    END
+  END w0_wd_in[65]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 61.640 0.500 62.140 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 62.560 0.500 63.060 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.480 0.500 63.980 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 64.400 0.500 64.900 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 65.320 0.500 65.820 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 66.240 0.500 66.740 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 67.160 0.500 67.660 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 68.080 0.500 68.580 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.000 0.500 69.500 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 69.920 0.500 70.420 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 70.840 0.500 71.340 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 71.760 0.500 72.260 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 72.680 0.500 73.180 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 73.600 0.500 74.100 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 74.520 0.500 75.020 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 75.440 0.500 75.940 ;
+    END
+  END r0_rd_out[9]
+  PIN r0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 76.360 0.500 76.860 ;
+    END
+  END r0_rd_out[10]
+  PIN r0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 77.280 0.500 77.780 ;
+    END
+  END r0_rd_out[11]
+  PIN r0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 78.200 0.500 78.700 ;
+    END
+  END r0_rd_out[12]
+  PIN r0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 79.120 0.500 79.620 ;
+    END
+  END r0_rd_out[13]
+  PIN r0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.040 0.500 80.540 ;
+    END
+  END r0_rd_out[14]
+  PIN r0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 80.960 0.500 81.460 ;
+    END
+  END r0_rd_out[15]
+  PIN r0_rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 81.880 0.500 82.380 ;
+    END
+  END r0_rd_out[16]
+  PIN r0_rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 82.800 0.500 83.300 ;
+    END
+  END r0_rd_out[17]
+  PIN r0_rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 83.720 0.500 84.220 ;
+    END
+  END r0_rd_out[18]
+  PIN r0_rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 84.640 0.500 85.140 ;
+    END
+  END r0_rd_out[19]
+  PIN r0_rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 85.560 0.500 86.060 ;
+    END
+  END r0_rd_out[20]
+  PIN r0_rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 86.480 0.500 86.980 ;
+    END
+  END r0_rd_out[21]
+  PIN r0_rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 87.400 0.500 87.900 ;
+    END
+  END r0_rd_out[22]
+  PIN r0_rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 88.320 0.500 88.820 ;
+    END
+  END r0_rd_out[23]
+  PIN r0_rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 89.240 0.500 89.740 ;
+    END
+  END r0_rd_out[24]
+  PIN r0_rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 90.160 0.500 90.660 ;
+    END
+  END r0_rd_out[25]
+  PIN r0_rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 91.080 0.500 91.580 ;
+    END
+  END r0_rd_out[26]
+  PIN r0_rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.000 0.500 92.500 ;
+    END
+  END r0_rd_out[27]
+  PIN r0_rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 92.920 0.500 93.420 ;
+    END
+  END r0_rd_out[28]
+  PIN r0_rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.840 0.500 94.340 ;
+    END
+  END r0_rd_out[29]
+  PIN r0_rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 94.760 0.500 95.260 ;
+    END
+  END r0_rd_out[30]
+  PIN r0_rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 95.680 0.500 96.180 ;
+    END
+  END r0_rd_out[31]
+  PIN r0_rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 96.600 0.500 97.100 ;
+    END
+  END r0_rd_out[32]
+  PIN r0_rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 97.520 0.500 98.020 ;
+    END
+  END r0_rd_out[33]
+  PIN r0_rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 98.440 0.500 98.940 ;
+    END
+  END r0_rd_out[34]
+  PIN r0_rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 99.360 0.500 99.860 ;
+    END
+  END r0_rd_out[35]
+  PIN r0_rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 100.280 0.500 100.780 ;
+    END
+  END r0_rd_out[36]
+  PIN r0_rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 101.200 0.500 101.700 ;
+    END
+  END r0_rd_out[37]
+  PIN r0_rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 102.120 0.500 102.620 ;
+    END
+  END r0_rd_out[38]
+  PIN r0_rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.040 0.500 103.540 ;
+    END
+  END r0_rd_out[39]
+  PIN r0_rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 103.960 0.500 104.460 ;
+    END
+  END r0_rd_out[40]
+  PIN r0_rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 104.880 0.500 105.380 ;
+    END
+  END r0_rd_out[41]
+  PIN r0_rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 105.800 0.500 106.300 ;
+    END
+  END r0_rd_out[42]
+  PIN r0_rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 106.720 0.500 107.220 ;
+    END
+  END r0_rd_out[43]
+  PIN r0_rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 107.640 0.500 108.140 ;
+    END
+  END r0_rd_out[44]
+  PIN r0_rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 108.560 0.500 109.060 ;
+    END
+  END r0_rd_out[45]
+  PIN r0_rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 109.480 0.500 109.980 ;
+    END
+  END r0_rd_out[46]
+  PIN r0_rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 110.400 0.500 110.900 ;
+    END
+  END r0_rd_out[47]
+  PIN r0_rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 111.320 0.500 111.820 ;
+    END
+  END r0_rd_out[48]
+  PIN r0_rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 112.240 0.500 112.740 ;
+    END
+  END r0_rd_out[49]
+  PIN r0_rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 113.160 0.500 113.660 ;
+    END
+  END r0_rd_out[50]
+  PIN r0_rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 114.080 0.500 114.580 ;
+    END
+  END r0_rd_out[51]
+  PIN r0_rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.000 0.500 115.500 ;
+    END
+  END r0_rd_out[52]
+  PIN r0_rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 115.920 0.500 116.420 ;
+    END
+  END r0_rd_out[53]
+  PIN r0_rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 116.840 0.500 117.340 ;
+    END
+  END r0_rd_out[54]
+  PIN r0_rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 117.760 0.500 118.260 ;
+    END
+  END r0_rd_out[55]
+  PIN r0_rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 118.680 0.500 119.180 ;
+    END
+  END r0_rd_out[56]
+  PIN r0_rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 119.600 0.500 120.100 ;
+    END
+  END r0_rd_out[57]
+  PIN r0_rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 120.520 0.500 121.020 ;
+    END
+  END r0_rd_out[58]
+  PIN r0_rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 121.440 0.500 121.940 ;
+    END
+  END r0_rd_out[59]
+  PIN r0_rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 122.360 0.500 122.860 ;
+    END
+  END r0_rd_out[60]
+  PIN r0_rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.280 0.500 123.780 ;
+    END
+  END r0_rd_out[61]
+  PIN r0_rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 124.200 0.500 124.700 ;
+    END
+  END r0_rd_out[62]
+  PIN r0_rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 125.120 0.500 125.620 ;
+    END
+  END r0_rd_out[63]
+  PIN r0_rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.040 0.500 126.540 ;
+    END
+  END r0_rd_out[64]
+  PIN r0_rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 126.960 0.500 127.460 ;
+    END
+  END r0_rd_out[65]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 127.880 0.500 128.380 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 128.800 0.500 129.300 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 129.720 0.500 130.220 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 130.640 0.500 131.140 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 131.560 0.500 132.060 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 133.280 ;
+      RECT 22.480 2.720 23.680 133.280 ;
+      RECT 37.200 2.720 38.400 133.280 ;
+      RECT 51.920 2.720 53.120 133.280 ;
+      RECT 66.640 2.720 67.840 133.280 ;
+      RECT 81.360 2.720 82.560 133.280 ;
+      RECT 96.080 2.720 97.280 133.280 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 133.280 ;
+      RECT 29.840 2.720 31.040 133.280 ;
+      RECT 44.560 2.720 45.760 133.280 ;
+      RECT 59.280 2.720 60.480 133.280 ;
+      RECT 74.000 2.720 75.200 133.280 ;
+      RECT 88.720 2.720 89.920 133.280 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 103.040 136.000 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 103.040 136.000 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 103.040 136.000 ;
+  END
+END fakeram_66x8_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_6x128_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_6x128_1r1w.lef
@@ -1,0 +1,326 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_6x128_1r1w
+  FOREIGN fakeram_6x128_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 124.200 BY 62.560 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 59.840 ;
+      RECT 22.480 2.720 23.680 59.840 ;
+      RECT 37.200 2.720 38.400 59.840 ;
+      RECT 51.920 2.720 53.120 59.840 ;
+      RECT 66.640 2.720 67.840 59.840 ;
+      RECT 81.360 2.720 82.560 59.840 ;
+      RECT 96.080 2.720 97.280 59.840 ;
+      RECT 110.800 2.720 112.000 59.840 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 59.840 ;
+      RECT 29.840 2.720 31.040 59.840 ;
+      RECT 44.560 2.720 45.760 59.840 ;
+      RECT 59.280 2.720 60.480 59.840 ;
+      RECT 74.000 2.720 75.200 59.840 ;
+      RECT 88.720 2.720 89.920 59.840 ;
+      RECT 103.440 2.720 104.640 59.840 ;
+      RECT 118.160 2.720 119.360 59.840 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 124.200 62.560 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 124.200 62.560 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 124.200 62.560 ;
+  END
+END fakeram_6x128_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_7x256_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_7x256_1r1w.lef
@@ -1,0 +1,371 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_7x256_1r1w
+  FOREIGN fakeram_7x256_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 189.520 BY 95.200 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_addr_in[7]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_addr_in[7]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 92.480 ;
+      RECT 22.480 2.720 23.680 92.480 ;
+      RECT 37.200 2.720 38.400 92.480 ;
+      RECT 51.920 2.720 53.120 92.480 ;
+      RECT 66.640 2.720 67.840 92.480 ;
+      RECT 81.360 2.720 82.560 92.480 ;
+      RECT 96.080 2.720 97.280 92.480 ;
+      RECT 110.800 2.720 112.000 92.480 ;
+      RECT 125.520 2.720 126.720 92.480 ;
+      RECT 140.240 2.720 141.440 92.480 ;
+      RECT 154.960 2.720 156.160 92.480 ;
+      RECT 169.680 2.720 170.880 92.480 ;
+      RECT 184.400 2.720 185.600 92.480 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 92.480 ;
+      RECT 29.840 2.720 31.040 92.480 ;
+      RECT 44.560 2.720 45.760 92.480 ;
+      RECT 59.280 2.720 60.480 92.480 ;
+      RECT 74.000 2.720 75.200 92.480 ;
+      RECT 88.720 2.720 89.920 92.480 ;
+      RECT 103.440 2.720 104.640 92.480 ;
+      RECT 118.160 2.720 119.360 92.480 ;
+      RECT 132.880 2.720 134.080 92.480 ;
+      RECT 147.600 2.720 148.800 92.480 ;
+      RECT 162.320 2.720 163.520 92.480 ;
+      RECT 177.040 2.720 178.240 92.480 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 189.520 95.200 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 189.520 95.200 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 189.520 95.200 ;
+  END
+END fakeram_7x256_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_8x256_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_8x256_1r1w.lef
@@ -1,0 +1,391 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_8x256_1r1w
+  FOREIGN fakeram_8x256_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 202.400 BY 103.360 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_addr_in[7]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_addr_in[7]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 100.640 ;
+      RECT 22.480 2.720 23.680 100.640 ;
+      RECT 37.200 2.720 38.400 100.640 ;
+      RECT 51.920 2.720 53.120 100.640 ;
+      RECT 66.640 2.720 67.840 100.640 ;
+      RECT 81.360 2.720 82.560 100.640 ;
+      RECT 96.080 2.720 97.280 100.640 ;
+      RECT 110.800 2.720 112.000 100.640 ;
+      RECT 125.520 2.720 126.720 100.640 ;
+      RECT 140.240 2.720 141.440 100.640 ;
+      RECT 154.960 2.720 156.160 100.640 ;
+      RECT 169.680 2.720 170.880 100.640 ;
+      RECT 184.400 2.720 185.600 100.640 ;
+      RECT 199.120 2.720 200.320 100.640 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 100.640 ;
+      RECT 29.840 2.720 31.040 100.640 ;
+      RECT 44.560 2.720 45.760 100.640 ;
+      RECT 59.280 2.720 60.480 100.640 ;
+      RECT 74.000 2.720 75.200 100.640 ;
+      RECT 88.720 2.720 89.920 100.640 ;
+      RECT 103.440 2.720 104.640 100.640 ;
+      RECT 118.160 2.720 119.360 100.640 ;
+      RECT 132.880 2.720 134.080 100.640 ;
+      RECT 147.600 2.720 148.800 100.640 ;
+      RECT 162.320 2.720 163.520 100.640 ;
+      RECT 177.040 2.720 178.240 100.640 ;
+      RECT 191.760 2.720 192.960 100.640 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 202.400 103.360 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 202.400 103.360 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 202.400 103.360 ;
+  END
+END fakeram_8x256_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lef/fakeram_9x80_1r1w.lef
+++ b/designs/sky130hd/NVDLA/sram/lef/fakeram_9x80_1r1w.lef
@@ -1,0 +1,380 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram_9x80_1r1w
+  FOREIGN fakeram_9x80_1r1w 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 120.060 BY 62.560 ;
+  CLASS BLOCK ;
+  PIN w0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 0.920 0.500 1.420 ;
+    END
+  END w0_wd_in[0]
+  PIN w0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 1.840 0.500 2.340 ;
+    END
+  END w0_wd_in[1]
+  PIN w0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.760 0.500 3.260 ;
+    END
+  END w0_wd_in[2]
+  PIN w0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.680 0.500 4.180 ;
+    END
+  END w0_wd_in[3]
+  PIN w0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 4.600 0.500 5.100 ;
+    END
+  END w0_wd_in[4]
+  PIN w0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.520 0.500 6.020 ;
+    END
+  END w0_wd_in[5]
+  PIN w0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 6.440 0.500 6.940 ;
+    END
+  END w0_wd_in[6]
+  PIN w0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 7.360 0.500 7.860 ;
+    END
+  END w0_wd_in[7]
+  PIN w0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.280 0.500 8.780 ;
+    END
+  END w0_wd_in[8]
+  PIN w0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 9.200 0.500 9.700 ;
+    END
+  END w0_addr_in[0]
+  PIN w0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.120 0.500 10.620 ;
+    END
+  END w0_addr_in[1]
+  PIN w0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.040 0.500 11.540 ;
+    END
+  END w0_addr_in[2]
+  PIN w0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 11.960 0.500 12.460 ;
+    END
+  END w0_addr_in[3]
+  PIN w0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 12.880 0.500 13.380 ;
+    END
+  END w0_addr_in[4]
+  PIN w0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.800 0.500 14.300 ;
+    END
+  END w0_addr_in[5]
+  PIN w0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 14.720 0.500 15.220 ;
+    END
+  END w0_addr_in[6]
+  PIN w0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 15.640 0.500 16.140 ;
+    END
+  END w0_clk
+  PIN w0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.560 0.500 17.060 ;
+    END
+  END w0_ce_in
+  PIN w0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 17.480 0.500 17.980 ;
+    END
+  END w0_we_in
+  PIN r0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.400 0.500 18.900 ;
+    END
+  END r0_rd_out[0]
+  PIN r0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 19.320 0.500 19.820 ;
+    END
+  END r0_rd_out[1]
+  PIN r0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 20.240 0.500 20.740 ;
+    END
+  END r0_rd_out[2]
+  PIN r0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.160 0.500 21.660 ;
+    END
+  END r0_rd_out[3]
+  PIN r0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 22.080 0.500 22.580 ;
+    END
+  END r0_rd_out[4]
+  PIN r0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.000 0.500 23.500 ;
+    END
+  END r0_rd_out[5]
+  PIN r0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 23.920 0.500 24.420 ;
+    END
+  END r0_rd_out[6]
+  PIN r0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.840 0.500 25.340 ;
+    END
+  END r0_rd_out[7]
+  PIN r0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 25.760 0.500 26.260 ;
+    END
+  END r0_rd_out[8]
+  PIN r0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 26.680 0.500 27.180 ;
+    END
+  END r0_addr_in[0]
+  PIN r0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.600 0.500 28.100 ;
+    END
+  END r0_addr_in[1]
+  PIN r0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 28.520 0.500 29.020 ;
+    END
+  END r0_addr_in[2]
+  PIN r0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.440 0.500 29.940 ;
+    END
+  END r0_addr_in[3]
+  PIN r0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 30.360 0.500 30.860 ;
+    END
+  END r0_addr_in[4]
+  PIN r0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 31.280 0.500 31.780 ;
+    END
+  END r0_addr_in[5]
+  PIN r0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.200 0.500 32.700 ;
+    END
+  END r0_addr_in[6]
+  PIN r0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.120 0.500 33.620 ;
+    END
+  END r0_clk
+  PIN r0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 34.040 0.500 34.540 ;
+    END
+  END r0_ce_in
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 7.760 2.720 8.960 59.840 ;
+      RECT 22.480 2.720 23.680 59.840 ;
+      RECT 37.200 2.720 38.400 59.840 ;
+      RECT 51.920 2.720 53.120 59.840 ;
+      RECT 66.640 2.720 67.840 59.840 ;
+      RECT 81.360 2.720 82.560 59.840 ;
+      RECT 96.080 2.720 97.280 59.840 ;
+      RECT 110.800 2.720 112.000 59.840 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 15.120 2.720 16.320 59.840 ;
+      RECT 29.840 2.720 31.040 59.840 ;
+      RECT 44.560 2.720 45.760 59.840 ;
+      RECT 59.280 2.720 60.480 59.840 ;
+      RECT 74.000 2.720 75.200 59.840 ;
+      RECT 88.720 2.720 89.920 59.840 ;
+      RECT 103.440 2.720 104.640 59.840 ;
+      RECT 118.160 2.720 119.360 59.840 ;
+    END
+  END VSS
+  OBS
+    LAYER met1 ;
+      RECT 0.000 0.000 120.060 62.560 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 120.060 62.560 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 120.060 62.560 ;
+  END
+END fakeram_9x80_1r1w
+END LIBRARY

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_11x128_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_11x128_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_11x128_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_11x128_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_11x128_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_11x128_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_11x128_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 11; bit_from : 10; bit_to : 0; downto : true;
+    }
+    type (fakeram_11x128_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    cell(fakeram_11x128_1r1w) {
+        area : 14157.328;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_11x128_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_11x128_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_11x128_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_11x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_11x128_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_11x128_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_11x128_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_11x128_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_11x128_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_14x80_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_14x80_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_14x80_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_14x80_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_14x80_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_14x80_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_14x80_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 14; bit_from : 13; bit_to : 0; downto : true;
+    }
+    type (fakeram_14x80_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    cell(fakeram_14x80_1r1w) {
+        area : 11420.954;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_14x80_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_14x80_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_14x80_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_14x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_14x80_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_14x80_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_14x80_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_14x80_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_14x80_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_15x80_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_15x80_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_15x80_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_15x80_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_15x80_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_15x80_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_15x80_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 15; bit_from : 14; bit_to : 0; downto : true;
+    }
+    type (fakeram_15x80_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    cell(fakeram_15x80_1r1w) {
+        area : 12227.978;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_15x80_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_15x80_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_15x80_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_15x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_15x80_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_15x80_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_15x80_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_15x80_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_15x80_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_16x160_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_16x160_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_16x160_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_16x160_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_16x160_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_16x160_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_16x160_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 16; bit_from : 15; bit_to : 0; downto : true;
+    }
+    type (fakeram_16x160_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 8; bit_from : 7; bit_to : 0; downto : true;
+    }
+    cell(fakeram_16x160_1r1w) {
+        area : 25854.797;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_16x160_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_16x160_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_16x160_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_16x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_16x160_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_16x160_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_16x160_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_16x160_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_16x160_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_18x128_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_18x128_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_18x128_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_18x128_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_18x128_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_18x128_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_18x128_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 18; bit_from : 17; bit_to : 0; downto : true;
+    }
+    type (fakeram_18x128_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    cell(fakeram_18x128_1r1w) {
+        area : 23372.416;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_18x128_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_18x128_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_18x128_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_18x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_18x128_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_18x128_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_18x128_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_18x128_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_18x128_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_22x60_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_22x60_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_22x60_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_22x60_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_22x60_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_22x60_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_22x60_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 22; bit_from : 21; bit_to : 0; downto : true;
+    }
+    type (fakeram_22x60_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 6; bit_from : 5; bit_to : 0; downto : true;
+    }
+    cell(fakeram_22x60_1r1w) {
+        area : 13287.744;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_22x60_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_22x60_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_22x60_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_22x60_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_22x60_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_22x60_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_22x60_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_22x60_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_22x60_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_256x16_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_256x16_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_256x16_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_256x16_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_256x16_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_256x16_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_256x16_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 256; bit_from : 255; bit_to : 0; downto : true;
+    }
+    type (fakeram_256x16_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 4; bit_from : 3; bit_to : 0; downto : true;
+    }
+    cell(fakeram_256x16_1r1w) {
+        area : 139530.070;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_256x16_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_256x16_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_256x16_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_256x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_256x16_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_256x16_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_256x16_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_256x16_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_256x16_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_272x16_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_272x16_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_272x16_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_272x16_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_272x16_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_272x16_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_272x16_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 272; bit_from : 271; bit_to : 0; downto : true;
+    }
+    type (fakeram_272x16_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 4; bit_from : 3; bit_to : 0; downto : true;
+    }
+    cell(fakeram_272x16_1r1w) {
+        area : 152621.376;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_272x16_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_272x16_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_272x16_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_272x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_272x16_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_272x16_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_272x16_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_272x16_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_272x16_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_32x128_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_32x128_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_32x128_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_32x128_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_32x128_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_32x128_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_32x128_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 32; bit_from : 31; bit_to : 0; downto : true;
+    }
+    type (fakeram_32x128_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    cell(fakeram_32x128_1r1w) {
+        area : 41313.373;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_32x128_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_32x128_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_32x128_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_32x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_32x128_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_32x128_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_32x128_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_32x128_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_32x128_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_4x256_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_4x256_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_4x256_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_4x256_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_4x256_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_4x256_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_4x256_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 4; bit_from : 3; bit_to : 0; downto : true;
+    }
+    type (fakeram_4x256_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 8; bit_from : 7; bit_to : 0; downto : true;
+    }
+    cell(fakeram_4x256_1r1w) {
+        area : 10540.109;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_4x256_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_4x256_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_4x256_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_4x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_4x256_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_4x256_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_4x256_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_4x256_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_4x256_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_64x16_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_64x16_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_64x16_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_64x16_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_64x16_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_64x16_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_64x16_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 64; bit_from : 63; bit_to : 0; downto : true;
+    }
+    type (fakeram_64x16_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 4; bit_from : 3; bit_to : 0; downto : true;
+    }
+    cell(fakeram_64x16_1r1w) {
+        area : 19518.720;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_64x16_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_64x16_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_64x16_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x16_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_64x16_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_64x16_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_64x16_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_64x16_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_64x16_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_64x256_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_64x256_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_64x256_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_64x256_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_64x256_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_64x256_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_64x256_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 64; bit_from : 63; bit_to : 0; downto : true;
+    }
+    type (fakeram_64x256_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 8; bit_from : 7; bit_to : 0; downto : true;
+    }
+    cell(fakeram_64x256_1r1w) {
+        area : 165120.864;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_64x256_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_64x256_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_64x256_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_64x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_64x256_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_64x256_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_64x256_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_64x256_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_64x256_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_65x160_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_65x160_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_65x160_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_65x160_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_65x160_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_65x160_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_65x160_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 65; bit_from : 64; bit_to : 0; downto : true;
+    }
+    type (fakeram_65x160_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 8; bit_from : 7; bit_to : 0; downto : true;
+    }
+    cell(fakeram_65x160_1r1w) {
+        area : 104259.994;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_65x160_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_65x160_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_65x160_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_65x160_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_65x160_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_65x160_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_65x160_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_65x160_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_65x160_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_66x64_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_66x64_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_66x64_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_66x64_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_66x64_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_66x64_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_66x64_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 66; bit_from : 65; bit_to : 0; downto : true;
+    }
+    type (fakeram_66x64_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 6; bit_from : 5; bit_to : 0; downto : true;
+    }
+    cell(fakeram_66x64_1r1w) {
+        area : 42700.954;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_66x64_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_66x64_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_66x64_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x64_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_66x64_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_66x64_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_66x64_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_66x64_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_66x64_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_66x80_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_66x80_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_66x80_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_66x80_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_66x80_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_66x80_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_66x80_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 66; bit_from : 65; bit_to : 0; downto : true;
+    }
+    type (fakeram_66x80_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    cell(fakeram_66x80_1r1w) {
+        area : 53075.904;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_66x80_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_66x80_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_66x80_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_66x80_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_66x80_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_66x80_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_66x80_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_66x80_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_66x8_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_66x8_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_66x8_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_66x8_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_66x8_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_66x8_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_66x8_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 66; bit_from : 65; bit_to : 0; downto : true;
+    }
+    type (fakeram_66x8_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 3; bit_from : 2; bit_to : 0; downto : true;
+    }
+    cell(fakeram_66x8_1r1w) {
+        area : 14013.440;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_66x8_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_66x8_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_66x8_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_66x8_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_66x8_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_66x8_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_66x8_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_66x8_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_66x8_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_6x128_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_6x128_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_6x128_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_6x128_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_6x128_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_6x128_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_6x128_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 6; bit_from : 5; bit_to : 0; downto : true;
+    }
+    type (fakeram_6x128_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    cell(fakeram_6x128_1r1w) {
+        area : 7769.952;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_6x128_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_6x128_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_6x128_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_6x128_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_6x128_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_6x128_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_6x128_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_6x128_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_6x128_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_7x256_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_7x256_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_7x256_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_7x256_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_7x256_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_7x256_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_7x256_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    type (fakeram_7x256_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 8; bit_from : 7; bit_to : 0; downto : true;
+    }
+    cell(fakeram_7x256_1r1w) {
+        area : 18042.304;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_7x256_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_7x256_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_7x256_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_7x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_7x256_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_7x256_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_7x256_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_7x256_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_7x256_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_8x256_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_8x256_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_8x256_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_8x256_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_8x256_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_8x256_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_8x256_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 8; bit_from : 7; bit_to : 0; downto : true;
+    }
+    type (fakeram_8x256_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 8; bit_from : 7; bit_to : 0; downto : true;
+    }
+    cell(fakeram_8x256_1r1w) {
+        area : 20920.064;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_8x256_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_8x256_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_8x256_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_8x256_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_8x256_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_8x256_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_8x256_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_8x256_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_8x256_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/NVDLA/sram/lib/fakeram_9x80_1r1w.lib
+++ b/designs/sky130hd/NVDLA/sram/lib/fakeram_9x80_1r1w.lib
@@ -1,0 +1,269 @@
+library(fakeram_9x80_1r1w) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram_9x80_1r1w_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram_9x80_1r1w_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram_9x80_1r1w_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram_9x80_1r1w_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 9; bit_from : 8; bit_to : 0; downto : true;
+    }
+    type (fakeram_9x80_1r1w_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 7; bit_from : 6; bit_to : 0; downto : true;
+    }
+    cell(fakeram_9x80_1r1w) {
+        area : 7510.954;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(w0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(w0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(w0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_addr_in) {
+            bus_type : fakeram_9x80_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(w0_wd_in) {
+            bus_type : fakeram_9x80_1r1w_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : w0_addr_in; clocked_on : "w0_clk"; }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "w0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(r0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(r0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_addr_in) {
+            bus_type : fakeram_9x80_1r1w_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram_9x80_1r1w_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(r0_rd_out) {
+            bus_type : fakeram_9x80_1r1w_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : r0_addr_in; }
+            timing() {
+                related_pin : "r0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram_9x80_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram_9x80_1r1w_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram_9x80_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram_9x80_1r1w_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/src/NVDLA/dev/gen_fakeram.py
+++ b/designs/src/NVDLA/dev/gen_fakeram.py
@@ -75,16 +75,29 @@ PLATFORM_PARAMS = {
         "op_cond_name": "tt_1.0_25.0",
     },
     "sky130hd": {
-        "pin_w": 0.170,
-        "pin_pitch": 0.340,
+        # Signal pin RECT spans (0, y) -> (pin_w, y + pin_w). pin_w must
+        # be wide enough to overlap met3's first vertical track at x=0.34
+        # (so set 0.5, covers x=0..0.5). pin_pitch matches met4's track
+        # pitch so each pin's Y extent always covers a met4 track,
+        # allowing DRT to stack a met3-met4 via.
+        "pin_w": 0.500,
+        "pin_pitch": 0.920,
+        # Supply rails run VERTICAL on met4 (perpendicular to met4's
+        # horizontal preferred direction). The platform's macro_grid_1
+        # connects met4-met5 with vertical met5 stripes; perpendicular
+        # met4 macro rails meet them at clean crossings with proper M4
+        # enclosure. Width 1.2 / pitch ~14.7 mirrors the working
+        # liteeth fakeram on this platform.
+        "supply_direction": "vertical",
+        "supply_rail_w": 1.200,
+        "supply_track_offset": 8.360,
+        "supply_track_pitch": 7.360,
         "snap_w": 0.460,
         "snap_h": 2.720,
         "area_per_bit": 10.0,
         "min_area": 1000,
         "pin_layer": "met3",
         "supply_layer": "met4",
-        "supply_track_offset": 0.085,
-        "supply_track_pitch": 0.340,
         "obs_layers": ["met1", "met2", "met3"],
         "nom_voltage": 1.8,
         "op_cond_name": "tt_1.0_25.0",
@@ -156,34 +169,33 @@ def gen_lef(name, width, depth, outdir, platform):
     add_pin("r0_clk", "INPUT")
     add_pin("r0_ce_in", "INPUT")
 
-    # VDD / VSS — horizontal rails on the supply layer, with rail centers
-    # snapped to that layer's routing track grid so DRT accepts the pins.
-    # VDD takes even-indexed tracks; VSS takes odd-indexed.
+    # VDD / VSS supply rails on the supply layer, snapped to that layer's
+    # routing track grid. Two orientations supported:
+    #   "horizontal" — rails run along the layer's preferred direction
+    #     (full-width thin strips stacked in Y). Works for asap7/nangate45.
+    #   "vertical" — rails run perpendicular to the preferred direction
+    #     (full-height thin strips spaced in X). Required for sky130hd:
+    #     the platform's met5 stripes that connect via macro_grid_1 are
+    #     vertical, so met4 macro rails must be vertical too to give the
+    #     M4-M5 via a perpendicular crossing with proper enclosure.
     track_off = p["supply_track_offset"]
     track_pitch = p["supply_track_pitch"]
-    rail_h = p["pin_w"]
-    # Sweep tracks within macro height. Skip tracks too close to top/bottom
-    # to keep the pin RECT inside the macro outline.
+    rail_w = p.get("supply_rail_w", p["pin_w"])
+    direction = p.get("supply_direction", "horizontal")
+    span_axis = h if direction == "horizontal" else w
     track_centers = []
     n = 0
     while True:
         c = track_off + n * track_pitch
-        if c + rail_h / 2 > h:
+        if c + rail_w / 2 > span_axis:
             break
-        if c - rail_h / 2 >= 0:
+        if c - rail_w / 2 >= 0:
             track_centers.append(c)
         n += 1
-    # Dense alternating VDD/VSS rails on every track. The macro sits under
-    # the platform's macro_grid stripes (M5 for nangate45, etc.); the PDN
-    # connect rule needs a same-polarity M4 rail under each M5 stripe to
-    # drop a via, so rails are placed every track. DRT still routes signals
-    # on lower metals (signal pins are on a different layer).
     vdd_centers = track_centers[0::2]
     vss_centers = track_centers[1::2]
 
     def add_supply(net, use, centers):
-        rail_x0 = p["snap_w"]
-        rail_x1 = w - p["snap_w"]
         lines.extend([
             f"  PIN {net}",
             f"    DIRECTION INOUT ;",
@@ -192,9 +204,13 @@ def gen_lef(name, width, depth, outdir, platform):
             f"      LAYER {p['supply_layer']} ;",
         ])
         for c in sorted(centers):
-            y0 = c - rail_h / 2
-            y1 = c + rail_h / 2
-            lines.append(f"      RECT {rail_x0:.3f} {y0:.3f} {rail_x1:.3f} {y1:.3f} ;")
+            if direction == "horizontal":
+                x0, x1 = p["snap_w"], w - p["snap_w"]
+                y0, y1 = c - rail_w / 2, c + rail_w / 2
+            else:  # vertical
+                x0, x1 = c - rail_w / 2, c + rail_w / 2
+                y0, y1 = p["snap_h"], h - p["snap_h"]
+            lines.append(f"      RECT {x0:.3f} {y0:.3f} {x1:.3f} {y1:.3f} ;")
         lines.extend([
             "    END",
             f"  END {net}",


### PR DESCRIPTION
## Summary

Port NVDLA partitions a, c, m, o, p from asap7 to sky130hd, mirroring the nangate45 port from #95. Per-partition tuning calibrated from sky130hd cross-platform references (NyuziProcessor / cnn / liteeth): clocks ~10× slower than asap7, util −15 to −20%, halo ~6× asap7.

## Status

| partition | period (ns) | WS (ns) | TNS | inst | macros | util | status |
|---|---|---|---|---|---|---|---|
| a | 15.0 | (post-merge: see CI) | 0 | ~50k | 2 | 35% | ✅ Complete on k8s |
| **c** | **15.0** | — | — | **1.7M** | **84** | **25%** | ⏳ **Still in global placement** at PR open time |
| m | 15.0 | (post-merge) | 0 | ~30k | 0 | 45% | ✅ Complete on k8s |
| o | 20.0 / 25.0 | (post-merge) | 0 | ~520k | 18 | 20% | ✅ Complete on k8s |
| p | 15.0 | (post-merge) | 0 | ~200k | 6 | 20% | ✅ Complete on k8s |

partition_c's `partition_c_final` build is still in global placement on the cluster (5+ hours into GPL on a 14-core node, ~74 CPU-hours consumed) — sky130's coarse track pitch + 1.7M instances + 84 macros at util=25 makes the placement engine genuinely slow. The config is committed now; the build will hit the remote cache once placement finishes locally.

## What's added

- **`designs/sky130hd/NVDLA/`** — top-level `BUILD.bazel` with per-partition SRAM filegroups, plus per-partition `BUILD.bazel` + `constraint.sdc`.
- **`designs/sky130hd/NVDLA/sram/{lef,lib}`** — 20 sky130hd FakeRAM macros covering all sizes used by partitions a/c/o/p.
- **`designs/src/NVDLA/dev/gen_fakeram.py`** — generator extended with sky130hd-specific platform parameters (see notes below).

## FakeRAM generator updates — sky130hd lessons

Five sky130hd-specific platform parameters added to `PLATFORM_PARAMS`, each found by iterating against k8s build failures:

1. **PDN-0006 (\"VDD on metal3 is blocked by obstructions on metal4\")** — `supply_layer` must be one above the signal layer (met4 vs met3) so the platform's `CORE_macro_grid_1` met4-met5 connect rule has a met4 power pin to land on. Also drop the supply layer from `OBS`.

2. **DRT-0073 (\"No access point\" on signal pins)** — pin RECT must overlap the layer's routing track in **both** axes so the via stack from met3 → met4 → ... has a clean drop site. Set `pin_w 0.5` (covers met3 x-track at 0.34) and `pin_pitch 0.92` (= met4 y_pitch).

3. **PDN-0110 (\"No via inserted between met4 and met5\")** — the M4-M5 via cut needs enough M4 enclosure. Add `supply_rail_w` (sky130 = 0.92, ≥ via cut + enclosure).

4. **PSM-0069 + PDN-0110 with horizontal rails** — supply rails must be **perpendicular** to the supply layer's preferred direction so the layer above can cross them at clean intersections. Add `supply_direction` (sky130 = `\"vertical\"` since met4 is horizontal-preferred). asap7 / nangate45 keep horizontal rails (default).

5. **GRT-0116 / GRT-0183 (routing congestion)** — partition_o and partition_p needed `CORE_UTILIZATION` lowered to 20% and `MACRO_PLACE_HALO` raised to 40-60μm to give global routing room to escape macro pin clusters.

## Test plan

- [x] partition_a, m, o, p complete RTL-to-GDS on the Nautilus k8s cluster
- [x] PSM-0040 reports both VDD and VSS fully connected for all four
- [x] Zero TNS, positive WS for all four
- [ ] partition_c completes once global placement converges (in progress at PR open)