### PR TITLE
Bump bazel-orfs submodule to HEAD; deprecate Make flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,22 +8,20 @@ HighTide is a VLSI design benchmark suite built on OpenROAD-flow-scripts (ORFS).
 
 ## Setup
 
-There are two build flows: the original **Make flow** (Docker-based) and the newer **Bazel flow** (native).
-
-### Make Flow Setup
-
-```bash
-./setup.sh            # Init ORFS submodule, create symlinks (scripts/, util/, platforms/)
-./runorfs.sh           # Launch Docker container with OpenROAD tools
-```
+There are two build flows: the **Bazel flow** (native, recommended) and the **Make flow** (Docker-based, *deprecated and scheduled for removal — [#100](https://github.com/VLSIDA/HighTide/issues/100)*).
 
 ### Bazel Flow Setup
 
-Requires an Ubuntu machine with:
-- [Bazelisk](https://github.com/bazelbuild/bazelisk) (or Bazel 7.6.1+)
-- Docker (for bazel-orfs tool extraction from ORFS image)
+Requires an Ubuntu machine with [Bazelisk](https://github.com/bazelbuild/bazelisk) (or Bazel 7.6.1+).  No additional setup needed — Bazel fetches everything via `MODULE.bazel` and the pinned `bazel-orfs` submodule.
 
-No additional setup needed — Bazel fetches ORFS and bazel-orfs automatically via `MODULE.bazel`.
+### Make Flow Setup (deprecated)
+
+> The Make flow is no longer maintained.  Since the bazel-orfs upgrade (#71) the Docker image tag is no longer tracked in `MODULE.bazel`, so `setup.sh` / `runorfs.sh` / `runorfs_ni.sh` are broken until the image is wired back manually.  Use the Bazel flow.
+
+```bash
+./setup.sh            # Init ORFS submodule, create symlinks (scripts/, util/, platforms/)
+./runorfs.sh          # Launch Docker container with OpenROAD tools
+```
 
 ## Build Commands
 
@@ -54,7 +52,7 @@ bazel build //designs/asap7/lfsr:lfsr_place
 
 Note: `hightide_design()` exposes only the per-stage `orfs_flow` targets (`_synth` … `_final`) plus `_generate_abstract` / `_generate_metadata`. There is no aggregate `:<design>` target — use `:<design>_final` for the full flow.
 
-### Make Flow (legacy)
+### Make Flow (deprecated, scheduled for removal)
 
 ```bash
 # Run full flow for a design (default: asap7/lfsr)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,12 +41,10 @@ local_path_override(
 bazel_dep(name = "orfs")
 git_override(
     module_name = "orfs",
-    commit = "2f4de31a0f3f6402ca74887f67b75a9303c6e061",
+    commit = "172bd233dabd45d04cd80062cd1894e5ac8e5d52",
     patch_strip = 1,
     patches = [
         "//patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
-        "//patches:orfs-preserve-tool-exe-env.patch",
-        "//patches:orfs-log-cmd-clock-fallback.patch",
     ],
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git",
 )
@@ -54,7 +52,7 @@ git_override(
 bazel_dep(name = "openroad")
 git_override(
     module_name = "openroad",
-    commit = "5f1bd87f37fd3c6dc83ad2195cc63b7b366771bc",
+    commit = "578be38ad2297637e938cbc9cb35e5a05d8936ff",
     init_submodules = True,
     remote = "https://github.com/The-OpenROAD-Project/OpenROAD.git",
 )

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The release RTL is then run through the [OpenROAD-flow-scripts](https://github.c
 - **[Architecture](docs/architecture.md)** — build system, flow stages, RTL management, caching
 - **[Adding Designs](docs/adding-designs.md)** — how to add a new design to the suite
 - **[Kubernetes Builds](k8s/README.md)** — building at scale on NRP Nautilus
-- **[Legacy Make Flow](docs/make-flow.md)** — Docker-based Make flow (still functional)
+- **[Legacy Make Flow](docs/make-flow.md)** — Docker-based Make flow (**deprecated**, scheduled for removal — use the Bazel flow)

--- a/docs/make-flow.md
+++ b/docs/make-flow.md
@@ -1,6 +1,15 @@
 # Legacy Make Flow
 
-The original HighTide build flow uses GNU Make and Docker. It is still functional but the **Bazel flow is recommended** for new work — see the [Quick Start Guide](quickstart.md).
+> **⚠️ DEPRECATED — scheduled for removal ([#100](https://github.com/VLSIDA/HighTide/issues/100)).**
+>
+> The Make flow is no longer maintained.  Since the bazel-orfs upgrade
+> ([#71](https://github.com/VLSIDA/HighTide/pull/71)) the Docker image
+> tag is no longer tracked in `MODULE.bazel`, so `setup.sh` /
+> `runorfs.sh` / `runorfs_ni.sh` will fail until that's wired back
+> manually.  All new work should use the [Bazel flow](quickstart.md);
+> this document is kept for reference until the Make flow is removed.
+
+The original HighTide build flow uses GNU Make and Docker.
 
 ## Setup
 

--- a/patches/orfs-log-cmd-clock-fallback.patch
+++ b/patches/orfs-log-cmd-clock-fallback.patch
@@ -1,1 +1,0 @@
-../bazel-orfs/patches/orfs-log-cmd-clock-fallback.patch

--- a/patches/orfs-preserve-tool-exe-env.patch
+++ b/patches/orfs-preserve-tool-exe-env.patch
@@ -1,1 +1,0 @@
-../bazel-orfs/patches/orfs-preserve-tool-exe-env.patch


### PR DESCRIPTION
## Summary

- Bump `bazel-orfs` submodule `232b2ea4` → `d9f8b757` (10 commits, including bumped orfs/openroad and the `behavioral_macros VDD/VSS` PDN fix).
- Sync root `MODULE.bazel` overrides: `orfs@2f4de31a` → `172bd233`, `openroad@5f1bd87f` → `578be38a`. Drop two upstream-absorbed orfs patches.
- Mark the Make flow deprecated in `README.md`, `CLAUDE.md`, and `docs/make-flow.md`, pointing at #100 for tracked removal. Code untouched.

## LFSR PPA delta (asap7) — bump only

| Metric | Pre-bump | Post-bump | Δ |
|---|---:|---:|---:|
| Total power | 0.910 mW | 0.909 mW | **−0.03%** |
| WNS | −104.26 ps | −105.16 ps | −0.90 ps |
| TNS | −1423.79 ps | −1412.77 ps | +11.02 ps |
| Cell area | 26.93 µm² | 26.93 µm² | 0 |
| Std-cell count | 216 | 216 | 0 |

Functionally a no-op for lfsr — same netlist, ≤1% power drift, ~1 ps timing wobble from updated openroad/orfs.

## Test plan

- [x] `bazel build //designs/asap7/lfsr:lfsr_final` — clean build, QoR within noise of pre-bump baseline
- [x] `bazel build //designs/{asap7,nangate45,sky130hd}/lfsr:lfsr_final` — all three platforms succeed; nangate45 closes timing, sky130hd −0.19 ps, asap7 −105 ps (intentionally aggressive SDC)
- [x] Round-trip swap (pre → post → pre) verified action keys and PPA reproducibility

## Out of scope

- Make-flow code removal — deferred to #100.
- Wiring a Docker image tag back into `MODULE.bazel` for `runorfs.sh` / `setup.sh` — not needed for the Bazel flow.