### PR TITLE
summary.sh: preserve variant names in incomplete-builds list

### DIFF
--- a/tools/summary.sh
+++ b/tools/summary.sh
@@ -96,7 +96,10 @@ echo "Incomplete builds:"
 find "$BIN_DIR/designs" -path "*/results/*/1_synth.odb" -not -path "*.runfiles*" 2>/dev/null | sort -u | while read -r synth; do
     dir=$(dirname "$synth")
     if [ ! -f "${dir}/6_final.gds" ] && [ ! -f "${dir}/6_final.odb" ]; then
-        rel="${synth#$BIN_DIR/designs/}"
+        # Parse from the inner results subtree so per-variant names
+        # (e.g. liteeth_mac_axi_mii) are preserved instead of collapsing
+        # to the parent dir (liteeth).  Mirrors the success loop above.
+        rel="${synth##*/results/}"
         platform="${rel%%/*}"
         rel="${rel#*/}"
         design="${rel%%/*}"


### PR DESCRIPTION
The "Incomplete builds" loop in `tools/summary.sh` strips `$BIN_DIR/designs/` and takes the second path segment as the design name.  For multi-variant designs that path looks like:

```
bazel-bin/designs/sky130hd/liteeth/liteeth_udp_raw_rgmii/results/sky130hd/liteeth_udp_raw_rgmii/base/1_synth.odb
                          ^^^^^^^^ ^^^^^^^^^^^^^^^^^^^^^
                          parent   variant subdir
```

so the second segment is the parent dir (`liteeth`), and all six liteeth variants collapse into one `sky130hd/liteeth — stopped at ...` line.

Fix: parse from `*/results/<platform>/<design>/...` (the inner subtree, which contains the top-module name), matching the success loop a few lines up.

Before:
```
Incomplete builds:
  sky130hd/liteeth — stopped at 1_synth
```
After:
```
Incomplete builds:
  sky130hd/liteeth_udp_raw_rgmii — stopped at 1_synth
```

Side benefit: failure-loop and success-loop now use the same naming scheme.

## Test plan

- [x] Run `./tools/summary.sh` against current local `bazel-bin/`; verify per-variant rows in the failure list.