### PR TITLE
Relax minimax clock periods to match achievable Fmax

### DIFF
--- a/designs/asap7/minimax/constraint.sdc
+++ b/designs/asap7/minimax/constraint.sdc
@@ -1,7 +1,7 @@
 current_design minimax
 
 set clk_name clk
-set clk_period 400
+set clk_period 900
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/minimax/constraint.sdc
+++ b/designs/nangate45/minimax/constraint.sdc
@@ -1,7 +1,7 @@
 current_design minimax
 
 set clk_name clk
-set clk_period 0.8
+set clk_period 1.6
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/minimax/constraint.sdc
+++ b/designs/sky130hd/minimax/constraint.sdc
@@ -1,7 +1,7 @@
 current_design minimax
 
 set clk_name clk
-set clk_period 4
+set clk_period 8
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]


### PR DESCRIPTION
## Summary
- The minimax constraints on all three platforms were ~50% of the design's actual achievable clock period, producing 2000+ setup violations on every build (WNS as much as 75% of the clock period).
- The worst setup path on every platform is the same shape: ~30-level combinational chain through ALU output → `register_file[*][*]/D`. Since HighTide RTL is a fixed benchmark input, the fix is purely constraint-side: relax each `clk_period` to the platform's `period_min` (with a small margin).

| Platform   | Old | New | Period_min after fix | WNS  | Fmax     |
|------------|-----|-----|----------------------|------|----------|
| asap7      | 400 ps | **900 ps** | 895.22 ps | +4.8 ps  | 1.117 GHz |
| nangate45  | 0.8 ns | **1.6 ns** | 1.59 ns   | +9.9 ps  | 629 MHz   |
| sky130hd   | 4 ns   | **8 ns**   | 7.69 ns   | +310 ps  | 130 MHz   |

asap7 needed extra slack (900 ps vs the naïve 2× = 800 ps) because synthesis becomes less aggressive at relaxed targets, drifting `period_min` upward; 900 ps is the first round number that closes cleanly.

## Test plan
- [x] `bazel build //designs/asap7/minimax:minimax_final //designs/nangate45/minimax:minimax_final //designs/sky130hd/minimax:minimax_final` — all three close with 0 setup violations.
- [x] `report_clock_min_period` confirms positive slack on every platform.
- [ ] Optional follow-up: run `/optimize-ppa` to see if any of the new clock targets can be tightened further.