### PR TITLE
Relax lfsr clock periods to match achievable Fmax

### DIFF
--- a/designs/asap7/lfsr/constraint.sdc
+++ b/designs/asap7/lfsr/constraint.sdc
@@ -2,7 +2,7 @@ current_design lfsr_prbs_gen
 
 set clk_name  core_clock
 set clk_port_name clk
-set clk_period 108
+set clk_period 700
 set clk_io_pct 0.8
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/sky130hd/lfsr/constraint.sdc
+++ b/designs/sky130hd/lfsr/constraint.sdc
@@ -2,7 +2,7 @@ current_design lfsr_prbs_gen
 
 set clk_name  core_clock
 set clk_port_name clk
-set clk_period 1.1
+set clk_period 1.4
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]


### PR DESCRIPTION
## Summary

asap7 and sky130hd `lfsr` constraints were producing failing setup paths on every build. nangate45 already meets timing (+130 ps slack) and is left alone.

Worst negative slack at HEAD:

| Platform | Period | WNS | TNS | Failing endpoints |
|---|---|---|---|---|
| asap7    | 108 ps | -105.16 ps | -1412.77 ps | 39 |
| sky130hd | 1.1 ns | -0.19 ns | -0.98 ns | 8 |

The RTL is fixed (HighTide is a benchmark suite), so the fix is purely constraint-side, mirroring #108 (minimax-clock-relax).

| Platform | Old | New | New WNS | Fmax |
|---|---|---|---|---|
| asap7    | 108 ps | **700 ps** | +12.4 ps | 1.454 GHz |
| sky130hd | 1.1 ns | **1.4 ns** | +10 ps   | 720 MHz |

asap7 needed a much larger relax than sky130hd because synthesis becomes less aggressive at slack targets and period_min drifts upward each iteration: 108→213, 230→311, 350→407, 700→688. The 700 ps target is the first round number above the converged period_min.

Note: commit 76d19b21 (Apr 8) reported 9.26 GHz Fmax at 108 ps; today the same RTL closes at 1.45 GHz. Something in the platform/tool stack has regressed asap7 lfsr's achievable Fmax by ~6.5× since then. This PR just realigns the SDC with what currently closes; bisecting the regression is left as future work.

## Test plan

- [x] `bazel build //designs/asap7/lfsr:lfsr_final` — closes with WNS +12.4 ps
- [x] `bazel build //designs/nangate45/lfsr:lfsr_final` — unchanged, WNS +127 ps
- [x] `bazel build //designs/sky130hd/lfsr:lfsr_final` — closes with WNS +10 ps