### PR TITLE
Update sky130hd NVDLA build status (a/m/o/p closing; c not finishing)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,17 +129,19 @@ Dev mode requires: `git submodule update --init designs/src/<design>/dev/repo` b
 | nangate45 | 45nm | coralnpu, gemmini, lfsr, minimax, NyuziProcessor, sha3, liteeth (6 variants), bp_processor (bp_uno, bp_quad), cnn |
 | sky130hd | 130nm open | gemmini, lfsr, minimax, sha3, liteeth (mac_axi_mii, mac_wb_mii, udp_stream_rgmii, udp_usp_gth_sgmii), cnn, liteeth (udp_raw_rgmii, udp_stream_sgmii) |
 
-#### Build status (as of 2026-04-26)
+#### Build status (as of 2026-05-02)
 
 Designs reaching `_final` (cached on remote build cache):
 - **asap7**: coralnpu, gemmini, lfsr, minimax, sha3, vortex, all 6 liteeth variants, NVDLA partitions a/m/o
 - **nangate45**: coralnpu, gemmini, lfsr, minimax, NyuziProcessor, sha3, all 6 liteeth variants
-- **sky130hd**: gemmini, lfsr, minimax, sha3, all 6 liteeth variants
+- **sky130hd**: gemmini, lfsr, minimax, sha3, all 6 liteeth variants, NVDLA partitions a/m/o/p
 
 Not yet finishing (not cached):
 - **asap7**: cnn, floonoc, NyuziProcessor, snitch_cluster, bp_processor (bp_uno, bp_quad), NVDLA partitions c, p
 - **nangate45**: cnn, bp_processor (bp_uno, bp_quad)
-- **sky130hd**: cnn
+- **sky130hd**: cnn, NVDLA partition c
+
+`sky130hd/NVDLA/partition_c` global placement plateaus at overflow ~0.31 (target 0.10) — 84 macros at sky130hd's coarse pitches create local density hot spots near macro pin clusters that the placer can't smooth out. Loosening `CORE_UTILIZATION` / `PLACE_DENSITY_LB_ADDON` / `MACRO_PLACE_HALO` to match working partitions doesn't fix it. Likely needs a manual `macros.tcl` to spread the 84 SRAMs into a regular grid.
 
 Use `tools/fetch_cache.sh` to pull cached `_final` results from the remote cache; designs marked NOT CACHED there are the not-yet-finishing set above.
 


### PR DESCRIPTION
Investigated NVDLA partition_c and partition_o on sky130hd.

## partition_o ✅
Closes through 6_final on the rebuilt source-built toolchain.  Verified locally:
- 1,599,803 instances post-fill, 18 macros
- WNS = +1.25 ns on \`nvdla_core_clk\` (target 20 ns), TNS = 0
- fmax = 54 MHz, 0 DRCs, 286.6 mW total power

partitions a / m / p were already closing.  Adding all four to the working list.

## partition_c ❌ (still broken)
Global placement plateaus at overflow ~0.31 against the default 0.10 convergence target — the placer cannot escape a local optimum despite making real iterations.  Verified across multiple param combinations:

| Attempt | Result |
|---|---|
| Default (\`CORE_UTILIZATION=25\`, addon 0.30, halo 30) | overflow 0.43 |
| Match \`partition_o\` (\`util=20\`, addon 0.15, halo 60) | overflow 0.32 |
| \`GPL_TIMING_DRIVEN=0\` to skip inner repair pass | doesn't help — GP itself is the bottleneck |
| Clock relax 15 → 25 → 70 ns | "193987 nets remaining" is total nets, not violators |

**Why**: 84 macros (4× partition_o's 18) on a 52 M µm² die at sky130hd's coarse pitches concentrate net traffic near macro pin clusters, creating local density hot spots even though global utilization is only ~5% std-cell.  No flow-knob combination smooths them out.

**Likely remediation** (out of scope for this PR): manual \`macros.tcl\` to spread the 84 SRAMs into a regular grid, leaving a clear stdcell core region.  That's an /optimize-ppa or /port-design effort rather than a doc fix.

## Test plan
- [x] \`bazel build //designs/sky130hd/NVDLA/partition_o:partition_o_final\` — 6_final + reports produced via remote-cache hits, 30 s wall.
- [x] \`./tools/summary.sh\` shows \`sky130hd NV_NVDLA_partition_o\` row and "Incomplete builds: sky130hd/NV_NVDLA_partition_c — stopped at 2_floorplan" line.