### PR TITLE
Migrate Bazel remote cache from GCS to self-hosted bazel-remote

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,9 +3,12 @@
 # submodule not being checked out doesn't break bazel invocations.
 try-import %workspace%/bazel-orfs/.bazelrc
 
-# Remote cache (Google Cloud Storage) — publicly readable, auth required to write.
-# To enable writes: gcloud auth application-default login
-build --remote_cache=https://storage.googleapis.com/hightide-bazel-cache
+# Remote cache (self-hosted bazel-remote on donut, fronted by Cloudflare Tunnel) —
+# publicly readable, auth required to write.  To enable writes, add to .bazelrc.user
+# (gitignored):
+#   build --remote_cache=https://USER:TOKEN@cache.hightide-benchmarks.dev
+#   build --remote_upload_local_results=true
+build --remote_cache=https://cache.hightide-benchmarks.dev
 build --remote_upload_local_results=false
 
 # Local disk cache as fallback

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,11 +1,11 @@
 # Kubernetes Builds on NRP Nautilus
 
-HighTide uses the [National Research Platform (NRP) Nautilus](https://nationalresearchplatform.org/nautilus/) Kubernetes cluster to build designs at scale. Each design is submitted as a separate K8s Job, and build results are uploaded to a shared GCS remote cache.
+HighTide uses the [National Research Platform (NRP) Nautilus](https://nationalresearchplatform.org/nautilus/) Kubernetes cluster to build designs at scale. Each design is submitted as a separate K8s Job, and build results are uploaded to a shared `bazel-remote` HTTP cache hosted at `cache.hightide-benchmarks.dev`.
 
 ## Prerequisites
 
 - `kubectl` configured with access to the NRP Nautilus cluster
-- Namespace `vlsida` with the `gcs-bazel-cache` secret for cache uploads
+- Namespace `vlsida` with the `bazel-cache-creds` secret for cache uploads (key `url` = `https://USER:TOKEN@cache.hightide-benchmarks.dev`).  Without it, jobs run with anonymous read-only access to the cache.
 
 See the [NRP Nautilus documentation](https://docs.nrp-nautilus.io/) for cluster access and configuration.
 
@@ -37,7 +37,7 @@ Each invocation of `run.sh` creates one K8s Job per matching design. Jobs clone 
 | `--branch BRANCH` | `main` | Git branch to build |
 | `--cpu NUM` | `8` | CPU request per job |
 | `--mem SIZE` | `64Gi` | Memory request per job (limit is 2x) |
-| `--upload-artifacts` | off | Upload `bazel-bin` artifacts to GCS for debug (see below) |
+| `--upload-artifacts` | off | Save `bazel-bin` artifacts to the `hightide-artifacts` PVC for debug (see below) |
 | `--dry-run` | | Print YAML without submitting |
 
 ## Monitoring Jobs
@@ -72,7 +72,7 @@ Jobs can be deleted by platform, design, or both. Deletion uses Kubernetes label
 
 ## Remote Cache
 
-Jobs are configured with a GCS remote cache (`--remote_cache`). When the `gcs-bazel-cache` secret is present in the namespace, jobs upload build results after completion. This enables:
+Jobs are configured with a self-hosted `bazel-remote` HTTP cache (`--remote_cache=https://cache.hightide-benchmarks.dev`).  Reads are public/anonymous; uploads require the `bazel-cache-creds` secret in the namespace.  When the secret is present, jobs upload build results after completion.  This enables:
 
 1. **Faster rebuilds** — subsequent jobs for the same design hit the cache
 2. **Local fetching** — developers can pull baseline results without building locally
@@ -172,5 +172,4 @@ Jobs have `backoffLimit: 1` (one retry on failure) and `ttlSecondsAfterFinished:
 | Volume | Type | Purpose |
 |--------|------|---------|
 | `repo` | emptyDir | Cloned repo (ephemeral) |
-| `gcs-key` | Secret (`gcs-bazel-cache`, optional) | GCS credentials for remote cache |
 | `artifacts` | PVC (`hightide-artifacts`) | Persistent artifact storage for debug |

--- a/k8s/job-template.yaml
+++ b/k8s/job-template.yaml
@@ -61,13 +61,16 @@ spec:
 
           cd /repo
 
-          # Build the design with remote cache (upload if credentials available)
-          CACHE_FLAGS="--remote_cache=https://storage.googleapis.com/hightide-bazel-cache"
-          if [ -f /secrets/gcs/key.json ]; then
-            echo "GCS credentials found, enabling cache upload"
-            CACHE_FLAGS="$CACHE_FLAGS --remote_upload_local_results=true --google_credentials=/secrets/gcs/key.json"
+          # Build the design with remote cache (upload if credentials available).
+          # BAZEL_CACHE_URL is injected from the bazel-cache-creds Secret in the form
+          # https://USER:TOKEN@cache.hightide-benchmarks.dev.  When unset (Secret missing
+          # or readers without write access), fall back to the public read-only URL.
+          if [ -n "${BAZEL_CACHE_URL:-}" ]; then
+            echo "Cache credentials found, enabling cache upload"
+            CACHE_FLAGS="--remote_cache=$BAZEL_CACHE_URL --remote_upload_local_results=true"
           else
-            echo "WARNING: GCS credentials not found, cache is read-only"
+            echo "WARNING: cache credentials not found, cache is read-only"
+            CACHE_FLAGS="--remote_cache=https://cache.hightide-benchmarks.dev"
           fi
 
           # When uploading artifacts, force download of all intermediate
@@ -106,12 +109,16 @@ spec:
           fi
 
           exit $BUILD_RC
+        env:
+        - name: BAZEL_CACHE_URL
+          valueFrom:
+            secretKeyRef:
+              name: bazel-cache-creds
+              key: url
+              optional: true
         volumeMounts:
         - name: repo
           mountPath: /repo
-        - name: gcs-key
-          mountPath: /secrets/gcs
-          readOnly: true
         - name: artifacts
           mountPath: /artifacts
         resources:
@@ -124,10 +131,6 @@ spec:
       volumes:
       - name: repo
         emptyDir: {}
-      - name: gcs-key
-        secret:
-          secretName: gcs-bazel-cache
-          optional: true
       - name: artifacts
         persistentVolumeClaim:
           claimName: hightide-artifacts

--- a/k8s/run.sh
+++ b/k8s/run.sh
@@ -16,7 +16,7 @@
 #   --branch BRANCH    Git branch to build (default: current branch)
 #   --cpu NUM          CPU request per job (default: 8)
 #   --mem SIZE         Memory request per job (default: 64Gi)
-#   --upload-artifacts Upload build artifacts (bazel-bin) to GCS for debug
+#   --upload-artifacts Save build artifacts (bazel-bin) to the hightide-artifacts PVC for debug
 #   --dry-run          Print generated YAML without submitting
 #   --status           Show status of submitted jobs
 #   --delete           Delete jobs (filtered by platform/design args)

--- a/tools/clear-cache.sh
+++ b/tools/clear-cache.sh
@@ -1,24 +1,19 @@
 #!/bin/bash
-# Clear the remote Bazel cache for specific designs.
+# Clear the local Bazel cache and bazel-bin outputs for specific designs.
 #
-# This works by invalidating the cache entries — it runs a no-op build with
-# --remote_upload_local_results=true after cleaning the local build artifacts,
-# which causes Bazel to rebuild and overwrite stale cache entries.
-#
-# For the GCS bucket, this script directly deletes cached action results using
-# gsutil (requires gcloud auth with write access to the bucket).
+# The remote cache (cache.hightide-benchmarks.dev) is content-addressed and
+# self-evicting via LRU — there is no client-side way to wipe it.  To force
+# a fresh build that overwrites cached results, rebuild with the flags shown
+# at the end of this script's output.
 #
 # Usage:
-#   ./k8s/clear-cache.sh [platform] [design]   # clear a specific design
-#   ./k8s/clear-cache.sh [platform]             # clear all designs for a platform
-#   ./k8s/clear-cache.sh --design [design]      # clear a design across all platforms
-#   ./k8s/clear-cache.sh --all                  # clear the entire cache
-#   ./k8s/clear-cache.sh --local                # clear local disk cache only
+#   ./tools/clear-cache.sh [platform] [design]   # clear a specific design
+#   ./tools/clear-cache.sh [platform]             # clear all designs for a platform
+#   ./tools/clear-cache.sh --design [design]      # clear a design across all platforms
+#   ./tools/clear-cache.sh --all                  # clear all local caches
 #
 # Options:
-#   --local    Only clear local disk cache (no GCS changes)
-#   --remote   Only clear remote GCS cache
-#   --all      Clear the entire cache (local + remote)
+#   --all      Clear the entire local cache (disk cache + bazel output base)
 #   --dry-run  Show what would be cleared without doing it
 
 set -euo pipefail
@@ -26,12 +21,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DISK_CACHE="${HOME}/.cache/bazel-disk-cache"
-GCS_BUCKET="gs://hightide-bazel-cache"
 
 # Defaults
 DRY_RUN=false
-CLEAR_LOCAL=true
-CLEAR_REMOTE=true
 CLEAR_ALL=false
 FILTER_PLATFORM=""
 FILTER_DESIGN=""
@@ -39,8 +31,6 @@ FILTER_DESIGN=""
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --local)    CLEAR_REMOTE=false; shift ;;
-        --remote)   CLEAR_LOCAL=false; shift ;;
         --all)      CLEAR_ALL=true; shift ;;
         --dry-run)  DRY_RUN=true; shift ;;
         --design)   FILTER_DESIGN="$2"; shift 2 ;;
@@ -63,34 +53,21 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$CLEAR_ALL" == true ]]; then
-    echo "Clearing entire Bazel cache..."
+    echo "Clearing all local Bazel caches..."
 
-    if [[ "$CLEAR_LOCAL" == true ]]; then
-        echo -n "  Local disk cache ($DISK_CACHE)... "
-        if [[ "$DRY_RUN" == true ]]; then
-            echo "would delete"
-        else
-            rm -rf "$DISK_CACHE"
-            echo "cleared"
-        fi
+    echo -n "  Local disk cache ($DISK_CACHE)... "
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "would delete"
+    else
+        rm -rf "$DISK_CACHE"
+        echo "cleared"
     fi
 
-    if [[ "$CLEAR_REMOTE" == true ]]; then
-        echo -n "  Remote GCS cache ($GCS_BUCKET)... "
-        if [[ "$DRY_RUN" == true ]]; then
-            echo "would delete all objects"
-        else
-            gsutil -m rm -r "${GCS_BUCKET}/**" 2>/dev/null && echo "cleared" || echo "already empty or no access"
-        fi
-    fi
-
-    if [[ "$CLEAR_LOCAL" == true ]]; then
-        echo -n "  Bazel output base... "
-        if [[ "$DRY_RUN" == true ]]; then
-            echo "would run bazel clean"
-        else
-            (cd "$REPO_DIR" && bazel clean 2>/dev/null) && echo "cleaned" || echo "skipped"
-        fi
+    echo -n "  Bazel output base... "
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "would run bazel clean"
+    else
+        (cd "$REPO_DIR" && bazel clean 2>/dev/null) && echo "cleaned" || echo "skipped"
     fi
 
     exit 0
@@ -140,37 +117,20 @@ if [[ ${#DESIGNS[@]} -eq 0 ]]; then
     exit 1
 fi
 
-echo "Clearing cache for ${#DESIGNS[@]} design(s)..."
-echo "  Local:  $CLEAR_LOCAL"
-echo "  Remote: $CLEAR_REMOTE"
+echo "Clearing local bazel-bin outputs for ${#DESIGNS[@]} design(s)..."
 echo ""
 
 for entry in "${DESIGNS[@]}"; do
     IFS='|' read -r platform name relpath target <<< "$entry"
     echo -n "  $platform/$name ... "
 
-    if [[ "$CLEAR_LOCAL" == true ]]; then
-        # Clear local bazel-bin outputs for this design
-        local_dir="$REPO_DIR/bazel-bin/designs/$relpath"
-        if [[ -d "$local_dir" ]]; then
-            if [[ "$DRY_RUN" == true ]]; then
-                echo -n "would delete $local_dir "
-            else
-                rm -rf "$local_dir"
-                echo -n "local "
-            fi
-        fi
-    fi
-
-    if [[ "$CLEAR_REMOTE" == true ]]; then
-        # Bazel remote cache uses content-addressed hashes, not design paths.
-        # We can't selectively delete by design from GCS without knowing the hashes.
-        # Instead, we force Bazel to rebuild by modifying the action environment.
-        # The simplest approach: tell the user to rebuild with --noremote_accept_cached.
+    local_dir="$REPO_DIR/bazel-bin/designs/$relpath"
+    if [[ -d "$local_dir" ]]; then
         if [[ "$DRY_RUN" == true ]]; then
-            echo -n "remote: use --noremote_accept_cached to force rebuild "
+            echo -n "would delete $local_dir "
         else
-            echo -n "(rebuild with: bazel build --noremote_accept_cached $target) "
+            rm -rf "$local_dir"
+            echo -n "local "
         fi
     fi
 
@@ -179,10 +139,10 @@ done
 
 echo ""
 echo "Note: The remote cache is content-addressed and cannot be selectively"
-echo "cleared by design name. To force a fresh build that overwrites cached"
-echo "results, rebuild with:"
+echo "cleared by design name.  To force a fresh build that re-executes actions"
+echo "and overwrites cached entries, rebuild with:"
 echo ""
-echo "  bazel build --noremote_accept_cached --remote_upload_local_results=true \\"
-echo "    --google_credentials=/path/to/key.json <target>"
+echo "  bazel build --noremote_accept_cached --remote_upload_local_results=true <target>"
 echo ""
-echo "To clear the entire remote cache, use: ./tools/clear-cache.sh --all"
+echo "(--remote_upload_local_results=true also requires the write credential in"
+echo " ~/HighTide/.bazelrc.user; readers without it will only re-execute locally.)"

--- a/tools/fetch_cache.sh
+++ b/tools/fetch_cache.sh
@@ -19,7 +19,7 @@ set -uo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
 
-REMOTE_CACHE="https://storage.googleapis.com/hightide-bazel-cache"
+REMOTE_CACHE="https://cache.hightide-benchmarks.dev"
 TIMEOUT=30
 STAGE="final"
 FILTER_PLATFORM=""

--- a/tools/test-cache.sh
+++ b/tools/test-cache.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Smoke-test the HighTide bazel-remote cache (cache.hightide-benchmarks.dev).
+# Runs from any machine with curl + sha256sum/shasum + openssl.
+#
+# Usage:
+#   ./test-cache.sh                   # anonymous read-only check
+#   ./test-cache.sh -u USER -p TOKEN  # full read+write check (needs the shared write credential)
+#   USER=... PASS=... ./test-cache.sh # same, via env vars
+set -euo pipefail
+
+HOST="${HOST:-cache.hightide-benchmarks.dev}"
+URL="https://${HOST}"
+USER="${USER:-}"
+PASS="${PASS:-}"
+while getopts "u:p:h:" opt; do
+  case "$opt" in
+    u) USER="$OPTARG" ;;
+    p) PASS="$OPTARG" ;;
+    h) URL="https://$OPTARG" ;;
+    *) echo "usage: $0 [-u user] [-p pass] [-h host]"; exit 2 ;;
+  esac
+done
+
+# Pick the right SHA256 tool (Linux uses sha256sum, macOS ships shasum)
+sha256() {
+  if command -v sha256sum >/dev/null; then sha256sum | awk '{print $1}';
+  else                                     shasum -a 256 | awk '{print $1}'; fi
+}
+
+pass=0; fail=0
+check() {
+  local name=$1 expect=$2 got=$3
+  if [[ "$got" == "$expect" ]]; then echo "  PASS  $name (got $got)"; pass=$((pass+1));
+  else                               echo "  FAIL  $name (expected $expect, got $got)"; fail=$((fail+1)); fi
+}
+
+echo "Target: $URL"
+echo
+
+echo "[1] /status reachable (anonymous):"
+code=$(curl -sS -o /dev/null -w "%{http_code}" "$URL/status" || echo "ERR")
+check "GET /status" 200 "$code"
+
+# Generate a fresh test blob each run so we exercise both cold-write and warm-read
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+printf 'hightide-cache-smoke-test %s' "$(date -u +%FT%TZ)" > "$TMP/blob"
+KEY=$(sha256 < "$TMP/blob")
+echo
+echo "[2] Anonymous PUT (should be rejected):"
+code=$(curl -sS -o /dev/null -w "%{http_code}" -X PUT --data-binary @"$TMP/blob" "$URL/cas/$KEY" || echo "ERR")
+check "anonymous PUT /cas/<sha>" 401 "$code"
+
+if [[ -n "$USER" && -n "$PASS" ]]; then
+  echo
+  echo "[3] Authenticated PUT (should succeed):"
+  code=$(curl -sS -o /dev/null -w "%{http_code}" -u "${USER}:${PASS}" -X PUT --data-binary @"$TMP/blob" "$URL/cas/$KEY" || echo "ERR")
+  check "auth PUT /cas/<sha>" 200 "$code"
+
+  echo
+  echo "[4] Anonymous GET round-trip (should return the bytes we just wrote):"
+  curl -sS -o "$TMP/got" -w "" "$URL/cas/$KEY" || true
+  if cmp -s "$TMP/blob" "$TMP/got"; then echo "  PASS  GET /cas/<sha> body matches"; pass=$((pass+1));
+  else                                   echo "  FAIL  GET /cas/<sha> body mismatch"; fail=$((fail+1)); fi
+else
+  echo
+  echo "[3,4] Skipped — no -u/-p (or USER/PASS) provided.  Pass credentials to test write+roundtrip."
+fi
+
+echo
+echo "Result: $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Summary

- Replaces the GCS-backed Bazel remote cache (`gs://hightide-bazel-cache`, ~337 GiB, ~$282/mo projected) with a self-hosted [`bazel-remote`](https://github.com/buchgr/bazel-remote) instance running on donut behind a Cloudflare Tunnel at `https://cache.hightide-benchmarks.dev`.
- Reads are anonymous (publicly accessible); writes require an HTTP basic-auth credential held in the `bazel-cache-creds` k8s Secret (already created in the `vlsida` namespace) and in each developer's gitignored `.bazelrc.user`.
- The cache is content-addressed and self-evicting via LRU (capped at 500 GiB), so the old `tools/clear-cache.sh --remote` GCS-wipe path no longer applies and was removed.

## Operator notes

- New cache hostname: **`cache.hightide-benchmarks.dev`** (Cloudflare-fronted, TLS terminated at the edge, HTTP between cloudflared and `bazel-remote` over loopback on donut).
- Service host: **donut**; both `bazel-remote.service` and `cloudflared-hightide.service` run as a dedicated `bazelcache` system user with hardened systemd directives (`ProtectSystem=strict`, `ProtectHome=read-only`, `ReadWritePaths` scoped to the cache dir, `NoNewPrivileges`, `RestrictNamespaces`, etc.).
- Access logging is on for `/cas/*` and `/ac/*` paths; HTTP read/write timeouts are set to 30 s / 120 s as a slow-loris defense.
- The old `gs://hightide-bazel-cache` bucket has a 21-day lifecycle rule and will be deleted after this PR lands and the new cache has a few days of real traffic.

## Per-developer migration

To enable cache uploads from your machine, drop into `.bazelrc.user` (gitignored):

```
build --remote_cache=https://USER:TOKEN@cache.hightide-benchmarks.dev
build --remote_upload_local_results=true
```

The credentials are shared out of band — ping @mrg.

## Test plan

- [x] `bazel build //designs/asap7/lfsr:lfsr_synth` on donut: 18,136 actions populated, cache grew from 3 → 53,485 entries / 463 MiB compressed
- [x] `tools/test-cache.sh` from `donut`: 4/4 pass (anon read, anon-write rejected, auth-write accepted, GET round-trip matches)
- [x] `tools/test-cache.sh` from `diode` (off-host): 4/4 pass — confirms cross-machine reachability and auth
- [x] One-off smoke `Job` in NRP `vlsida` namespace using `bazel-cache-creds` Secret env vars: 4/4 pass — confirms cache reachable from Nautilus
- [ ] After merge: rebase any in-flight branches; smoke-test `k8s/run.sh` against the migrated `job-template.yaml`