### PR TITLE
k8s: per-design resource sizing via design_resources.conf

### DIFF
--- a/k8s/design_resources.conf
+++ b/k8s/design_resources.conf
@@ -1,0 +1,77 @@
+# Per-design resource overrides for Kubernetes Jobs submitted by k8s/run.sh.
+#
+# Format
+# ------
+# Each non-comment line is:
+#   <design_id> KEY=VALUE [KEY=VALUE ...]
+#
+# Where <design_id> is one of:
+#   defaults                — fallback for any design without its own entry
+#   <platform>/<design>     — exact match (e.g. asap7/bp_quad)
+#
+# Recognized keys:
+#   cpu_req cpu_lim         — CPU cores
+#   mem_req mem_lim         — memory (Ki/Mi/Gi)
+#   eph_req eph_lim         — ephemeral storage (Ki/Mi/Gi)
+#
+# Lookup order
+# ------------
+# For each design, run.sh tries `<platform>/<design>` first, then `defaults`,
+# then a hard-coded fallback. Command-line --cpu / --mem flags override
+# everything below.
+#
+# Sizing hints
+# ------------
+# Tiny designs (lfsr, minimax, sha3) and most medium designs (cnn, liteeth,
+# coralnpu, vortex) are well-served by the defaults — leave them out.
+# Add an entry only when a run has run out of memory or ephemeral storage,
+# or when a design is large enough that the default headroom is risky.
+
+# Defaults (cluster-friendly: 4 CPU, 32-128Gi mem, 50-100Gi eph storage).
+defaults              cpu_req=4 cpu_lim=16 mem_req=32Gi mem_lim=128Gi eph_req=50Gi eph_lim=100Gi
+
+# 4-core BlackParrot — direct measurement: 113GB peak memory in 5_2_route,
+# 51GB in 4_cts; ephemeral usage exceeded the 50Gi default at 8h in 3_place.
+# 339k flops, 560 macros, ~2.5GB intermediate ODBs.
+asap7/bp_quad         mem_req=64Gi mem_lim=160Gi eph_req=100Gi eph_lim=200Gi
+nangate45/bp_quad     mem_req=64Gi mem_lim=160Gi eph_req=100Gi eph_lim=200Gi
+
+# Single-core BlackParrot — 2.2M instances, 6.8GB artifacts. Last run
+# completed in defaults (~17GB peak memory) but bump eph_lim headroom
+# since CTS leaves multi-GB intermediate ODBs in the sandbox.
+asap7/bp_uno          eph_lim=150Gi
+nangate45/bp_uno      eph_lim=150Gi
+
+# Gemmini — 33b069c3 raised the global memory request to 64Gi specifically
+# to keep this design happy; 45b54bd1 closed timing on all platforms with
+# that headroom in place. Pin per-design instead of inflating the default.
+asap7/gemmini         mem_req=48Gi
+nangate45/gemmini     mem_req=48Gi
+sky130hd/gemmini      mem_req=48Gi
+
+# NyuziProcessor — 934k instances, 2.8GB artifacts; large RISC-V GPU
+# similar in scale to bp_uno. Bump eph headroom defensively.
+asap7/NyuziProcessor      eph_lim=150Gi
+nangate45/NyuziProcessor  eph_lim=150Gi
+
+# FloonNoC — 7.5M instances (largest non-bp_quad design observed),
+# 6.5GB artifacts. All-std-cell so memory load is moderate, but the
+# Bazel sandbox holds a lot of placement state.
+asap7/floonoc         eph_lim=150Gi
+nangate45/floonoc     eph_lim=150Gi
+sky130hd/floonoc      eph_lim=150Gi
+
+# Snitch Cluster — 8 RISC-V cores in PULP cluster, 5.5GB artifacts.
+asap7/snitch_cluster  eph_lim=150Gi
+
+# CoralNPU — large NPU; on sky130hd in particular the design balloons
+# significantly compared to asap7 (168k insts).
+asap7/coralnpu        eph_lim=150Gi
+nangate45/coralnpu    eph_lim=150Gi
+sky130hd/coralnpu     mem_req=48Gi eph_lim=150Gi
+
+# NVDLA partition_c — repeatedly fails on multiple platforms; the larger
+# of the NVDLA partitions. Bump headroom while it's being debugged.
+asap7/partition_c     eph_lim=150Gi
+nangate45/partition_c eph_lim=150Gi
+sky130hd/partition_c  eph_lim=150Gi

--- a/k8s/job-template.yaml
+++ b/k8s/job-template.yaml
@@ -125,9 +125,11 @@ spec:
           requests:
             memory: __MEM_REQUEST__
             cpu: __CPU_REQUEST__
+            ephemeral-storage: __EPH_REQUEST__
           limits:
             memory: __MEM_LIMIT__
             cpu: __CPU_LIMIT__
+            ephemeral-storage: __EPH_LIMIT__
       volumes:
       - name: repo
         emptyDir: {}

--- a/k8s/run.sh
+++ b/k8s/run.sh
@@ -14,31 +14,55 @@
 #
 # Options:
 #   --branch BRANCH    Git branch to build (default: current branch)
-#   --cpu NUM          CPU request per job (default: 8)
-#   --mem SIZE         Memory request per job (default: 64Gi)
+#   --cpu NUM          CPU request per job (overrides design_resources.conf)
+#   --mem SIZE         Memory request per job (overrides design_resources.conf)
 #   --upload-artifacts Save build artifacts (bazel-bin) to the hightide-artifacts PVC for debug
 #   --dry-run          Print generated YAML without submitting
 #   --status           Show status of submitted jobs
 #   --delete           Delete jobs (filtered by platform/design args)
+#
+# Per-design resource sizing lives in k8s/design_resources.conf (CPU, memory,
+# and ephemeral-storage). --cpu / --mem are job-wide overrides; for one-off
+# resource bumps just edit the conf file.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMPLATE="$SCRIPT_DIR/job-template.yaml"
+RESOURCES_CONF="$SCRIPT_DIR/design_resources.conf"
 NAMESPACE="vlsida"
 
 # Defaults
 BRANCH="main"
-CPU_REQUEST="4"
-CPU_LIMIT="16"
-MEM_REQUEST="32Gi"
-MEM_LIMIT="128Gi"
+CLI_CPU=""             # --cpu N (empty = use design_resources.conf)
+CLI_MEM=""             # --mem N (empty = use design_resources.conf)
 DRY_RUN=false
 MODE="submit"
 UPLOAD_ARTIFACTS="false"
 FILTER_PLATFORM=""
 FILTER_DESIGN=""
+
+# Resolve a resource value from design_resources.conf for the given design.
+# Tries <platform>/<design>, falls back to "defaults", then to the supplied
+# default. Reads from $RESOURCES_CONF.
+read_resource() {
+  local key="$1" design_id="$2" fallback="$3"
+  if [[ -f "$RESOURCES_CONF" ]]; then
+    local val
+    for tag in "$design_id" defaults; do
+      val=$(awk -v t="$tag" -v k="$key" '
+        $1 == t {
+          for (i = 2; i <= NF; i++) {
+            n = split($i, a, "=")
+            if (n == 2 && a[1] == k) { print a[2]; exit }
+          }
+        }' "$RESOURCES_CONF")
+      [[ -n "$val" ]] && { echo "$val"; return; }
+    done
+  fi
+  echo "$fallback"
+}
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -48,14 +72,11 @@ while [[ $# -gt 0 ]]; do
     shift 2
     ;;
   --cpu)
-    CPU_REQUEST="$2"
-    CPU_LIMIT="$((${2} * 2))"
+    CLI_CPU="$2"
     shift 2
     ;;
   --mem)
-    MEM_REQUEST="$2"
-    MEM_LIMIT="${2%Gi}"
-    MEM_LIMIT="$((MEM_LIMIT * 2))Gi"
+    CLI_MEM="$2"
     shift 2
     ;;
   --upload-artifacts)
@@ -220,7 +241,10 @@ fi
 
 echo "Submitting ${#DESIGNS[@]} job(s) to NRP Nautilus ($NAMESPACE)..."
 echo "  Branch: $BRANCH"
-echo "  Resources: ${CPU_REQUEST} CPU / ${MEM_REQUEST} memory"
+if [[ -n "$CLI_CPU" || -n "$CLI_MEM" ]]; then
+  echo "  CLI overrides: ${CLI_CPU:+CPU=$CLI_CPU} ${CLI_MEM:+memory=$CLI_MEM}"
+fi
+echo "  Per-design resources from: $RESOURCES_CONF"
 echo ""
 
 # Generate and submit jobs
@@ -232,16 +256,39 @@ for entry in "${DESIGNS[@]}"; do
   job_name="${USER}-hightide-${platform}-${leaf_name}"
   job_name=$(echo "$job_name" | tr '[:upper:]' '[:lower:]' | tr '_' '-' | cut -c1-63)
 
+  # Resolve resources: CLI flag > design entry > defaults entry > fallback.
+  design_id="$platform/$leaf_name"
+  if [[ -n "$CLI_CPU" ]]; then
+    cpu_request="$CLI_CPU"
+    cpu_limit="$((CLI_CPU * 2))"
+  else
+    cpu_request=$(read_resource cpu_req "$design_id" 4)
+    cpu_limit=$(read_resource cpu_lim "$design_id" "$((cpu_request * 2))")
+  fi
+  if [[ -n "$CLI_MEM" ]]; then
+    mem_request="$CLI_MEM"
+    mem_num="${CLI_MEM%Gi}"
+    mem_limit="$((mem_num * 2))Gi"
+  else
+    mem_request=$(read_resource mem_req "$design_id" 32Gi)
+    mem_default_lim="${mem_request%Gi}"
+    mem_limit=$(read_resource mem_lim "$design_id" "$((mem_default_lim * 2))Gi")
+  fi
+  eph_request=$(read_resource eph_req "$design_id" 50Gi)
+  eph_limit=$(read_resource eph_lim "$design_id" 100Gi)
+
   # Generate YAML from template
   yaml=$(sed \
     -e "s|__JOB_NAME__|${job_name}|g" \
     -e "s|__BRANCH__|${BRANCH}|g" \
     -e "s|__BAZEL_TARGET__|${target}|g" \
     -e "s|__UPLOAD_ARTIFACTS__|${UPLOAD_ARTIFACTS}|g" \
-    -e "s|__CPU_REQUEST__|${CPU_REQUEST}|g" \
-    -e "s|__CPU_LIMIT__|${CPU_LIMIT}|g" \
-    -e "s|__MEM_REQUEST__|${MEM_REQUEST}|g" \
-    -e "s|__MEM_LIMIT__|${MEM_LIMIT}|g" \
+    -e "s|__CPU_REQUEST__|${cpu_request}|g" \
+    -e "s|__CPU_LIMIT__|${cpu_limit}|g" \
+    -e "s|__MEM_REQUEST__|${mem_request}|g" \
+    -e "s|__MEM_LIMIT__|${mem_limit}|g" \
+    -e "s|__EPH_REQUEST__|${eph_request}|g" \
+    -e "s|__EPH_LIMIT__|${eph_limit}|g" \
     "$TEMPLATE")
 
   # Add labels for filtering


### PR DESCRIPTION
## Summary
- New `k8s/design_resources.conf` provides per-design overrides for CPU, memory, and ephemeral-storage requests/limits.
- `k8s/run.sh` resolves resources from the conf at submission time (CLI `--cpu` / `--mem` flags still override everything; `defaults` entry in the conf is the fallback).
- `k8s/job-template.yaml` now substitutes `__EPH_REQUEST__` / `__EPH_LIMIT__` placeholders alongside the existing CPU/mem ones.

## Why
asap7 `bp_quad` was evicted at ~8h in `3_place` after exceeding the cluster's 50Gi ephemeral-storage default — Bazel's sandbox plus multi-GB intermediate ODBs blow past it for 4-core BlackParrot. Rather than inflating one global limit (wasteful for `lfsr`-class designs that fit easily in 50Gi), this lets each design declare what it needs.

## Initial entries
Calibrated from observed instance counts, artifact sizes, and recent failure history:

| design | resources |
|---|---|
| `{asap7,nangate45}/bp_quad` | mem 64Gi/160Gi · eph 100Gi/200Gi (direct measurement: 113GB peak, evicted at 50Gi) |
| `{asap7,nangate45}/bp_uno` | eph_lim=150Gi (defensive, 2.2M instances) |
| `{asap7,nangate45,sky130hd}/gemmini` | mem_req=48Gi (per `33b069c3`) |
| `{asap7,nangate45}/NyuziProcessor` | eph_lim=150Gi |
| `{asap7,nangate45,sky130hd}/floonoc` | eph_lim=150Gi (7.5M instances on asap7) |
| `asap7/snitch_cluster` | eph_lim=150Gi |
| `{asap7,nangate45}/coralnpu` | eph_lim=150Gi |
| `sky130hd/coralnpu` | mem_req=48Gi · eph_lim=150Gi |
| `{asap7,nangate45,sky130hd}/partition_c` | eph_lim=150Gi (failure history) |

All other designs (`lfsr`, `minimax`, `sha3`, `cnn`, `liteeth*`, `vortex`, NVDLA partition_a/m/o/p, ...) inherit the `defaults` entry: 4 CPU / 32Gi mem req · 16 CPU / 128Gi mem limit · 50Gi eph req / 100Gi eph limit.

## Test plan
- [x] Dry-run `bp_quad` — gets 64/160 mem + 100/200 eph
- [x] Dry-run `lfsr` — gets defaults (32/128 mem + 50/100 eph)
- [x] Dry-run `coralnpu` on sky130hd — gets 48Gi mem_req + 150Gi eph_lim (per-platform override)
- [x] CLI `--cpu 8 --mem 64Gi` still overrides per-design conf values
- [ ] Submit a real bp_quad job to confirm no eviction at >50Gi