### PR TITLE
Enable wire compression for remote cache uploads

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,11 @@ try-import %workspace%/bazel-orfs/.bazelrc
 #   build --remote_upload_local_results=true
 build --remote_cache=https://cache.hightide-benchmarks.dev
 build --remote_upload_local_results=false
+# Compress payloads on the wire.  ORFS produces multi-100-MB stage ODBs
+# (2_floorplan.odb, 3_place.odb on big designs like NVDLA partition_c)
+# that exceed Cloudflare's free-tier 100 MB request-body limit on upload.
+# zstd compression typically gets ODBs well under that ceiling.
+build --remote_cache_compression
 
 # Local disk cache as fallback
 build --disk_cache=~/.cache/bazel-disk-cache


### PR DESCRIPTION
## Summary

Adds `build --remote_cache_compression` to the project `.bazelrc`.

ORFS produces multi-100-MB stage ODBs (e.g. `2_floorplan.odb` for NVDLA `partition_c` is 377 MB) that exceed Cloudflare's free-tier 100 MB request-body limit when Bazel tries to upload them to the self-hosted `bazel-remote` cache fronted by the Cloudflare Tunnel.  Without compression these uploads return `413 Payload Too Large` and the action result never lands in the remote cache, forcing every subsequent build to re-execute the action.

zstd compression on the wire typically gets ODBs well under the 100 MB ceiling (ODBs are very compressible — lots of zeros and repeated structures).  Reads decompress transparently.  Single-flag change, no infrastructure work required.

## Test plan

- [x] `bazel info release` parses the flag without error on Bazel 8.5
- [ ] After merge: re-run a build that produces a >100 MB ODB (e.g. `partition_c_floorplan` on the upcoming partition_c-edge-macros branch) and confirm no `413` warning, with the action result visible in the cache