### PR TITLE
Add /update-results skill for keeping results.html + figures/ in sync

### DIFF
--- a/.claude/skills/update-results/SKILL.md
+++ b/.claude/skills/update-results/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: update-results
+description: Refresh webpage/results.html and webpage/figures/ to reflect each (platform, design) pair's latest cached build. Detects stale rows by comparing a per-row data-commit attribute to the design's most recent commit, refetches the cached 6_report.json via tools/fetch_cache.sh, regenerates the gallery image at <design>_<platform>_<sha>.png, deletes the previous versioned image, and rewrites the table between RESULTS_START / RESULTS_END markers. Also handles the one-time migration from canonical filenames (cnn_asap7.png) to commit-versioned ones. Use after a build sweep lands new artifacts in the remote cache.
+argument-hint: "[platform] [design]"
+---
+
+# Update results.html and gallery figures
+
+Keeps `webpage/results.html` and `webpage/figures/` in sync with each design's latest cached `6_report.json`.  Each row pins a **commit SHA** (the most recent commit touching that design's BUILD/SDC/RTL); the gallery image is named with the same SHA so the row and image cannot drift.  Old image files are deleted as new versions land.
+
+The user may have given a `[platform]` and/or `[design]` filter (`$0` / `$1`) — use the same matching semantics as `k8s/run.sh` (positional, with `--design` for design-only).  No filter = sweep everything.
+
+**Operates on the `webpage` git worktree**, not whichever branch the user is currently on.  Find it with `git worktree list | awk '$3=="[webpage]"{print $1}'`.
+
+## Step 1: Locate the webpage worktree and check it's clean
+
+```bash
+WT=$(git worktree list | awk '$3=="[webpage]"{print $1}')
+test -n "$WT" || die "no webpage worktree found; create one with 'git worktree add ../webpage webpage'"
+git -C "$WT" status --short
+```
+
+If the worktree has uncommitted changes (other than the ones you're about to make), warn the user and ask whether to proceed — don't blindly add to a dirty tree.
+
+If `webpage` is behind `origin/webpage`, fast-forward it before doing any work:
+
+```bash
+git -C "$WT" pull --ff-only
+```
+
+## Step 2: Detect first-time migration
+
+Look for canonical filenames (no SHA component).  These predate this skill and need a one-time rename to the new convention:
+
+```bash
+ls "$WT"/figures/*.png 2>/dev/null \
+    | grep -vE '_[0-9a-f]{7,}\.png$' \
+    | grep -vE '/(HighTideFLOW|lighthouse|final_placement_)'   # exclude infra figures, not per-design
+```
+
+Anything that comes back is on the canonical-name convention.  For each, decode `<design>_<platform>` from the filename, compute the design's current SHA (Step 4 below), then:
+
+```bash
+git mv "$WT"/figures/<design>_<platform>.png \
+       "$WT"/figures/<design>_<platform>_<sha>.png
+```
+
+Use `git mv` so the rename history is preserved.
+
+After all migrations, the existing single `<tr>` in results.html (currently a hardcoded lfsr row) should be replaced with a freshly-generated row in Step 6.  Don't try to migrate the row in place — just regenerate it.
+
+## Step 3: Determine the design list
+
+```bash
+bazel query '//designs/...' 2>/dev/null \
+    | awk -F: '/_final$/ { sub(":.*", "", $0); print $0 }' \
+    | sort -u
+```
+
+That yields entries like `//designs/asap7/cnn`.  Strip the prefix to get `<platform>/<design-path>`.  Apply `[platform]` / `[design]` filters if provided.
+
+For each, derive:
+- `platform` (first segment)
+- `design_dir` (full path under `designs/`)
+- `leaf` (last segment of `design_dir`)
+- `bazel_target = //designs/<design_dir>:<leaf>_final`
+- `gallery_target = //designs/<design_dir>:<leaf>_gallery`
+- `report_path = bazel-bin/designs/<design_dir>/logs/<platform>/<top>/base/6_report.json` — `<top>` is whatever the design's `top` is, usually `<leaf>` but not always (e.g. lfsr's top is `lfsr_prbs_gen`).  Read it from `bazel query --output=build //designs/<design_dir>:<leaf>_final` if uncertain, or just glob `logs/<platform>/*/base/6_report.json`.
+
+## Step 4: Compute the design SHA
+
+For each (platform, design):
+
+```bash
+sha=$(git log -1 --format=%h -- \
+    "designs/$design_dir/" \
+    "designs/src/$leaf/" 2>/dev/null)
+```
+
+7 chars (default `%h`), matching GitHub's commit-link convention.  If the design has no `designs/src/<leaf>/` (no per-design RTL submodule, e.g. lfsr's RTL is in `designs/src/lfsr/` but for designs whose RTL lives elsewhere, just drop the second arg).
+
+## Step 5: Refresh stale designs
+
+Parse `webpage/results.html` for existing rows.  Each row is keyed by `data-design` + `data-platform`; its current commit is `data-commit`.  A row is **stale** if `data-commit` ≠ the SHA from Step 4, or the row is missing entirely.
+
+For each stale (platform, design):
+
+```bash
+# Pull the cached JSON.  No local build — if cache miss, log + skip.
+./tools/fetch_cache.sh "$platform" "$leaf" || { echo "WARN: $platform/$leaf NOT CACHED, skipping"; continue; }
+
+# Build only this design's gallery target.
+bazel build "$gallery_target"
+
+# Copy versioned image, delete the previous one.
+new_img="$WT/figures/${leaf}_${platform}_${sha}.png"
+old_img=$(ls "$WT"/figures/${leaf}_${platform}_*.png 2>/dev/null | grep -v "_${sha}.png$" | head -1)
+cp "bazel-bin/designs/$design_dir/${leaf}_gallery.png" "$new_img"
+[[ -n "$old_img" ]] && git -C "$WT" rm -f "$old_img"
+git -C "$WT" add "$new_img"
+```
+
+Capture QoR from the JSON using the same metric keys `tools/summary.sh` reads:
+- `finish__design__die__area`
+- `finish__design__core__area`
+- `finish__design__instance__area__stdcell`
+- `finish__design__instance__utilization` (× 100 for %)
+- `finish__design__instance__count__stdcell`
+- `finish__design__instance__count__macros`
+- `finish__design__io`
+- `finish__timing__setup__ws` (WNS)
+- `finish__timing__setup__tns` (TNS)
+- `finish__timing__fmax` (÷ 1e9 for GHz)
+- `finish__power__total` (× 1000 for mW)
+- `finish__flow__errors__count` (DRCs)
+
+Format with the same precision as `tools/summary.sh:53-84` (areas / cells / counts: 1 decimal; timing / fmax: 2 decimals; power: 3 decimals; util: 1 decimal).
+
+## Step 6: Rewrite the table between markers
+
+Find `<!-- RESULTS_START -->` and `<!-- RESULTS_END -->` in `webpage/results.html`.  Replace everything between them with one `<tr>` per (platform, design) in `(platform, design)` sort order:
+
+```html
+<tr data-design="cnn" data-platform="asap7" data-commit="a1b2c3d">
+  <td><span class="platform-badge badge-asap7">asap7</span></td>
+  <td>cnn</td>
+  <td>360000.0</td>
+  <td>336166.0</td>
+  <td>23936.7</td>
+  <td>40.1</td>
+  <td>212257</td>
+  <td>65</td>
+  <td>367</td>
+  <td>-44.30</td>
+  <td>-149.87</td>
+  <td>0.96</td>
+  <td>456.091</td>
+  <td>0</td>
+  <td><a href="https://github.com/VLSIDA/HighTide/commit/a1b2c3d">a1b2c3d</a></td>
+</tr>
+```
+
+The first time the skill runs the table needs a new `<th>Commit</th>` column at the right end of the `<thead>` row — add it once, idempotent.
+
+If a (platform, design) is currently NOT CACHED (Step 5 skipped it), preserve any existing row in the table (don't drop the design from the page just because the user's local cache is empty).  Use `<!-- skipped: not cached on YYYY-MM-DD -->` as a comment marker to make stale-data sources visible.
+
+## Step 7: Update gallery.html thumbnails
+
+`webpage/gallery.html` references the same images.  Replace its `<img src="figures/<old>.png">` references to point at the new versioned filenames.  Same migration rule applies on first run.
+
+## Step 8: Show the diff and stop
+
+```bash
+git -C "$WT" status --short
+git -C "$WT" diff --stat
+git -C "$WT" diff figures/ -- ':(exclude)*.png' | head   # text-only diff for HTML
+```
+
+Surface the change set to the user, list any designs that were skipped because the cache was cold, and stop.  Don't `git commit` or `git push` — leave that to the user.
+
+## Worked example
+
+```
+/update-results
+```
+
+(No filter, so sweep everything.)
+
+```
+> Locating webpage worktree at /home/mrg/HighTide/webpage … clean (origin/webpage @ 1d9ccec4).
+> Migration check: 38 canonical-name PNGs found, renaming to <design>_<platform>_<sha>.png …
+>   figures/cnn_asap7.png        → cnn_asap7_a1b2c3d.png
+>   figures/coralnpu_asap7.png   → coralnpu_asap7_e4f5g6h.png
+>   …
+> Sweep: 56 (platform, design) pairs.
+>   asap7/cnn         a1b2c3d  STALE (table commit was canonical-only)
+>     ./tools/fetch_cache.sh asap7 cnn → cached
+>     bazel build //designs/asap7/cnn:cnn_gallery → 0.4s, cache hit
+>     wrote figures/cnn_asap7_a1b2c3d.png (replaces cnn_asap7.png)
+>   sky130hd/NVDLA/partition_c   stale  NOT CACHED → skipped
+>   …
+> Rewrote results.html (56 rows, 1 skipped → preserved as comment).
+> Rewrote gallery.html (38 image references updated).
+> Diff:
+>     results.html | 412 ++++++++++++++++++++++++++++++++++++++++++--------------
+>     gallery.html |  84 +++++-----
+>     figures/     | 38 deletions, 38 creations (renames)
+> Run `git -C /home/mrg/HighTide/webpage diff` to review, then commit + push.
+```


### PR DESCRIPTION
Adds a new HighTide skill at \`.claude/skills/update-results/SKILL.md\` (189 lines) that keeps \`webpage/results.html\` and \`webpage/figures/\` synchronized with each (platform, design) pair's latest cached build.

## Why

Today the pieces exist (\`tools/summary.sh\` produces the QoR table on stdout; \`tools/gallery/collect_gallery.sh\` rebuilds every gallery image; \`webpage/results.html\` has \`<!-- RESULTS_START -->\` / \`<!-- RESULTS_END -->\` markers anticipating an automated inserter), but no glue ties them together.  The result.html table currently has one hand-rolled lfsr row, and gallery images can drift from the row QoR because nothing pins them to the same build.

## What the skill does

Each row pins a **commit SHA** (the most recent commit touching that design's BUILD/SDC/RTL).  The gallery image is named \`<design>_<platform>_<sha>.png\` so a row and its image cannot drift.  Old image files are deleted as new versions land.

Eight phases:

1. Locate the \`webpage\` worktree, fast-forward, refuse if dirty.
2. **One-time migration** — \`git mv\` canonical-name PNGs (\`cnn_asap7.png\`) to \`<design>_<platform>_<sha>.png\` at the design's current SHA.
3. Enumerate designs from \`bazel query\`, apply \`[platform]\` / \`[design]\` filters (same semantics as \`k8s/run.sh\`).
4. Compute per-design SHA via \`git log -1 --format=%h -- designs/<dir>/ designs/src/<leaf>/\`.
5. For stale rows (\`data-commit\` mismatch): \`tools/fetch_cache.sh\` to pull the cached \`6_report.json\` — skip + warn on NOT CACHED, never trigger a local source build.  Then \`bazel build :<leaf>_gallery\`, copy to the new versioned filename, \`git rm\` the old one.
6. Rewrite rows between RESULTS_START / RESULTS_END with \`data-design\` / \`data-platform\` / \`data-commit\` attrs and a new rightmost **Commit** column linking to \`github.com/VLSIDA/HighTide/commit/<sha>\`.  Preserves rows for designs that are currently NOT CACHED locally.
7. Update \`webpage/gallery.html\` image refs to the new filenames.
8. \`git diff\` and stop — does not commit, does not push.

## Invocation

- \`/update-results\` — sweep all designs
- \`/update-results asap7\` — one platform
- \`/update-results asap7 cnn\` — one (platform, design)
- \`/update-results --design lfsr\` — one design across all platforms

## Test plan

- [x] Skill registers in \`/skills\` listing (frontmatter parses cleanly)
- [x] Description references the existing \`tools/fetch_cache.sh\` / \`tools/gallery/\` tooling for reuse
- [x] Worked example in the SKILL.md walks through migration + sweep + skip-on-cache-miss