### PR TITLE
Add per-design DECISIONS.md tracking to update-design (and cross-checks in debug-design / optimize-ppa)

### DIFF
--- a/.claude/skills/debug-design/SKILL.md
+++ b/.claude/skills/debug-design/SKILL.md
@@ -10,6 +10,23 @@ You are debugging the design at `designs/$0`. The user may have specified a stag
 
 **Important:** HighTide is a benchmark suite — the RTL is a fixed input. Never suggest modifying the upstream Verilog/RTL. All fixes must be scoped to flow parameters (config.mk), timing constraints (constraint.sdc), physical design files (io.tcl, pdn.tcl), and FakeRAM configuration.
 
+## Step 0: Check prior art — CLAUDE.md bugs and other designs' DECISIONS.md
+
+Before reading logs, spend 60 seconds looking for someone who already solved this:
+
+1. **CLAUDE.md "Known OpenROAD / yosys-slang bug workarounds"** at the repo root.  Grep for the error code (`grep -E "MPL-0040|CTS-0105|ODB-1200" CLAUDE.md`) or the failing stage name.  If a row matches, the **Workaround** column points at the exact fix and the **Issue** column links the upstream tracker.
+
+2. **Other designs' DECISIONS.md**.  These live at `designs/src/<design>/DECISIONS.md` and capture per-(design, platform) tuning rationale, manual placement strategies, and timing-constraint reasoning.  A design with a similar shape (macro-heavy, deep pipeline, same platform) often hit the same problem first:
+
+   ```bash
+   # Search every DECISIONS.md for the symptom — error code, stage name, or keyword
+   grep -rn -E "<error-code>|<stage-name>|<symptom>" designs/src/*/DECISIONS.md
+   ```
+
+   When grep hits, read the full **Decisions** entry on the matching platform — the why is what generalizes, even if the exact fix doesn't.  Common reusable patterns: `MACRO_PLACE_HALO` for sky130hd macro-heavy designs, `TNS_END_PERCENT = 100` vs lower for repair_timing budget, `clk_io_pct` bumps for nangate45 long IO paths, `PRE_CTS_TCL` for CTS-0105.
+
+If a similar problem turned up in another design and the workaround applies, propose it as the candidate fix in Step 5 — and note in the DECISIONS.md update which design's experience you reused.
+
 ## Step 1: Locate Build Artifacts
 
 Check for artifacts in three locations, in order of preference:

--- a/.claude/skills/optimize-ppa/SKILL.md
+++ b/.claude/skills/optimize-ppa/SKILL.md
@@ -15,6 +15,28 @@ You are optimizing the PPA (power, performance, area) of the design at `designs/
 
 **Key lesson: utilization and clock period are coupled.** Tighter clock constraints cause synthesis and repair_timing to insert more buffers, increasing the effective cell area. A design that fits at 80% utilization with a relaxed clock may overflow at 80% with an aggressive clock. Optimize utilization first at the current clock, then tighten the clock and re-check utilization.
 
+## Step 0: Check prior art — CLAUDE.md bugs and other designs' DECISIONS.md
+
+Before measuring or tuning anything, spend 60 seconds looking at how similar designs were optimized:
+
+1. **CLAUDE.md "Known OpenROAD / yosys-slang bug workarounds"** at the repo root — if a row's "Affected designs" cell mentions this design or a structurally-similar one, the workaround may already be active in `arguments={…}`.  Don't re-introduce a knob the bug-table already controls.
+
+2. **Other designs' DECISIONS.md** at `designs/src/<design>/DECISIONS.md`.  These capture *why* each design's util / density / halo / clock landed where it did.  Before tightening any knob, check whether a similarly-shaped design (same platform, same macro count, same gate type — e.g., another sky130hd ML-accelerator with N macros) already explored the same axis:
+
+   ```bash
+   # Same platform, similar size or shape — read all of them
+   grep -rln '^## sky130hd' designs/src/*/DECISIONS.md
+   # Specific knobs people have written about
+   grep -rE 'CORE_UTILIZATION|PLACE_DENSITY|MACRO_PLACE_HALO|clk_period' designs/src/*/DECISIONS.md
+   ```
+
+   The reusable pattern is usually:
+   - **Floor on `CORE_UTILIZATION`** for a given (platform, macro-count) — if every macro-heavy design on sky130hd has a util ceiling around 25%, this design probably can't push past it without a manual macros.tcl.
+   - **Floor on clock period** — period_min vs target ratios that converged elsewhere generalize.
+   - **Halo trade-off shape** — what halo value each platform's working designs settled on.
+
+   Reusing prior art beats re-discovering it: when this skill makes the final DECISIONS.md update in Step 6, note which other design's experience informed the decision.
+
 ## Step 1: Establish Baseline
 
 First, gather the current metrics from the most recent build.

--- a/.claude/skills/update-design/SKILL.md
+++ b/.claude/skills/update-design/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: update-design
-description: Check for upstream updates to existing HighTide designs and tools, summarize what changed, and apply updates. Use when a design needs to be refreshed, or with no arguments to audit all designs for available updates.
+description: Check for upstream updates to existing HighTide designs and tools, summarize what changed, apply updates, and keep the per-design DECISIONS.md (designs/src/<design>/DECISIONS.md) in sync — recording bug workarounds, manual macro/IO placement, timing-constraint choices, utilization tuning, and any other non-obvious decisions, with one section per technology. Use when a design needs to be refreshed, with no arguments to audit all designs for available updates, or with `--init-decisions <design>` to bootstrap a new DECISIONS.md from existing git history + BUILD.bazel + SDC.
 argument-hint: "[design-name or 'all'] [platform]"
 ---
 
 # Update an Existing Design
 
 If `$ARGUMENTS` is empty or `all`, run the **Upstream Audit** first. Otherwise, you are updating the design `$0` on platform `$1` — determine what kind of update is needed by asking the user or inferring from context.
+
+**Always** also keep `designs/src/$0/DECISIONS.md` in sync — see the **Decisions Document** section below for the file shape, where to record what, and the bootstrap workflow for designs that don't have one yet.
 
 ## Upstream Audit
 
@@ -70,6 +72,108 @@ Format the results as a table:
 ```
 
 Let the user decide which updates to apply. Small changes that don't affect RTL generation (docs, tests, CI) are usually not worth updating for. Major changes that affect RTL output, fix synthesis bugs, or add new features are worth considering.
+
+## Decisions Document
+
+Every design has a long-form decisions log at `designs/src/<design>/DECISIONS.md` (one file per design — variants share it via sub-sections).  This is the place where non-obvious tuning choices, workaround rationale, and platform-specific gotchas live.  The file complements but **does not duplicate**:
+
+- **CLAUDE.md "Known OpenROAD / yosys-slang bug workarounds" table** — the canonical bug index.  DECISIONS.md cross-links to specific rows there rather than restating the bug.
+- **BUILD.bazel `arguments = { … }`** — the live config.  DECISIONS.md records *why* an argument has the value it does, not the value itself.
+- **`constraint.sdc` comments** — the live constraints.  DECISIONS.md records *why* a clock period or `set_false_path` was chosen.
+
+### When to record a decision
+
+Update `designs/src/<design>/DECISIONS.md` whenever any of these change:
+
+- A bug workaround lands in BUILD.bazel (`PRE_CTS_TCL`, `SKIP_*`, `SETUP_MOVE_SEQUENCE` trim, etc.) — link to the CLAUDE.md row.
+- The clock period changes — record before/after Fmax and the period_min that motivated the change.
+- A `macros.tcl`, `io.tcl`, `pdn.tcl`, or `*_pre_*.tcl` is added.
+- Utilization, density addon, or macro halo gets a non-default value.
+- A platform-specific FakeRAM tweak is needed.
+- Synthesis is hierarchical / uses `SYNTH_HIERARCHICAL`, with a reason.
+- A platform is marked "not yet finishing" (record what's been tried and what blocks closure).
+- An optimization-PPA pass moves the QoR more than ~5% in any axis.
+
+The other HighTide skills (`/debug-design`, `/optimize-ppa`, `/port-design`, `/track-bug`) should each append to this file when their work touches one of the above triggers.
+
+### File shape
+
+```markdown
+# <design> Design Decisions
+
+Per-platform notes on tuning, workarounds, and platform-specific
+quirks for <design>.  See CLAUDE.md (root) for the canonical
+upstream-bug index; this file cross-links to it.
+
+## asap7
+
+**Status**: closing | not finishing | failing-timing | partial
+**Last updated**: 2026-05-08 (commit a1b2c3d)
+
+### Configuration
+- `CORE_UTILIZATION = N` — <one-line why this value>
+- `PLACE_DENSITY_LB_ADDON = X` — <reason>
+- Clock: `<N> ns` (Fmax `<X>` MHz) — <reason>
+- Active workarounds: link to CLAUDE.md rows by error code
+
+### Decisions
+- **YYYY-MM-DD `<short-sha>`**: one-line summary of the decision and its motivation, with PR or issue reference where applicable.
+- **YYYY-MM-DD `<short-sha>`**: …
+
+### Known issues / open questions
+- One bullet per known limitation, e.g. "DRC-clean but Fmax limited by macro→macro cross-die paths; manual macros.tcl might unlock further."
+
+## nangate45
+
+…
+
+## sky130hd
+
+…
+```
+
+For multi-variant designs (NVDLA, liteeth, bp_processor), each platform's section gets variant sub-sections:
+
+```markdown
+## sky130hd
+
+### partition_a
+…
+### partition_c
+**Status**: not finishing — GP overflow plateaus at 0.31, see CLAUDE.md.
+…
+```
+
+### Bootstrap workflow (`--init-decisions <design>`)
+
+If the file doesn't exist yet, build it from already-committed history rather than asking the user from scratch:
+
+1. **Find the design's commits**:
+   ```bash
+   git log --oneline --reverse -- "designs/*/$design/" "designs/src/$design/"
+   ```
+
+2. **For each platform**, derive the live configuration:
+   - Read `designs/<platform>/<design>/BUILD.bazel` → `arguments`, `sources`.
+   - Read `designs/<platform>/<design>/constraint.sdc` → clock period, `set_false_path` lines, IO delay constants.
+   - Note any `pdn.tcl` / `io.tcl` / `macros.tcl` / `*pre*.tcl` files that exist.
+
+3. **Pull bug links from CLAUDE.md**: any row in the workarounds table whose "Affected designs" cell mentions this design becomes a "Active workarounds" bullet in the matching platform section, with the issue link copied verbatim.
+
+4. **Pull historical decisions from git log**: scan commit messages on files in `designs/<platform>/<design>/` and `designs/src/<design>/`.  Promote commits that match these patterns to "Decisions" entries:
+   - "Relax", "Tighten", "Bump", "Drop", "Switch", "Disable", "Enable" + clock/util/density/halo terms.
+   - Anything tagged `Fix`, `Workaround`, `Skip`.
+   - Initial port commits (first `Add … on <platform>` for each platform).
+
+5. **Drop decisions older than 1 year** unless they're still load-bearing (e.g. the clock period chosen at port still in effect).  The doc is a working memory, not a changelog.
+
+6. **Show the user the proposed file before writing**, especially when the inferred reasoning is uncertain — they may have context that didn't make it into commit messages.
+
+### Updating an existing decisions file
+
+Each invocation of `/update-design <design> <platform>` that touches the live config should also append (or replace) entries under that platform's **Decisions** list with the current commit short-sha.  Don't rewrite history — append a new dated bullet, and update the platform section's `**Last updated**` line.
+
+If the only change is regenerating RTL from upstream with no flow-config impact, no DECISIONS.md update is needed (the upstream audit table is enough).
 
 ## Types of Updates
 


### PR DESCRIPTION
Adds a per-design **DECISIONS.md** at \`designs/src/<design>/DECISIONS.md\` to capture non-obvious tuning choices, workaround rationale, and platform-specific gotchas.  The file complements but doesn't duplicate \`CLAUDE.md\`'s bug table or the live BUILD.bazel / SDC — it records *why* knobs have the values they do.

## Three skill changes in one PR

### \`update-design\` (+106 lines)
- **Description**: now mentions DECISIONS.md upkeep + a \`--init-decisions <design>\` bootstrap mode.
- **New "Decisions Document" section** before "Types of Updates" — file shape, when to record (8-bullet trigger list), bootstrap workflow that mines git log + BUILD.bazel + SDC + CLAUDE.md to populate the file from existing history.
- Multi-variant designs (NVDLA, liteeth, bp_processor) use variant sub-sections within each platform.

### \`debug-design\` (+17 lines)
- **New "Step 0: Check prior art"** runs *before* reading logs.  Greps \`CLAUDE.md\` for the error code and \`designs/src/*/DECISIONS.md\` for the symptom / stage / keyword.  Designs of similar shape often hit the same problem first; the reusable pattern is the *why*, not always the exact knob.

### \`optimize-ppa\` (+22 lines)
- **New "Step 0: Check prior art"** with the same pattern, focused on tuning knobs.  Suggests targeted greps (\`grep -rE 'CORE_UTILIZATION|PLACE_DENSITY|MACRO_PLACE_HALO|clk_period' designs/src/*/DECISIONS.md\`) so optimizers don't re-discover utilization floors / clock-period floors / halo trade-offs that another design already mapped.

Both \`debug-design\` and \`optimize-ppa\` are told to credit the borrowed-from design when writing the new DECISIONS.md entry, so prior-art reuse stays visible.

## What this enables

Once the file is bootstrapped on each design (followup PR), \`/debug-design\` and \`/optimize-ppa\` get a much faster cold-start because the most useful information — what's been tried, what worked, what didn't — is one grep away instead of buried in commit messages or implicit in BUILD.bazel diffs.

## Test plan
- [x] Three skills register cleanly in \`/skills\` listing with updated descriptions.
- [x] Each skill's "prior art" step gives concrete grep commands rather than abstract advice.
- [x] DECISIONS.md file shape includes Configuration / Decisions / Known issues subsections, with a worked example for multi-variant designs.

## Out of scope (followup)

Bootstrapping \`DECISIONS.md\` for the 17 designs currently on results.html — will do that as a separate PR once this lands.