### PR TITLE
Bootstrap DECISIONS.md for 7 designs currently on results.html

### DIFF
--- a/.claude/skills/update-design/SKILL.md
+++ b/.claude/skills/update-design/SKILL.md
@@ -107,7 +107,7 @@ upstream-bug index; this file cross-links to it.
 
 ## asap7
 
-**Status**: closing | not finishing | failing-timing | partial
+**Status**: finishing | not finishing | failing-timing | partial
 **Last updated**: 2026-05-08 (commit a1b2c3d)
 
 ### Configuration

--- a/designs/src/coralnpu/DECISIONS.md
+++ b/designs/src/coralnpu/DECISIONS.md
@@ -1,0 +1,61 @@
+# coralnpu Design Decisions
+
+Per-platform notes on tuning, workarounds, and platform-specific quirks for `coralnpu` (Google CoreMiniAxi NPU).  See `CLAUDE.md` (root) for the canonical upstream-bug index.
+
+Mid-large NPU with several FakeRAM macros.  Hierarchical synthesis required for tractable build times.
+
+## Common to all platforms
+
+- `SYNTH_HIERARCHICAL = 1` — flat synthesis runs out of memory / time on this design's hierarchy.
+- `TNS_END_PERCENT = 100` — repair every violator (target Fmax is loose enough that this converges).
+
+## asap7
+
+**Status**: closing
+**Last updated**: 2026-04-26 (commit `643ba623`)
+
+### Configuration
+- `CORE_UTILIZATION = 40`
+- `PLACE_DENSITY_LB_ADDON = 0.20`
+- `MACRO_PLACE_HALO = "6 6"` — small halo since asap7 cells are physically tiny
+- Clock: `3000 ps` (Fmax ~333 MHz)
+
+### Decisions
+- **2026-04-26 `643ba623`**: initial close.  Halo 6×6 chosen to keep std cells out of macro shadow but avoid wasting die area.
+
+### Known issues / open questions
+- None.
+
+## nangate45
+
+**Status**: closing
+**Last updated**: 2026-04-26 (commit `643ba623`)
+
+### Configuration
+- `CORE_UTILIZATION = 40`
+- `PLACE_DENSITY_LB_ADDON = 0.20`
+- `MACRO_PLACE_HALO = "40 40"` — much larger than asap7 because nangate45's cells are ~10× wider, so the equivalent stdcell-rows-of-clearance value scales up
+- Clock: `9 ns` (Fmax ~111 MHz)
+
+### Decisions
+- **2026-04-26 `643ba623`**: halo bumped to 40×40 (vs asap7's 6×6) — same number of stdcell tracks of macro clearance, just expressed in micrometers at nangate45's pitch.
+
+### Known issues / open questions
+- None.
+
+## sky130hd
+
+**Status**: closing
+**Last updated**: 2026-04-26 (commit `6d6f2dc2`)
+
+### Configuration
+- `CORE_UTILIZATION = 20` — much lower than asap7/nangate45; sky130hd's coarse pitches plus this design's macro count create heavy local-density hot spots
+- `PLACE_DENSITY = 0.15` — explicit (not addon)
+- `MACRO_PLACE_HALO = "30 30"`
+- Clock: `30 ns` (Fmax ~33 MHz)
+
+### Decisions
+- **2026-04-26 `6d6f2dc2`**: util dropped to 20%, density set explicitly to 0.15 to relieve sky130hd routing congestion on this macro-heavy NPU.
+
+### Known issues / open questions
+- None.

--- a/designs/src/coralnpu/DECISIONS.md
+++ b/designs/src/coralnpu/DECISIONS.md
@@ -11,7 +11,7 @@ Mid-large NPU with several FakeRAM macros.  Hierarchical synthesis required for 
 
 ## asap7
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-04-26 (commit `643ba623`)
 
 ### Configuration
@@ -28,7 +28,7 @@ Mid-large NPU with several FakeRAM macros.  Hierarchical synthesis required for 
 
 ## nangate45
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-04-26 (commit `643ba623`)
 
 ### Configuration
@@ -45,7 +45,7 @@ Mid-large NPU with several FakeRAM macros.  Hierarchical synthesis required for 
 
 ## sky130hd
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-04-26 (commit `6d6f2dc2`)
 
 ### Configuration

--- a/designs/src/floonoc/DECISIONS.md
+++ b/designs/src/floonoc/DECISIONS.md
@@ -1,0 +1,54 @@
+# floonoc Design Decisions
+
+Per-platform notes on tuning, workarounds, and platform-specific quirks for `floonoc` (PULP Network-on-Chip mesh).  See `CLAUDE.md` (root) for the canonical upstream-bug index.
+
+Network-on-chip with std-cell-only logic; the only physical-design knobs are clock period, util, and IO placement (the design has many ports).  An `io.tcl` is shared across platforms to spread the IO ring.
+
+## asap7
+
+**Status**: closing
+**Last updated**: 2026-04-29 (commit `ec7be591`)
+
+### Configuration
+- `TNS_END_PERCENT = 100`
+- `io.tcl` present — spreads NoC ports around the die perimeter to relieve IO-region congestion
+- Clock: `2000 ps` (Fmax ~500 MHz)
+
+### Decisions
+- **2026-04-29 `ec7be591`**: closed at 2 ns clock; manual io.tcl was needed because the auto IO placer clustered ports along one edge and choked routing in that region.
+
+### Known issues / open questions
+- None.
+
+## nangate45
+
+**Status**: closing
+**Last updated**: 2026-04-29 (commit `ec7be591`)
+
+### Configuration
+- `TNS_END_PERCENT = 100`
+- `io.tcl` present (same purpose as asap7)
+- Clock: `5.0 ns` (Fmax ~200 MHz, ~311 MHz reported on results.html)
+
+### Decisions
+- **2026-04-29 `ec7be591`**: same shape as asap7 — io.tcl carried over with platform-appropriate metal-layer references.
+
+### Known issues / open questions
+- None.
+
+## sky130hd
+
+**Status**: not finishing
+**Last updated**: 2026-04-29 (commit `ec7be591`)
+
+### Configuration
+- `TNS_END_PERCENT = 100`
+- `io.tcl` present
+- Clock: `20.0 ns` (Fmax target ~50 MHz)
+
+### Decisions
+- **2026-04-29 `ec7be591`**: gave the same treatment as the working platforms (io.tcl + 20 ns clock) but synthesis still doesn't reach `_final` on sky130hd.  Stops at `1_synth` per `tools/summary.sh` "Incomplete builds" output.
+
+### Known issues / open questions
+- Synthesis itself is failing on sky130hd; need to inspect the yosys log to determine whether it's a memory-inference issue, a slang-frontend incompatibility, or something else.
+- Worth checking the yosys-slang log against the gallery of known failures before deeper debug.

--- a/designs/src/floonoc/DECISIONS.md
+++ b/designs/src/floonoc/DECISIONS.md
@@ -6,7 +6,7 @@ Network-on-chip with std-cell-only logic; the only physical-design knobs are clo
 
 ## asap7
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-04-29 (commit `ec7be591`)
 
 ### Configuration
@@ -22,7 +22,7 @@ Network-on-chip with std-cell-only logic; the only physical-design knobs are clo
 
 ## nangate45
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-04-29 (commit `ec7be591`)
 
 ### Configuration

--- a/designs/src/gemmini/DECISIONS.md
+++ b/designs/src/gemmini/DECISIONS.md
@@ -10,7 +10,7 @@ Large macro-heavy ML accelerator with FakeRAM black-boxes for the accumulator an
 
 ## asap7
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-05-03 (commit `45b54bd1`)
 
 ### Configuration
@@ -27,7 +27,7 @@ Large macro-heavy ML accelerator with FakeRAM black-boxes for the accumulator an
 
 ## nangate45
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-05-03 (commit `45b54bd1`)
 
 ### Configuration
@@ -43,7 +43,7 @@ Large macro-heavy ML accelerator with FakeRAM black-boxes for the accumulator an
 
 ## sky130hd
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-05-03 (commit `45b54bd1`)
 
 ### Configuration

--- a/designs/src/gemmini/DECISIONS.md
+++ b/designs/src/gemmini/DECISIONS.md
@@ -1,0 +1,58 @@
+# gemmini Design Decisions
+
+Per-platform notes on tuning, workarounds, and platform-specific quirks for `gemmini` (Berkeley ML systolic array accelerator, Chisel/Scala).  See `CLAUDE.md` (root) for the canonical upstream-bug index.
+
+Large macro-heavy ML accelerator with FakeRAM black-boxes for the accumulator and scratchpad SRAMs.
+
+## Active workarounds (all platforms)
+
+- **ODB-1200** in CTS-time `repair_timing` — fixed via `SETUP_MOVE_SEQUENCE = "unbuffer,sizeup,swap,buffer,clone"` (drop the default `split_load` move that triggers the bug).  Keeps the rest of repair_timing active, unlike `SKIP_CTS_REPAIR_TIMING` which other ODB-1200-affected designs use.  See [HighTide#75](https://github.com/VLSIDA/HighTide/issues/75).
+
+## asap7
+
+**Status**: closing
+**Last updated**: 2026-05-03 (commit `45b54bd1`)
+
+### Configuration
+- `CORE_UTILIZATION = 35` — macro-heavy; lower std-cell density helps router around macro pin clusters
+- `SETUP_MOVE_SEQUENCE = "unbuffer,sizeup,swap,buffer,clone"` (ODB-1200 workaround)
+- `io.tcl`, `pdn.tcl` present (manual IO placement + power grid)
+- Clock: `1.5 ns` (Fmax ~667 MHz)
+
+### Decisions
+- **2026-05-03 `45b54bd1`**: closed timing in PR #114 by combining the SETUP_MOVE_SEQUENCE workaround for ODB-1200 with appropriate clock period.
+
+### Known issues / open questions
+- None.
+
+## nangate45
+
+**Status**: closing
+**Last updated**: 2026-05-03 (commit `45b54bd1`)
+
+### Configuration
+- `CORE_UTILIZATION = 35`
+- `SETUP_MOVE_SEQUENCE = "unbuffer,sizeup,swap,buffer,clone"` (ODB-1200 workaround)
+- Clock: `3.0 ns` (Fmax ~333 MHz)
+
+### Decisions
+- **2026-05-03 `45b54bd1`**: closed timing in PR #114, same workaround as asap7.
+
+### Known issues / open questions
+- None.
+
+## sky130hd
+
+**Status**: closing
+**Last updated**: 2026-05-03 (commit `45b54bd1`)
+
+### Configuration
+- `CORE_UTILIZATION = 30` — lowest util across the three platforms; sky130hd macro-pin congestion is worst here
+- `SETUP_MOVE_SEQUENCE = "unbuffer,sizeup,swap,buffer,clone"` (ODB-1200 workaround)
+- Clock: `13 ns` (Fmax ~77 MHz)
+
+### Decisions
+- **2026-05-03 `45b54bd1`**: closed timing in PR #114.  Util had to drop further than asap7/nangate45 to keep GP overflow under control on the macro-heavy floorplan.
+
+### Known issues / open questions
+- None.

--- a/designs/src/lfsr/DECISIONS.md
+++ b/designs/src/lfsr/DECISIONS.md
@@ -1,0 +1,54 @@
+# lfsr Design Decisions
+
+Per-platform notes on tuning, workarounds, and platform-specific quirks for `lfsr` (LFSR / PRBS generator, top-level module `lfsr_prbs_gen`).  See `CLAUDE.md` (root) for the canonical upstream-bug index.
+
+This is a small std-cell-only design (~200 cells, no macros) used as a smoke test for the flow on every platform.
+
+## asap7
+
+**Status**: closing
+**Last updated**: 2026-05-01 (commit `6511fb56`)
+
+### Configuration
+- `CORE_UTILIZATION = 55` — std-cell-only, fits comfortably tight
+- `TNS_END_PERCENT = 100` — repair every violator (small design, cheap to fix all)
+- Clock: `700 ps` (Fmax ~1.43 GHz)
+
+### Decisions
+- **2026-05-01 `6511fb56`**: clock relaxed from 200 ps → 700 ps in PR #109 to match achievable Fmax — at the prior aggressive target the resizer inserted dozens of buffers chasing an unreachable bound.
+
+### Known issues / open questions
+- None.
+
+## nangate45
+
+**Status**: closing
+**Last updated**: 2026-03-21 (commit `fb6ec1d4`)
+
+### Configuration
+- `CORE_UTILIZATION = 20` — design is so small (~200 cells) that lower util just gives breathing room for IO placement
+- `PLACE_DENSITY_LB_ADDON = 0.20`
+- `TNS_END_PERCENT = 100`
+- Clock: `0.46 ns` (Fmax ~2.17 GHz)
+
+### Decisions
+- None recorded — initial port closed cleanly with these values.
+
+### Known issues / open questions
+- None.
+
+## sky130hd
+
+**Status**: closing
+**Last updated**: 2026-05-01 (commit `6511fb56`)
+
+### Configuration
+- `CORE_UTILIZATION = 40`
+- `TNS_END_PERCENT = 100`
+- Clock: `1.4 ns` (Fmax ~715 MHz)
+
+### Decisions
+- **2026-05-01 `6511fb56`**: clock relaxed in PR #109 (same shape as asap7) to match achievable Fmax on sky130hd's coarser cells.
+
+### Known issues / open questions
+- None.

--- a/designs/src/lfsr/DECISIONS.md
+++ b/designs/src/lfsr/DECISIONS.md
@@ -6,7 +6,7 @@ This is a small std-cell-only design (~200 cells, no macros) used as a smoke tes
 
 ## asap7
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-05-01 (commit `6511fb56`)
 
 ### Configuration
@@ -22,7 +22,7 @@ This is a small std-cell-only design (~200 cells, no macros) used as a smoke tes
 
 ## nangate45
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-03-21 (commit `fb6ec1d4`)
 
 ### Configuration
@@ -39,7 +39,7 @@ This is a small std-cell-only design (~200 cells, no macros) used as a smoke tes
 
 ## sky130hd
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-05-01 (commit `6511fb56`)
 
 ### Configuration

--- a/designs/src/liteeth/DECISIONS.md
+++ b/designs/src/liteeth/DECISIONS.md
@@ -21,7 +21,7 @@ FakeRAM macros are shared across variants per platform under `designs/<platform>
 
 ## asap7
 
-**Status**: all 6 variants closing
+**Status**: all 6 variants finishing
 **Last updated**: variants land between `518c6e03` (2026-03-19) and `c8d96617` (2026-04-30)
 
 ### Per-variant configuration
@@ -41,7 +41,7 @@ FakeRAM macros are shared across variants per platform under `designs/<platform>
 
 ## nangate45
 
-**Status**: all 6 variants closing
+**Status**: all 6 variants finishing
 **Last updated**: 2026-03-19 (commit `518c6e03`)
 
 ### Per-variant configuration
@@ -60,7 +60,7 @@ FakeRAM macros are shared across variants per platform under `designs/<platform>
 
 ## sky130hd
 
-**Status**: all 6 variants closing
+**Status**: all 6 variants finishing
 **Last updated**: variants land between `518c6e03` and `c8d96617`
 
 ### Per-variant configuration

--- a/designs/src/liteeth/DECISIONS.md
+++ b/designs/src/liteeth/DECISIONS.md
@@ -1,0 +1,85 @@
+# liteeth Design Decisions
+
+Per-platform / per-variant notes for the `liteeth` Ethernet stack family (LiteX/Python).  See `CLAUDE.md` (root) for the canonical upstream-bug index.
+
+The 6 variants share `designs/src/liteeth/` for RTL but each has its own per-platform `BUILD.bazel` and `constraint.sdc` because they differ in size, FakeRAM count, and PHY interface complexity:
+
+| Variant | Protocol | PHY |
+|---|---|---|
+| `liteeth_mac_axi_mii` | MAC (AXI) | MII |
+| `liteeth_mac_wb_mii` | MAC (Wishbone) | MII |
+| `liteeth_udp_raw_rgmii` | UDP raw | RGMII |
+| `liteeth_udp_stream_rgmii` | UDP stream | RGMII |
+| `liteeth_udp_stream_sgmii` | UDP stream | SGMII |
+| `liteeth_udp_usp_gth_sgmii` | UDP | USP GTH SGMII |
+
+FakeRAM macros are shared across variants per platform under `designs/<platform>/liteeth/sram/{lef,lib}/`.
+
+## Active workarounds
+
+- **ODB-1200** in CTS-time `repair_timing` affects `liteeth_udp_stream_sgmii` and `liteeth_udp_usp_gth_sgmii` on **asap7**.  Fixed via `SKIP_CTS_REPAIR_TIMING = 1` (skip the entire repair pass; route's own hold-repair still runs).  See [HighTide#75](https://github.com/VLSIDA/HighTide/issues/75).
+
+## asap7
+
+**Status**: all 6 variants closing
+**Last updated**: variants land between `518c6e03` (2026-03-19) and `c8d96617` (2026-04-30)
+
+### Per-variant configuration
+
+| Variant | Util | Density | Halo | Clock (ps) | Notes |
+|---|---:|---:|---:|---:|---|
+| `liteeth_mac_axi_mii` | 40 | 0.4 | 2 2 | 610 | Smallest variant |
+| `liteeth_mac_wb_mii` | 30 | 0.4 | 5 5 | 1000 | Wishbone bus is wider |
+| `liteeth_udp_raw_rgmii` | 35 | 0.3 | 5 5 | 590 | `SYNTH_HIERARCHICAL=1` |
+| `liteeth_udp_stream_rgmii` | 35 | 0.5 | 5 5 | 700 | |
+| `liteeth_udp_stream_sgmii` | 40 | 0.3 | 5 5 | 1000 | `SKIP_CTS_REPAIR_TIMING=1` (ODB-1200) |
+| `liteeth_udp_usp_gth_sgmii` | 35 | 0.3 | — | 1000 | `SKIP_CTS_REPAIR_TIMING=1` (ODB-1200) |
+
+### Decisions
+- **2026-04-24 `87829fdb`**: `liteeth_udp_stream_sgmii` hit ODB-1200 in CTS repair_timing; added `SKIP_CTS_REPAIR_TIMING=1`.
+- **2026-04-30 `c8d96617`**: `liteeth_udp_usp_gth_sgmii` hit the same ODB-1200; same workaround applied.
+
+## nangate45
+
+**Status**: all 6 variants closing
+**Last updated**: 2026-03-19 (commit `518c6e03`)
+
+### Per-variant configuration
+
+| Variant | Util | Density | Halo | Clock (ns) | Notes |
+|---|---:|---:|---:|---:|---|
+| `liteeth_mac_axi_mii` | (default) | 0.4 | 30 30 | (default ~10) | |
+| `liteeth_mac_wb_mii` | (default) | 0.35 | 30 30 | (default) | |
+| `liteeth_udp_raw_rgmii` | 35 | 0.6 | — | 10 | `SYNTH_HIERARCHICAL=1` |
+| `liteeth_udp_stream_rgmii` | 45 | 0.7 | — | 10 | `SYNTH_HIERARCHICAL=1` — packs tightest of all variants |
+| `liteeth_udp_stream_sgmii` | 60 | 0.85 | — | 10 | `SYNTH_HIERARCHICAL=1` — densest variant on nangate45; ODB-1200 doesn't trigger here, no CTS skip needed |
+| `liteeth_udp_usp_gth_sgmii` | 45 | 0.4 | — | 10 | `SYNTH_HIERARCHICAL=1` |
+
+### Decisions
+- nangate45 closes the SGMII variants without the ODB-1200 workaround that asap7 needs — the bug is sensitive to the specific resizer-state interaction triggered by asap7's smaller cells.
+
+## sky130hd
+
+**Status**: all 6 variants closing
+**Last updated**: variants land between `518c6e03` and `c8d96617`
+
+### Per-variant configuration
+
+| Variant | Util | Density | Halo | Clock (ns) | Notes |
+|---|---:|---:|---:|---:|---|
+| `liteeth_mac_axi_mii` | 45 | 0.15 | 30 30 | (default) | |
+| `liteeth_mac_wb_mii` | 40 | 0.15 | 20 20 | (default) | |
+| `liteeth_udp_raw_rgmii` | 35 | 0.4 | 30 30 | 10 | `SYNTH_HIERARCHICAL=1` |
+| `liteeth_udp_stream_rgmii` | 40 | 0.35 | 30 30 | 10 | |
+| `liteeth_udp_stream_sgmii` | 35 | 0.3 | 30 30 | 10 | No ODB-1200 workaround needed on sky130hd |
+| `liteeth_udp_usp_gth_sgmii` | 50 | 0.4 | 30 30 | 10 | |
+
+### Decisions
+- sky130hd halos are uniformly 30×30 across variants — large enough to keep std cells out of the macro shadow given sky130hd's wide cells.
+- ODB-1200 doesn't trigger on sky130hd's variants either, same as nangate45.
+
+## Cross-platform notes
+
+- The `mac_*_mii` variants are smallest and use the loosest util / lowest density; the `udp_stream_*` variants pack tighter because they have less FakeRAM overhead.
+- `SYNTH_HIERARCHICAL=1` is set on the larger variants (anything `udp_*` on nangate45 and the rgmii variants on sky130hd) to keep synth tractable.
+- ODB-1200 is asap7-only for the SGMII pair; do not pre-emptively add `SKIP_CTS_REPAIR_TIMING` on other platforms — it disables a repair pass that nangate45/sky130hd actually use.

--- a/designs/src/minimax/DECISIONS.md
+++ b/designs/src/minimax/DECISIONS.md
@@ -6,7 +6,7 @@ A small RISC-V core (~10–20k stdcells, no macros).  Used as a real-RTL smoke t
 
 ## asap7
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-05-01 (commit `49c7aee5`)
 
 ### Configuration
@@ -23,7 +23,7 @@ A small RISC-V core (~10–20k stdcells, no macros).  Used as a real-RTL smoke t
 
 ## nangate45
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-05-01 (commit `49c7aee5`)
 
 ### Configuration
@@ -40,7 +40,7 @@ A small RISC-V core (~10–20k stdcells, no macros).  Used as a real-RTL smoke t
 
 ## sky130hd
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-05-01 (commit `49c7aee5`)
 
 ### Configuration

--- a/designs/src/minimax/DECISIONS.md
+++ b/designs/src/minimax/DECISIONS.md
@@ -1,0 +1,56 @@
+# minimax Design Decisions
+
+Per-platform notes on tuning, workarounds, and platform-specific quirks for `minimax` (RV32I core, SystemVerilog → sv2v).  See `CLAUDE.md` (root) for the canonical upstream-bug index.
+
+A small RISC-V core (~10–20k stdcells, no macros).  Used as a real-RTL smoke test on every platform.
+
+## asap7
+
+**Status**: closing
+**Last updated**: 2026-05-01 (commit `49c7aee5`)
+
+### Configuration
+- `CORE_UTILIZATION = 65` — packs std cells tight; design fits at higher util than typical for asap7
+- `PLACE_DENSITY = 0.7`
+- `CORE_ASPECT_RATIO = 1.0`, `CORE_MARGIN = 4`
+- Clock: `900 ps` (Fmax ~1.11 GHz, WNS +4.8 ps)
+
+### Decisions
+- **2026-05-01 `49c7aee5`**: clock relaxed from 400 ps → 900 ps in PR #108.  Old 400 ps was ~50% of the design's actual capability; period_min after FP was ~750 ps and the resizer chased 2000+ violators on every build.  900 ps (vs naive 800 ps) chosen because synthesis becomes less aggressive at relaxed targets, drifting period_min upward — 900 ps is the first round number that closes cleanly.
+
+### Known issues / open questions
+- None.
+
+## nangate45
+
+**Status**: closing
+**Last updated**: 2026-05-01 (commit `49c7aee5`)
+
+### Configuration
+- `CORE_UTILIZATION = 60`
+- `PLACE_DENSITY = 0.7`
+- `CORE_ASPECT_RATIO = 1.0`, `CORE_MARGIN = 6`
+- Clock: `1.6 ns` (Fmax ~629 MHz, WNS +9.9 ps)
+
+### Decisions
+- **2026-05-01 `49c7aee5`**: clock relaxed from 0.8 ns → 1.6 ns in PR #108.  Same shape as asap7 — original constraint was ~50% of achievable Fmax.
+
+### Known issues / open questions
+- None.
+
+## sky130hd
+
+**Status**: closing
+**Last updated**: 2026-05-01 (commit `49c7aee5`)
+
+### Configuration
+- `CORE_UTILIZATION = 40`
+- `PLACE_DENSITY = 0.6`
+- `CORE_ASPECT_RATIO = 1.0`, `CORE_MARGIN = 12`
+- Clock: `8 ns` (Fmax ~130 MHz, WNS +310 ps)
+
+### Decisions
+- **2026-05-01 `49c7aee5`**: clock relaxed from 4 ns → 8 ns in PR #108.  sky130hd's coarse pitches and slower std cells push period_min above the original target by ~2×.
+
+### Known issues / open questions
+- None.

--- a/designs/src/sha3/DECISIONS.md
+++ b/designs/src/sha3/DECISIONS.md
@@ -6,7 +6,7 @@ Mid-size combinational-heavy core (~20k stdcells, no macros).
 
 ## asap7
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-03-19 (commit `187ef139`)
 
 ### Configuration
@@ -22,7 +22,7 @@ Mid-size combinational-heavy core (~20k stdcells, no macros).
 
 ## nangate45
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-03-21 (commit `205e9ff0`)
 
 ### Configuration
@@ -38,7 +38,7 @@ Mid-size combinational-heavy core (~20k stdcells, no macros).
 
 ## sky130hd
 
-**Status**: closing
+**Status**: finishing
 **Last updated**: 2026-04-25 (commit `caba4c83`)
 
 ### Configuration

--- a/designs/src/sha3/DECISIONS.md
+++ b/designs/src/sha3/DECISIONS.md
@@ -1,0 +1,53 @@
+# sha3 Design Decisions
+
+Per-platform notes on tuning, workarounds, and platform-specific quirks for `sha3` (SHA3 hash engine, Verilog).  See `CLAUDE.md` (root) for the canonical upstream-bug index.
+
+Mid-size combinational-heavy core (~20k stdcells, no macros).
+
+## asap7
+
+**Status**: closing
+**Last updated**: 2026-03-19 (commit `187ef139`)
+
+### Configuration
+- `CORE_UTILIZATION = 70` — combinational logic packs tight
+- `PLACE_DENSITY = 0.75`
+- Clock: `1000 ps` (Fmax ~1 GHz)
+
+### Decisions
+- None recorded — initial port closed at these values.
+
+### Known issues / open questions
+- None.
+
+## nangate45
+
+**Status**: closing
+**Last updated**: 2026-03-21 (commit `205e9ff0`)
+
+### Configuration
+- `CORE_UTILIZATION = 45`
+- `PLACE_DENSITY_LB_ADDON = 0.20`
+- Clock: `2.5 ns` (Fmax ~400 MHz)
+
+### Decisions
+- None recorded.
+
+### Known issues / open questions
+- None.
+
+## sky130hd
+
+**Status**: closing
+**Last updated**: 2026-04-25 (commit `caba4c83`)
+
+### Configuration
+- `CORE_UTILIZATION = 25` — sky130hd's coarse pitches force a much lower util than asap7/nangate45 to avoid routing congestion
+- `PLACE_DENSITY_LB_ADDON = 0.20`
+- Clock: `10 ns` (Fmax ~100 MHz)
+
+### Decisions
+- None recorded.
+
+### Known issues / open questions
+- None.


### PR DESCRIPTION
Followup to #120.  Bootstraps `designs/src/<design>/DECISIONS.md` for each design that currently has rows on the public `webpage/results.html`:

| Design | Variants | Platforms | Notes |
|---|---|---|---|
| lfsr | 1 | asap7 / nangate45 / sky130hd | Std-cell-only; clocks relaxed in PR #109 |
| minimax | 1 | asap7 / nangate45 / sky130hd | Std-cell-only; clocks relaxed in PR #108 |
| sha3 | 1 | asap7 / nangate45 / sky130hd | Combinational-heavy hash core |
| gemmini | 1 | asap7 / nangate45 / sky130hd | **ODB-1200** workaround active on all 3 (drops `split_load` from `SETUP_MOVE_SEQUENCE`) |
| coralnpu | 1 | asap7 / nangate45 / sky130hd | `SYNTH_HIERARCHICAL=1` everywhere; sky130hd halos scaled to platform pitch |
| floonoc | 1 | asap7 / nangate45 (+ sky130hd marked not finishing) | NoC with manual `io.tcl` |
| liteeth | 6 | asap7 / nangate45 / sky130hd | **ODB-1200** workaround active on `asap7/liteeth_udp_stream_sgmii` and `asap7/liteeth_udp_usp_gth_sgmii` (`SKIP_CTS_REPAIR_TIMING=1`); 6 variants summarised in per-platform tables inside the file |

Each file follows the shape from #120's skill update: `## <platform>` sections with **Configuration**, **Decisions**, and **Known issues / open questions**.  Multi-variant designs (liteeth) use a per-platform table instead of duplicating six sub-sections each.

## How this was generated

For each (platform, design) pair:
- Read `BUILD.bazel` `arguments={…}` for util / density / halo / `SETUP_MOVE_SEQUENCE` / `SKIP_*` flags.
- Read `constraint.sdc` for clock period.
- Noted presence of `io.tcl` / `pdn.tcl` / `macros.tcl`.
- Cross-referenced rows in CLAUDE.md's bug table (`gemmini` ODB-1200, `liteeth_udp_*_sgmii` ODB-1200, `floonoc` not finishing on sky130hd).
- Pulled `git log -1 --format=%h -- designs/<platform>/<design>/ designs/src/<design>/` for the "Last updated" sha.
- Filtered git log for commits matching tuning verbs (Relax, Tighten, Drop, Skip, etc.) for the "Decisions" entries; kept the most recent meaningful one per platform.

## What's not in scope

- NVDLA, vortex, NyuziProcessor, snitch_cluster, bp_processor, cnn — these aren't on results.html yet.  When they land there, run `/update-design --init-decisions <design>` to generate their files following the same shape.

## Test plan

- [x] All 7 files parse as valid markdown (no broken tables).
- [x] Each file's bug-table cross-references exist in CLAUDE.md's row.
- [x] Per-platform configs match the live BUILD.bazel as of `b36dfb79` (origin/main).