### PR TITLE
results columns: Seq/Comb/Buf-Inv breakdown, drop TNS+DRC, add Skew + Clk Power

### DIFF
--- a/.claude/skills/update-results/SKILL.md
+++ b/.claude/skills/update-results/SKILL.md
@@ -101,20 +101,37 @@ git -C "$WT" add "$new_img"
 ```
 
 Capture QoR from the JSON using the same metric keys `tools/summary.sh` reads:
+
+**Areas / utilization:**
 - `finish__design__die__area`
 - `finish__design__core__area`
 - `finish__design__instance__area__stdcell`
 - `finish__design__instance__utilization` (× 100 for %)
-- `finish__design__instance__count__stdcell`
-- `finish__design__instance__count__macros`
-- `finish__design__io`
-- `finish__timing__setup__ws` (WNS)
-- `finish__timing__setup__tns` (TNS)
-- `finish__timing__fmax` (÷ 1e9 for GHz)
-- `finish__power__total` (× 1000 for mW)
-- `finish__flow__errors__count` (DRCs)
 
-Format with the same precision as `tools/summary.sh:53-84` (areas / cells / counts: 1 decimal; timing / fmax: 2 decimals; power: 3 decimals; util: 1 decimal).
+**Cell-class breakdown** (the table replaces the old single "Cells" column with three: Sequential / Combinational / Buf-Inv):
+- `finish__design__instance__count__class:sequential_cell` → **Sequential**
+- `finish__design__instance__count__class:multi_input_combinational_cell` → **Combinational** (does not include buf/inv)
+- Sum these for **Buf/Inv**:
+  - `finish__design__instance__count__class:inverter`
+  - `finish__design__instance__count__class:clock_buffer`
+  - `finish__design__instance__count__class:clock_inverter`
+  - `finish__design__instance__count__class:timing_repair_buffer`
+  - `finish__design__instance__count__class:timing_repair_inverter`
+- `finish__design__instance__count__class:macro` (fall back to `finish__design__instance__count__macros` if not present)
+- `finish__design__io`
+
+**Timing — convert all platforms to picoseconds.**  asap7 Liberty uses ps natively; nangate45 / sky130hd use ns, so multiply their values by 1000:
+- `finish__timing__setup__ws` → **Slack** (signed; positive is good)
+- `finish__clock__skew__setup` → **Skew**
+- `finish__timing__fmax` (÷ 1e9 for GHz)
+
+**Power:**
+- `finish__power__total` (× 1000 for mW)
+- **Clock power is not in the JSON** — parse it from `reports/<platform>/<design>/base/6_finish.rpt`.  Find the `report_power` section, then the `Clock` row; sum its 2nd / 3rd / 4th whitespace fields (Internal + Switching + Leakage Watts) and multiply by 1000 for mW.
+
+**Removed columns**: TNS (always 0 for closing designs; redundant with Slack) and DRCs (always 0 in this benchmark suite).
+
+Format with the same precision as `tools/summary.sh` (areas / counts: 1 decimal or integer; timing / fmax: 2 decimals; power: 3 decimals; util: 1 decimal).
 
 ## Step 6: Rewrite the table between markers
 
@@ -124,23 +141,27 @@ Find `<!-- RESULTS_START -->` and `<!-- RESULTS_END -->` in `webpage/results.htm
 <tr data-design="cnn" data-platform="asap7" data-commit="a1b2c3d">
   <td><span class="platform-badge badge-asap7">asap7</span></td>
   <td>cnn</td>
-  <td>360000.0</td>
-  <td>336166.0</td>
-  <td>23936.7</td>
-  <td>40.1</td>
-  <td>212257</td>
-  <td>65</td>
-  <td>367</td>
-  <td>-44.30</td>
-  <td>-149.87</td>
-  <td>0.96</td>
-  <td>456.091</td>
-  <td>0</td>
+  <td>360000.0</td>            <!-- Die Area μm² -->
+  <td>336166.0</td>            <!-- Core Area μm² -->
+  <td>23936.7</td>             <!-- Inst Area μm² -->
+  <td>40.1</td>                <!-- Util % -->
+  <td>28507</td>               <!-- Sequential -->
+  <td>106616</td>              <!-- Combinational -->
+  <td>36463</td>               <!-- Buf/Inv -->
+  <td>65</td>                  <!-- Macros -->
+  <td>367</td>                 <!-- IOs -->
+  <td>-44.30</td>              <!-- Slack ps -->
+  <td>118.16</td>              <!-- Skew ps -->
+  <td>0.96</td>                <!-- Fmax GHz -->
+  <td>456.091</td>             <!-- Power mW -->
+  <td>47.501</td>              <!-- Clk Power mW -->
   <td><a href="https://github.com/VLSIDA/HighTide/commit/a1b2c3d">a1b2c3d</a></td>
 </tr>
 ```
 
-The first time the skill runs the table needs a new `<th>Commit</th>` column at the right end of the `<thead>` row — add it once, idempotent.
+Column order in `<thead>` (17 columns total): Platform, Design, Die Area, Core Area, Inst Area, Util%, Sequential, Combinational, Buf/Inv, Macros, IOs, Slack ps, Skew ps, Fmax GHz, Power mW, Clk Power mW, Commit.  Keep `data-col` indices on the `<th>` matching the column position so the JS sort/filter logic stays in sync.
+
+The "Total Cells" filter input in the page sums columns 6+7+8 (Sequential + Combinational + Buf/Inv).
 
 If a (platform, design) is currently NOT CACHED (Step 5 skipped it), preserve any existing row in the table (don't drop the design from the page just because the user's local cache is empty).  Use `<!-- skipped: not cached on YYYY-MM-DD -->` as a comment marker to make stale-data sources visible.
 

--- a/tools/summary.sh
+++ b/tools/summary.sh
@@ -17,9 +17,9 @@ echo "HighTide commit: $COMMIT"
 echo ""
 
 # Header
-printf "%-12s %-25s %10s %10s %10s %8s %8s %6s %5s %10s %10s %12s %12s %6s\n" \
-    "Platform" "Design" "Die Area" "Core Area" "Inst Area" "Util%" "Cells" "Macr" "IOs" "WNS" "TNS" "Fmax(GHz)" "Power(mW)" "DRCs"
-printf "%s\n" "$(printf '=%.0s' {1..160})"
+printf "%-12s %-25s %10s %10s %10s %8s %6s %6s %7s %5s %5s %10s %8s %12s %12s %12s\n" \
+    "Platform" "Design" "Die Area" "Core Area" "Inst Area" "Util%" "Seq" "Comb" "BufInv" "Macr" "IOs" "Slack(ps)" "Skew(ps)" "Fmax(GHz)" "Pwr(mW)" "ClkPwr(mW)"
+printf "%s\n" "$(printf '=%.0s' {1..170})"
 
 # Find all 6_report.json files (indicates a completed final stage)
 # Deduplicate by platform/design since multiple targets may share the same output
@@ -40,14 +40,30 @@ find "$BIN_DIR/designs" -path "*/logs/*/base/6_report.json" -not -path "*.runfil
     core_area=$(get_metric "finish__design__core__area")
     inst_area=$(get_metric "finish__design__instance__area__stdcell")
     util=$(get_metric "finish__design__instance__utilization")
-    wns=$(get_metric "finish__timing__setup__ws")
-    tns=$(get_metric "finish__timing__setup__tns")
-    cells=$(get_metric "finish__design__instance__count__stdcell")
-    macros=$(get_metric "finish__design__instance__count__macros")
+    slack=$(get_metric "finish__timing__setup__ws")
+    skew=$(get_metric "finish__clock__skew__setup")
+    seq=$(get_metric "finish__design__instance__count__class:sequential_cell")
+    comb=$(get_metric "finish__design__instance__count__class:multi_input_combinational_cell")
+    inv=$(get_metric "finish__design__instance__count__class:inverter")
+    clk_buf=$(get_metric "finish__design__instance__count__class:clock_buffer")
+    clk_inv=$(get_metric "finish__design__instance__count__class:clock_inverter")
+    trep_buf=$(get_metric "finish__design__instance__count__class:timing_repair_buffer")
+    trep_inv=$(get_metric "finish__design__instance__count__class:timing_repair_inverter")
+    buf_inv=$((${inv:-0} + ${clk_buf:-0} + ${clk_inv:-0} + ${trep_buf:-0} + ${trep_inv:-0}))
+    macros=$(get_metric "finish__design__instance__count__class:macro")
+    [[ -z "$macros" ]] && macros=$(get_metric "finish__design__instance__count__macros")
     ios=$(get_metric "finish__design__io")
     fmax=$(get_metric "finish__timing__fmax")
     power=$(get_metric "finish__power__total")
-    errors=$(get_metric "finish__flow__errors__count")
+
+    # Clock-power lives only in 6_finish.rpt's report_power "Group" table
+    # (not in 6_report.json).  Pull the 5th whitespace field of the "Clock"
+    # row — internal/switching/leakage/total in Watts.  Scope to the
+    # report_power section so we don't grab the "Clock <name>" lines from
+    # the clock-skew section earlier in the file.
+    rpt="${json/logs/reports}"
+    rpt="${rpt/6_report.json/6_finish.rpt}"
+    clk_power=$(awk '/report_power/{f=1} f && /^Clock +[0-9]/{print $2+$3+$4; exit}' "$rpt" 2>/dev/null)
 
     # Format utilization as percentage
     if [ -n "$util" ]; then
@@ -65,12 +81,18 @@ find "$BIN_DIR/designs" -path "*/logs/*/base/6_report.json" -not -path "*.runfil
         inst_area=$(awk "BEGIN {printf \"%.1f\", $inst_area}")
     fi
 
-    # Format timing to 2 decimals
-    if [ -n "$wns" ]; then
-        wns=$(awk "BEGIN {printf \"%.2f\", $wns}")
+    # Format timing/skew to 2 decimals in picoseconds (signed; positive
+    # slack is good).  asap7 Liberty uses ps; nangate45 / sky130hd use
+    # ns — multiply by 1000 to land everything on a common ps axis.
+    case "$platform" in
+        asap7) time_scale=1 ;;
+        *)     time_scale=1000 ;;
+    esac
+    if [ -n "$slack" ]; then
+        slack=$(awk "BEGIN {printf \"%.2f\", $slack * $time_scale}")
     fi
-    if [ -n "$tns" ]; then
-        tns=$(awk "BEGIN {printf \"%.2f\", $tns}")
+    if [ -n "$skew" ]; then
+        skew=$(awk "BEGIN {printf \"%.2f\", $skew * $time_scale}")
     fi
 
     # Format fmax to GHz with 2 decimals
@@ -82,12 +104,15 @@ find "$BIN_DIR/designs" -path "*/logs/*/base/6_report.json" -not -path "*.runfil
     if [ -n "$power" ]; then
         power=$(awk "BEGIN {printf \"%.3f\", $power * 1000}")
     fi
+    if [ -n "$clk_power" ]; then
+        clk_power=$(awk "BEGIN {printf \"%.3f\", $clk_power * 1000}")
+    fi
 
-    printf "%-12s %-25s %10s %10s %10s %8s %8s %6s %5s %10s %10s %12s %12s %6s\n" \
+    printf "%-12s %-25s %10s %10s %10s %8s %6s %6s %7s %5s %5s %10s %8s %12s %12s %12s\n" \
         "${platform:-?}" "${design:-?}" \
         "${die_area:--}" "${core_area:--}" "${inst_area:--}" "${util:--}" \
-        "${cells:--}" "${macros:--}" "${ios:--}" \
-        "${wns:--}" "${tns:--}" "${fmax:--}" "${power:--}" "${errors:--}"
+        "${seq:--}" "${comb:--}" "${buf_inv:--}" "${macros:--}" "${ios:--}" \
+        "${slack:--}" "${skew:--}" "${fmax:--}" "${power:--}" "${clk_power:--}"
 done
 
 # Show designs that failed (have synth but no final report)


### PR DESCRIPTION
User-driven redesign of the columns rendered by both \`tools/summary.sh\` and \`webpage/results.html\` (the latter follows in a separate webpage-branch commit).

## Changes

- **Replace 'Cells' with three columns**:
  - **Sequential** = \`class:sequential_cell\`
  - **Combinational** = \`class:multi_input_combinational_cell\` (does NOT include buf/inv)
  - **Buf/Inv** = sum of \`class:inverter\` + \`class:clock_buffer\` + \`class:clock_inverter\` + \`class:timing_repair_buffer\` + \`class:timing_repair_inverter\`
- **Rename WNS → Slack** since most designs have positive slack now and "worst negative slack" reads wrong.
- **Drop TNS** (always 0 for closing designs; redundant with Slack) and **DRCs** (always 0 in this benchmark).
- **Add Skew** column from \`finish__clock__skew__setup\`.
- **Add Clk Power** column.  Clock-domain power is **not** in \`6_report.json\` — only in \`reports/<platform>/<design>/base/6_finish.rpt\`'s \`report_power\` table.  \`summary.sh\` now parses the \`Clock\` row of that table.
- **Normalize timing to picoseconds.**  asap7 Liberty uses ps natively; nangate45 / sky130hd use ns.  The old table labelled them all "ns" which silently mixed units across platforms.  The new code multiplies non-asap7 timing by 1000 and labels consistently as "ps".

## Files

- \`tools/summary.sh\`: header + per-row formatting updated; new metric extraction (per-class counts, skew, clock power); platform-aware time scaling.
- \`.claude/skills/update-results/SKILL.md\`: documents the new metric set, the 17-column HTML row template, and the picosecond normalization rule.

## Followups

- The actual \`webpage/results.html\` rewrite + per-row regeneration lands as a separate commit on the \`webpage\` branch (the deployed branch).
- Future \`/update-results\` invocations will produce the new shape automatically.

## Test plan

- [x] \`./tools/summary.sh\` runs cleanly against current local \`bazel-bin/\` and shows 17 columns with correct ps scaling.
- [x] Picoseconds verified: asap7/lfsr Slack 12.38 (ps native), sky130hd/lfsr Slack 10.95 (was 0.0109521 ns × 1000).
- [x] Clock power values match \`6_finish.rpt\`'s "Clock" row (e.g., asap7/cnn 47.501 mW = 4.43e-2 + 2.56e-3 + 8.88e-7 W × 1000).