### PR TITLE
fetch_cache: bump default timeout 30s -> 300s

### DIFF
--- a/tools/fetch_cache.sh
+++ b/tools/fetch_cache.sh
@@ -12,7 +12,7 @@
 # Options:
 #   --stage STAGE   Stop at stage (synth, floorplan, place, cts, route, final)
 #                   Default: final
-#   --timeout SECS  Remote cache timeout in seconds (default: 30)
+#   --timeout SECS  Remote cache timeout in seconds (default: 300)
 
 set -uo pipefail
 
@@ -20,7 +20,7 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
 
 REMOTE_CACHE="https://cache.hightide-benchmarks.dev"
-TIMEOUT=30
+TIMEOUT=300
 STAGE="final"
 FILTER_PLATFORM=""
 FILTER_DESIGN=""


### PR DESCRIPTION
## Summary
- The 30s default timeout silently kills `bazel build` mid-fetch on designs with many remote-cache-only actions (NVDLA partitions are ~6000 actions, ~50s wall time on a fresh state).
- The script then reports `NOT CACHED` for designs that actually exist in the cache, just because bazel hadn't finished fetching all stages within 30s.
- Bumping the default to 300s gives bazel enough headroom for any current design without forcing every caller to remember `--timeout 300`.

## Test plan
- [x] Verified that fetching a fresh NVDLA partition_a with the unauth URL completes in ~51s and reports 5995 remote cache hits (well above the old 30s ceiling).
- [x] `--timeout` flag still works as an explicit override.