### PR TITLE
update-results: emit per-platform placeholders for missing builds

### DIFF
--- a/.claude/skills/update-results/SKILL.md
+++ b/.claude/skills/update-results/SKILL.md
@@ -177,6 +177,21 @@ Concretely: emit all asap7 thumbs (sorted by variant), then all nangate45 thumbs
 
 For cards with one thumb per platform (CoralNPU, Vortex, Gemmini, etc.), the variant secondary sort is a no-op — just preserve asap7 → nangate45 → sky130hd order.
 
+### Per-platform placeholders for cards with missing builds
+
+A design card lists one platform badge per technology it *targets*; not every target has a cached `_final` yet.  When a badged platform has no thumb at all (no cached build, no fallback variant), emit a placeholder in that platform's slot instead of leaving the row visually shorter than the badge count suggests:
+
+```html
+<div class="thumb-placeholder"><div class="ph-box">pending</div><span class="thumb-label asap7">asap7</span></div>
+```
+
+Rules:
+- One placeholder per badged platform that has zero thumbs in the card.  If even a single family member (e.g. one LiteEth variant, one NVDLA partition) has a thumb for that platform, do not emit a placeholder.
+- Place each placeholder in the (platform, variant) sort position it would occupy if a real thumb existed — i.e. inside the asap7 group, nangate45 group, etc.
+- Don't emit per-variant placeholders for missing variants within a platform that already has at least one thumb — those would clutter family cards (LiteEth, NVDLA) where the variant set is the user's choice, not a build-status signal.
+
+The legacy single `<div class="placeholder">Die image pending</div>` block is deprecated; replace it with the per-platform placeholder pattern above on first run.
+
 ## Step 8: Update the Design Portfolio platform badges in index.html
 
 `webpage/index.html` has a "Design Portfolio" table (`<section id="designs">`) where each row's last column is a list of `<span class="platform-badge badge-<platform>">…</span>` tags.  Those badges must reflect which platforms each design *actually* reaches `_final` on, derived from the same per-(platform, design) sweep used above.


### PR DESCRIPTION
## Summary

Document a placeholder pattern for design cards that are badged for a platform but have no cached build on that platform.

Rather than the legacy single \`<div class=\"placeholder\">Die image pending</div>\` block (which hides the per-platform breakdown), emit one \`<div class=\"thumb-placeholder\">\` per badged-but-uncached platform, in the same (platform, variant) sort position a real thumb would occupy. Single-thumb-per-platform cards (Snitch Cluster, NyuziProcessor) now show one slot per badge instead of disappearing into a generic placeholder.

Rules captured in Step 7:
- One placeholder per *badged platform with zero thumbs*. No per-variant placeholders within an already-covered platform — that would clutter family cards like LiteEth / NVDLA where the variant set is the user's choice, not a build-status signal.
- Legacy single placeholder block is deprecated; replace on first run.

## Test plan

- [x] Already applied to the webpage branch (commit 82d2fc42 on webpage). Snitch Cluster + NyuziProcessor now show per-platform placeholders.
- [ ] Next \`/update-results\` sweep should not introduce a diff on those two cards (idempotency).