### PR TITLE
improve-skills: mine DECISIONS.md and OpenROAD issues during audits

### DIFF
--- a/.claude/skills/improve-skills/SKILL.md
+++ b/.claude/skills/improve-skills/SKILL.md
@@ -37,6 +37,53 @@ Look for:
 
 Read the memory index at the project memory path for any feedback or project memories that should be reflected in skills.
 
+### 1d. Mine per-design DECISIONS.md files
+
+Each design records non-obvious choices in `designs/src/<design>/DECISIONS.md`
+(bug workarounds, manual macro/IO placement, timing-constraint choices,
+utilization tuning, etc., with one section per technology). Aggregate these
+into patterns:
+
+```bash
+# All decision files with their headings and workaround/issue lines
+for f in designs/src/*/DECISIONS.md; do
+    echo "=== $f ==="
+    grep -E '^#|^- |Workaround:|Issue:|OpenROAD #|yosys-slang #' "$f"
+done
+```
+
+Look for:
+- **Same workaround in multiple designs** — promote to a skill bullet (in `debug-design`, `port-design`, or `optimize-ppa` as appropriate). If the same env var, macro-halo bump, or SDC pattern shows up in 2+ DECISIONS files, it is general knowledge, not design-specific.
+- **Same upstream bug referenced** — confirm it is in `CLAUDE.md`'s "Known OpenROAD / yosys-slang bug workarounds" table; if not, hand off to the `track-bug` skill or add it directly.
+- **Decisions that contradict skill guidance** — either the skill is wrong, or the design is doing something the skill should explicitly warn about.
+
+### 1e. Cross-reference with OpenROAD upstream issues
+
+DECISIONS.md, CLAUDE.md, and commit messages often reference OpenROAD GitHub
+issues by number (e.g. `OpenROAD #1234`) or by tool category (`ODB-1200`,
+`CTS-0105`, `MPL-0040`, `PSM-0069`, `GRT-…`, `RSZ-…`). For each issue
+referenced more than once across the repo, check its current state:
+
+```bash
+# Collect upstream-bug references and rank by frequency
+{
+    grep -rohE 'OpenROAD[ -]#[0-9]+|ODB-[0-9]+|CTS-[0-9]+|GRT-[0-9]+|MPL-[0-9]+|PSM-[0-9]+|RSZ-[0-9]+' \
+        designs/src/*/DECISIONS.md CLAUDE.md 2>/dev/null
+    git log --pretty=%B -200 | grep -oE 'OpenROAD[ -]#[0-9]+|ODB-[0-9]+|CTS-[0-9]+|GRT-[0-9]+|MPL-[0-9]+|PSM-[0-9]+|RSZ-[0-9]+'
+} | sort | uniq -c | sort -rn
+
+# For frequently-referenced upstream issues, check current state:
+gh issue view <num> --repo The-OpenROAD-Project/OpenROAD --json state,title,closedAt
+```
+
+Update skills when:
+- **An upstream issue is now closed/fixed**: the workaround in DECISIONS.md, CLAUDE.md, or skills can be removed (or marked "no longer needed as of OpenROAD vX.Y") — but verify in a real build before deleting the workaround.
+- **A pattern emerges** (e.g., several designs hit MPL-* or CTS-* issues at high utilization): add an early-warning bullet to the relevant skill (`debug-design`, `optimize-ppa`, `port-design`) so future runs spot the symptom sooner.
+- **An issue applies broadly** but is only documented in one DECISIONS.md: lift it into `CLAUDE.md`'s known-bug table so all designs benefit.
+
+Use the `track-bug` skill for the mechanics of recording a newly-found
+upstream bug; this step is the *discovery* phase that feeds it.
+
 ## Step 2: Audit Existing Skills
 
 Read each skill and check for these problems:


### PR DESCRIPTION
## Summary
- Add **Step 1d** to `.claude/skills/improve-skills/SKILL.md`: scan every `designs/src/<design>/DECISIONS.md` for recurring workarounds and upstream-bug references. A workaround that shows up in 2+ designs is general knowledge — promote it to `debug-design` / `port-design` / `optimize-ppa`. Bugs that aren't yet in `CLAUDE.md`'s known-bug table get handed off to `track-bug`.
- Add **Step 1e**: frequency-rank OpenROAD issue references (`OpenROAD #N`, `ODB-…`, `CTS-…`, `MPL-…`, `PSM-…`, `GRT-…`, `RSZ-…`) across DECISIONS files, CLAUDE.md, and recent commits, then `gh issue view --repo The-OpenROAD-Project/OpenROAD` each top hit. Use that to (a) retire workarounds for fixed upstream bugs, (b) add early-warning bullets when a pattern emerges, (c) lift design-local notes into the shared known-bug table when broadly applicable.

## Test plan
- [ ] Spot-check the bash snippets locally: run the DECISIONS.md aggregator and the OpenROAD-issue frequency rank from `Step 1d` / `1e`.
- [ ] Run `/improve-skills` end-to-end on a recent debugging session and confirm the new steps surface useful candidates without false positives.