### PR TITLE
Add shared timing-analysis reference; consolidate debug-design + optimize-ppa

### DIFF
--- a/.claude/skills/debug-design/SKILL.md
+++ b/.claude/skills/debug-design/SKILL.md
@@ -201,61 +201,17 @@ tail -200 logs/<platform>/<design>/base/5_*.log
 
 ### F. Timing Violations (Any Stage)
 
-Timing analysis should cover setup slack, hold slack, clock skew, and IO constraint realism. Since the RTL is fixed, the goal is to find the best achievable Fmax by tuning constraints and flow parameters.
+**First, diagnose.** Run the structured triage in `.claude/skills/shared/timing-analysis.md` to decide whether the dominant problem is (a) clock skew, (b) unreasonable clock period or IO delay, (c) wire vs. logic vs. macro delay, (d) a single problematic stage, (e) a multi-corner STA failure, or (f) something else. The shared reference gives the exact report/`jq` commands, the heuristic for each bucket, and the conclusion format. Targeting the right knob beats trying every fix below in sequence.
 
-**Read timing reports:**
-```bash
-# Setup timing (critical for Fmax)
-head -100 reports/<platform>/<design>/base/6_finish_setup.rpt 2>/dev/null
+**Important: utilization and clock period are coupled.** Tighter clock constraints cause synthesis and `repair_timing` to insert more buffers and decompose gates, which raises the effective utilization. A design that fits at 80% util with a relaxed clock may overflow at 80% with an aggressive clock. When diagnosing timing, also check whether cell count and instance area changed compared to a relaxed-clock build.
 
-# Hold timing
-head -100 reports/<platform>/<design>/base/6_finish_hold.rpt 2>/dev/null
+**Common fixes (after diagnosis):**
 
-# JSON metrics summary
-cat logs/<platform>/<design>/base/6_report.json 2>/dev/null
-```
-
-**Key metrics to extract and present:**
-- **WNS** (worst negative slack) — negative means violation
-- **TNS** (total negative slack) — sum of all violating paths
-- **Fmax** — maximum achievable frequency
-- **`report_clock_min_period`** — look for this in the finish report; it gives the true minimum achievable clock period directly, which is more reliable than computing it from WNS
-- **Top 5 worst paths**: start point, end point, path delay breakdown
-
-**Important: utilization and clock period are coupled.** Tighter clock constraints cause synthesis to produce more cells (more buffering, complex gate decompositions), which increases the effective utilization. A design that fits at 80% util with a relaxed clock may overflow at 80% with an aggressive clock. When diagnosing timing, also check if the cell count and instance area increased compared to a relaxed-clock build.
-
-**Clock skew analysis:**
-
-Clock tree insertion delay can cause timing violations when IO constraints assume ideal clocks. Check for this:
-
-1. **Read the clock tree report** to find insertion delay:
-   ```bash
-   grep -i "insertion\|skew\|latency" reports/<platform>/<design>/base/4_cts*.rpt 2>/dev/null
-   grep -i "insertion\|skew\|latency" logs/<platform>/<design>/base/4_*.log 2>/dev/null
-   ```
-
-2. **Compare insertion delay to IO constraints**: In the SDC, IO delays are typically set as a fraction of the clock period (`clk_io_pct`). If the clock tree insertion delay is significant compared to `clk_period * clk_io_pct`, the IO paths will have unrealistic timing targets.
-
-   For example, if `clk_period = 1.0ns` and `clk_io_pct = 0.2`, the IO delay budget is 0.2ns. If clock insertion delay is 0.15ns, that leaves almost no margin for actual IO path logic.
-
-3. **Check if failing paths are IO paths**: Look at the worst timing paths in the setup report. If they are input-to-register or register-to-output paths (not register-to-register), the IO constraints are likely the problem, not the core logic.
-
-4. **Fixes for clock-skew-related IO timing:**
-   - Increase `clk_io_pct` to account for clock tree insertion delay (e.g., 0.3 or 0.4)
-   - Use `set_clock_uncertainty` in the SDC to model expected skew
-   - Set different input/output delays that account for insertion delay:
-     ```tcl
-     # Instead of using clk_io_pct for both:
-     set_input_delay  [expr $clk_period * 0.3] -clock $clk_name $non_clock_inputs
-     set_output_delay [expr $clk_period * 0.4] -clock $clk_name [all_outputs]
-     ```
-   - For benchmarking purposes, if external IO timing is not meaningful, relax IO constraints significantly or use `set_false_path` on IO ports to focus on core register-to-register Fmax
-
-**Common timing fixes:**
-1. **Relax clock period** in `constraint.sdc` to find the achievable Fmax for this design/platform combination
-2. **Adjust IO constraints** as described above if clock skew is causing false IO violations
-3. **Set `TNS_END_PERCENT = 100`** in BUILD.bazel `arguments` to prioritize timing closure
-4. **Hold violations** are usually fixed automatically by the flow; if persistent, check for clock tree issues
+1. **Relax clock period** in `constraint.sdc` to find the achievable Fmax for this (design, platform) pair.
+2. **Lower `clk_io_pct`** when IO paths dominate. `clk_io_pct` multiplies `clk_period` to set both `set_input_delay` and `set_output_delay`; raising it makes IO timing *tighter*, lowering it gives the design more internal slack on IO paths. For benchmarking, `set_false_path` on non-meaningful IO ports lets the core register-to-register Fmax come through.
+3. **Set `TNS_END_PERCENT = 100`** in BUILD.bazel `arguments` to give the flow more budget for `repair_timing` iterations.
+4. **Add `set_clock_uncertainty`** in the SDC when CTS insertion delay is comparable to the IO budget — shared `(a)` covers when to suspect this.
+5. **Hold violations** are usually fixed automatically by the flow; persistent hold failures usually indicate clock-tree problems — shared `(a)` again.
 
 ---
 

--- a/.claude/skills/optimize-ppa/SKILL.md
+++ b/.claude/skills/optimize-ppa/SKILL.md
@@ -147,36 +147,9 @@ Reach for this when Step 2 plateaus before timing converges and std-cell utiliza
 
 ## Step 3: Maximize Clock Frequency (Performance Optimization)
 
-The goal is to find the highest Fmax by tightening the clock period until timing violations appear, then backing off slightly.
+The goal is to find the highest Fmax by tightening the clock period until timing violations appear, then backing off slightly. **Before tightening, run the structured diagnosis in `.claude/skills/shared/timing-analysis.md`** to identify *why* the current critical path is slow — clock skew, unreasonable clock period or IO delay, wire/logic/macro delay dominance, a single problematic stage, a multi-corner failure, or something else. The lever you reach for (tighten the clock vs. fix placement vs. retune SDC) depends on the answer; the steps below assume that triage is done.
 
-### 3a. Analyze current timing
-
-**Read the timing report and extract `report_clock_min_period`:**
-```bash
-grep "period_min\|fmax" reports/*/base/6_finish.rpt 2>/dev/null
-```
-
-This gives the true minimum period directly — use it as the starting point for clock tightening instead of computing from WNS.
-
-**Also determine where timing margin exists:**
-- If WNS is significantly positive (e.g., > 0.1ns), there is room to tighten the clock
-- Identify the critical path — is it register-to-register or involves IO?
-- Check both the overall worst path and the reg-to-reg worst path separately
-
-### 3b. Check for clock skew effects on IO paths
-
-Clock tree insertion delay can cause misleading timing results when IO constraints assume ideal clocks.
-
-1. **Find clock insertion delay** from the CTS log or finish report (`report_clock_skew` section)
-
-2. **Compare to IO delay budget**: IO delays are typically `clk_period * clk_io_pct`. If clock insertion delay is a significant fraction of this budget, IO paths have unrealistic constraints that will limit apparent Fmax.
-
-3. **Separate IO timing from core timing**: For benchmarking, the core register-to-register Fmax is what matters. If IO paths are the bottleneck:
-   - Increase `clk_io_pct` (e.g., 0.3–0.8) to give IO paths more slack
-   - Or set asymmetric input/output delays that account for insertion delay
-   - Add `set_clock_uncertainty` to model expected skew
-
-### 3c. Tighten clock period
+### 3a. Tighten clock period
 
 Use `report_clock_min_period` from the finish report as the starting target, then binary search:
 
@@ -191,11 +164,11 @@ Use `report_clock_min_period` from the finish report as the starting target, the
 
 **Remember the util/clock coupling:** after tightening the clock significantly, re-check that the design still fits. CTS repair_timing inserts buffers that increase cell area. You may need to lower utilization when the clock gets aggressive.
 
-### 3d. Watch for runtime blowup during clock tightening
+### 3b. Watch for runtime blowup during clock tightening
 
 As the clock period gets tighter, the CTS and routing stages will spend increasingly more time on repair_timing iterations. If a run is taking significantly longer than the baseline (2-3x+), the clock target is likely too aggressive — kill it, back off to the previous period, and declare that as the achievable Fmax.
 
-### 3e. Clock period guidance by platform
+### 3c. Clock period guidance by platform
 
 - **asap7 (7nm)**: 500-1000 ps typical; aggressive designs may reach 300-500 ps
 - **nangate45 (45nm)**: 2-10 ns typical

--- a/.claude/skills/shared/timing-analysis.md
+++ b/.claude/skills/shared/timing-analysis.md
@@ -1,0 +1,200 @@
+# Timing Diagnosis Reference
+
+Shared reference for diagnosing setup/hold failures. Used by `debug-design`
+(when a flow stage fails or reports negative WNS) and `optimize-ppa` (when
+clock tightening stalls). The goal is to decide *what kind* of timing
+problem we have so the fix targets the right knob instead of the
+shotgun: clock period? IO delay? skew? a wire-dominated path? a single
+slow stage? a corner-specific failure?
+
+## Inputs
+
+Per-stage timing reports under `reports/<platform>/<design>/base/`:
+
+| File | Use |
+|------|-----|
+| `6_finish_setup.rpt` | post-route setup paths (authoritative for final WNS) |
+| `6_finish_hold.rpt` | post-route hold paths |
+| `6_finish_clock_skew.rpt` | clock skew between launch/capture FFs |
+| `6_finish_clock_min_period.rpt` | minimum achievable period (per clock) |
+| `6_report.json` | JSON metrics (WNS, TNS, Fmax, power, area) |
+| `4_cts.rpt` / `5_2_route.rpt` | intermediate snapshots when finish is degraded |
+
+`reports/.../6_report.json` is the easiest entry point — its
+`finish__timing__setup__ws`, `finish__timing__setup__tns`,
+`finish__timing__fmax`, and `finish__clock__skew__worst_setup_*`
+fields tell you which checks below to run first.
+
+## Step-by-step diagnosis
+
+Run the checks below in order; stop when one of them is clearly the
+dominant problem.
+
+### (a) Clock skew
+
+Symptoms:
+- `report_clock_skew` shows worst skew comparable to the slack deficit.
+- Setup and hold violations on the *same* launch–capture pair (rare when
+  skew is healthy).
+- Hold-time violations clustered on short reg-to-reg paths.
+
+Checks:
+```bash
+grep -A 30 "Clock skew" reports/<plat>/<des>/base/6_finish_clock_skew.rpt
+jq '.finish__clock__skew__worst_setup_min, .finish__clock__skew__worst_setup_max,
+    .finish__clock__skew__worst_hold_min,  .finish__clock__skew__worst_hold_max' \
+    reports/<plat>/<des>/base/6_report.json
+```
+
+If the worst skew is a meaningful fraction of WNS (say > 30%), the
+clock tree itself is the bottleneck. Likely causes:
+- `CTS_BUF_LIST` doesn't include enough buffer strengths for the
+  insertion delay required → adjust per-platform defaults are usually
+  fine; only override in `BUILD.bazel` if you have a strong reason.
+- Clock tree was forced into a corner of the die (look at the
+  placement image — clock buffers crammed against macros).
+- Bumping `MACRO_PLACE_HALO` and rerunning often fixes both skew and
+  congestion at once.
+
+### (b) Unreasonable clock period or IO delay
+
+Symptoms:
+- WNS is large and negative AND the design has no obvious congestion or
+  macro hotspots.
+- The critical path runs end-to-end through combinational logic with
+  many stages.
+- The path *starts* or *ends* at a top-level IO port.
+
+Checks:
+```bash
+# Min achievable period per clock — the true Fmax target.
+grep -A 5 "clock_period_min\|period_min" \
+     reports/<plat>/<des>/base/6_finish_clock_min_period.rpt
+jq '.finish__timing__fmax, .finish__timing__setup__ws' \
+   reports/<plat>/<des>/base/6_report.json
+```
+
+If `clock_period_min` is well below the current `clk_period` in
+`constraint.sdc`, the clock is over-constrained — relax it toward
+`period_min + margin` (margin: ~50ps asap7, ~100ps nangate45/sky130hd).
+
+If the worst path is from an `input` port or to an `output` port, the
+problem is IO delay, not clock period:
+- `clk_io_pct` in the SDC controls the input/output delay budget
+  (typical 0.2–0.4). Raising it (0.5–0.8) shrinks the IO budget and is
+  *more* aggressive; lowering it is what you want when IO paths dominate.
+- Confirm against `set_clock_uncertainty` — large uncertainty also
+  consumes the IO budget.
+
+Real benchmark Fmax is reg-to-reg, so if IO paths dominate the
+worst path, also report the worst *reg-to-reg* path separately:
+```
+report_checks -from [all_registers -clock_pins] \
+              -to   [all_registers -data_pins] \
+              -group_path_count 5
+```
+
+### (c) Wire vs. logic vs. macro delay
+
+Symptoms: the path itself is the question — break it into segments.
+
+Generate a detailed path dump (use the OpenROAD shell against the post-
+route ODB, or read the existing report):
+```
+report_checks -path_delay min_max -format full_clock_expanded \
+              -fields {slew cap input_pins nets fanout} \
+              -group_path_count 1
+```
+
+Walk the path and bucket each delay:
+- **Wire delay**: rows whose delay is attributed to a net (`net …`),
+  driven by routing. Heavy wire delay → routing congestion, long net
+  spans, or weak drivers. Fix in this order: lower utilization, add
+  `IO_CONSTRAINTS`/`FOOTPRINT_TCL`, increase `MACRO_PLACE_HALO`, or
+  add `set_load` on long capacitive loads.
+- **Logic delay**: rows through std cells. Heavy logic delay → too
+  many stages in one clock cycle (RTL-side, which we cannot change) or
+  weak buffering. Set `ABC_AREA = 0` (perf-oriented synthesis), raise
+  `TNS_END_PERCENT = 100`, or move to a faster cell variant via the
+  library tier (asap7 R/SL/SLVT).
+- **Macro delay**: rows where the cell is a FakeRAM (`fakeram_*`). If a
+  single macro dominates, the macro's `.lib` access time IS the
+  bottleneck — consider repartitioning (see
+  `.claude/skills/shared/sram-repartition.md`) to a smaller, faster
+  macro, or place the macro closer to its consumer in `io.tcl`/
+  manual macro placement.
+
+Rough heuristic: if any one bucket is > 60% of the total path delay,
+that bucket is the lever. If they're balanced (~30/30/30), the design
+is genuinely at its limit and only RTL changes (which we don't make in
+HighTide) would help.
+
+### (d) Single problematic stage
+
+Symptoms: most of the path delay sits in one cell or one net.
+
+Read the `full_clock_expanded` report and find the largest single delay
+contribution. Common patterns:
+- **One huge net**: a single net's delay > 30% of the path. Almost
+  always a placement problem — driver and load are on opposite sides of
+  the die. Check `placement.webp` for the cluster; consider an `io.tcl`
+  / `macro_placement.tcl` constraint to colocate them.
+- **One slow cell**: a single std cell delay > 30% of the path. Usually
+  the synthesizer mapped it to a weak variant; bump `ABC_AREA = 0`
+  and/or rerun.
+- **One macro access**: a FakeRAM read/write that consumes most of the
+  cycle. See (c) — repartition or move physically.
+
+This is the most common "fix one thing and the design closes" pattern.
+When you find a dominant stage, fixing it usually clears WNS entirely.
+
+### (e) Multi-corner STA issue
+
+Symptoms: WNS is fine at the typical corner but the flow still reports
+violations; or hold passes only at the slow corner; or setup passes only
+at the fast corner.
+
+Checks: confirm which corners the flow ran with, and that all required
+corners are constrained:
+```
+report_checks -path_delay min_max -corner <corner_name>
+report_checks -scenes      # if multi-scene/multi-mode is configured
+```
+
+Look at:
+- `STA_CORNERS` (default vs. overridden in BUILD.bazel) — is the failing
+  corner even in the analyzed set?
+- Slow / fast / typical liberty files — are all wired in via the
+  platform PDK?
+- Derate values (`set_timing_derate`) on the failing corner.
+
+For HighTide, single-corner failure is rare and usually means a
+constraint is corner-specific (e.g., `set_clock_uncertainty` that's too
+tight for the slow corner). Common fix: relax the constraint that's
+corner-specific, or add a corner-specific override. See
+`.claude/skills/sdc-sta/SKILL.md` for the multi-corner SDC primitives.
+
+### (f) None of the above
+
+If (a)–(e) don't fit, the failure is something else. Sanity checks
+before declaring "RTL limit":
+- **Constraint typos**: `report_checks -unconstrained` and `check_setup`
+  surface ports with missing `set_input_delay`/`set_output_delay`. A
+  forgotten constraint can make a path "infinitely fast" or
+  "infinitely slow" depending on direction.
+- **Stale ODB**: rerun the report against the *current* ODB, not a
+  cached one from an earlier iteration.
+- **Hold paths driving setup choices**: if you tightened the clock to
+  fix hold, you may have created a setup problem. Treat them separately.
+- **CTS-0105, ODB-1200, MPL-0040**: known OpenROAD bugs documented in
+  `CLAUDE.md`'s known-bug table — check it before chasing the symptom.
+
+Report your conclusion in this shape:
+```
+Dominant issue: <(a)–(f)>
+Evidence:       <one or two numeric facts: e.g., "skew 95ps vs WNS 110ps">
+Recommended fix: <one or two flow-parameter or SDC changes>
+```
+
+Keep the report short and numeric. If multiple buckets contribute
+(say 50/40/10), say so — and address the larger lever first.


### PR DESCRIPTION
## Summary
- New **`.claude/skills/shared/timing-analysis.md`** — structured diagnosis flow that decides which bucket dominates before reaching for a fix: **(a)** clock skew, **(b)** unreasonable clock period or IO delay, **(c)** wire vs. logic vs. macro delay, **(d)** single problematic stage, **(e)** multi-corner STA failure, **(f)** something else. Each section ships the exact `gh`/`jq`/`report_checks` commands and the heuristic for declaring it the verdict. Output is constrained to a short `Dominant issue / Evidence / Recommended fix` shape.
- **`debug-design` §F**: removed the redundant "Read timing reports" code block, the "Key metrics" list, and the entire "Clock skew analysis" subsection — all covered by the new shared doc. Kept the unique util/clock-coupling paragraph and a tightened "Common fixes" list.
- **`optimize-ppa` Step 3**: rolled the diagnosis pointer up into the Step-3 preamble, deleted **3a "Analyze current timing"** and **3b "Check for clock skew effects on IO paths"** (both fully covered by shared), renumbered 3c→3a / 3d→3b / 3e→3c. The fix recipes (binary-search tightening, runtime-blowup watch, per-platform clock guidance) are unchanged.
- **Bug fixed in passing**: both removed sections said *"Increase `clk_io_pct` to give IO paths more slack."* That's backwards — grep confirms every constraint.sdc uses `set_input_delay [expr $clk_period * $clk_io_pct]`, so raising `clk_io_pct` tightens IO. The corrected guidance lives once, in the shared doc and in `debug-design`'s common-fixes list.

Net: +212 / -83. One source of truth for the diagnostic flow, no contradiction across skills.

## Test plan
- [ ] Walk a known-failing design (e.g. one of the sky130hd/liteeth variants pre-PPA-sweep) through the (a)–(f) checks and confirm the verdict matches the fix that actually closed timing.
- [ ] Run `/debug-design` and `/optimize-ppa` end-to-end and check that the new reference is picked up and reduces the number of speculative fixes attempted.
- [ ] Grep `clk_io_pct` across DECISIONS.md to spot any per-design notes that still parrot the wrong direction.