### PR TITLE
update-results skill: localhost cache bypass + warm-then-timeout gallery method

### DIFF
--- a/.claude/skills/update-results/SKILL.md
+++ b/.claude/skills/update-results/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-results
-description: Refresh webpage/results.html, webpage/index.html (Design Portfolio platform badges), webpage/gallery.html, and webpage/figures/ to reflect each (platform, design) pair's latest cached build. Detects stale rows by comparing a per-row data-commit attribute to the design's most recent commit, refetches the cached 6_report.json via tools/fetch_cache.sh, regenerates the gallery image at <design>_<platform>_<sha>.png, deletes the previous versioned image, and rewrites the table between RESULTS_START / RESULTS_END markers. Use after a build sweep lands new artifacts in the remote cache.
+description: Refresh webpage/results.html, webpage/index.html (Design Portfolio platform badges), webpage/gallery.html, and webpage/figures/ to reflect each (platform, design) pair's latest cached build. Detects stale rows by comparing a per-row data-commit attribute to the design's most recent commit, then does ONE batched bazel build of all stale designs' lightweight _gallery targets against the (localhost, on the cache host) remote cache — using the build-event log for an authoritative cached/missing split — regenerates the gallery image at <design>_<platform>_<sha>.png, deletes the previous versioned image, and rewrites the table between RESULTS_START / RESULTS_END markers. Use after a build sweep lands new artifacts in the remote cache.
 argument-hint: "[platform] [design]"
 ---
 
@@ -62,33 +62,68 @@ sha=$(git log -1 --format=%h -- \
 
 7 chars (default `%h`), matching GitHub's commit-link convention.  If the design has no `designs/src/<leaf>/` (no per-design RTL submodule, e.g. lfsr's RTL is in `designs/src/lfsr/` but for designs whose RTL lives elsewhere, just drop the second arg).
 
-## Step 5: Refresh stale designs
+## Step 5: Refresh stale designs (batched `_gallery` build)
 
 Parse `webpage/results.html` for existing rows.  Each row is keyed by `data-design` + `data-platform`; its current commit is `data-commit`.  A row is **stale** if `data-commit` ≠ the SHA from Step 4, or the row is missing entirely.
 
-For each stale (platform, design):
+> **Two failure modes to avoid — the timeout must be *kept*, but applied correctly:**
+> 1. **A per-design timeout that's too short on a *cold* server → false negatives.**  Cold Bazel analysis of the 56-design repo is ~250 s; a short per-design timeout SIGKILLs designs mid-analysis and mislabels them "NOT CACHED" before Bazel ever queries the cache.  *Fix: warm the server once first (Step 5b) so analysis is paid a single time, then per-design builds are fast for hits.*
+> 2. **No per-design timeout → uncached designs build the full flow.**  A `_gallery` target is **not** a cache-only probe: if the design isn't cached, Bazel will run the *entire* RTL-to-GDS flow (synth→…→route→final) to produce the routed DB, then render the image — hours per design.  A single overall wall cap does **not** prevent this; you must bound *each* design so an uncached one fails fast instead of kicking off a multi-hour build.  *Fix: keep a per-design `timeout`, sized post-warm.*
+>
+> Also never enumerate via `_final`: it carries multi-GB ODB/GDS/SPEF, so `--remote_download_toplevel` over 56 designs never completes.  Use the lightweight `_gallery` target.
+
+### 5a. Point Bazel at the cache, bypassing Cloudflare on the cache host
+
+The remote cache is self-hosted `bazel-remote`; the public `https://cache.hightide-benchmarks.dev` URL is just a Cloudflare tunnel (slow, 100 MB cap).  **On the host that runs `bazel-remote`**, hit it directly — ~100× lower latency, no cap.  This is already wired via the gitignored, host-local `.bazelrc.user` (`build --remote_cache=http://USER:TOKEN@127.0.0.1:8080`); if absent, pass `--remote_cache=http://127.0.0.1:8080` explicitly.  Other users / k8s keep the committed Cloudflare URL.
+
+### 5b. Warm the server once, then per-design timeout-bounded gallery build
+
+**First, warm the Bazel server** with a single no-timeout build of a design known to be cached (e.g. `lfsr`, whose inputs rarely change).  This pays the ~250 s cold full-repo analysis (loading every BUILD file + external repos) exactly once; subsequent per-design builds reuse that warm analysis cache and resolve a hit in seconds.
 
 ```bash
-# Pull the cached JSON.  No local build — if cache miss, log + skip.
-./tools/fetch_cache.sh "$platform" "$leaf" || { echo "WARN: $platform/$leaf NOT CACHED, skipping"; continue; }
+# one-time warm-up (also a cache-soundness probe — lfsr MUST be a hit)
+bazel --output_base=/tmp/ob_results build //designs/asap7/lfsr:lfsr_gallery \
+  --remote_cache=http://127.0.0.1:8080
+```
 
-# Build only this design's gallery target.
-bazel build "$gallery_target"
+**Then, per stale design, a timeout-bounded gallery build on the now-warm server:**
 
-# Copy versioned full-res image, delete the previous one.
+```bash
+# authoritative gallery labels (handles leaf≠name, e.g. bp_quad → bp_processor_gallery)
+if timeout 240 bazel --output_base=/tmp/ob_results build "$gallery_target" \
+     --remote_cache=http://127.0.0.1:8080 2>/dev/null; then
+  : # cached → image + report available under bazel-bin
+else
+  echo "NOT CACHED: $platform/$leaf (preserve existing row)"; continue
+fi
+```
+
+Why this is correct where the earlier attempts weren't:
+- **Warm server** ⇒ a *cache hit* completes in seconds (per-target analysis is incremental, not the 250 s cold cost), so a modest per-design `timeout` (≈240 s — generous for the largest design's incremental analysis + cache fetch) does **not** false-negative hits.
+- **Per-design `timeout`** ⇒ an *uncached* design, which would otherwise run the full multi-hour RTL-to-GDS flow to synthesize the image, is killed at the bound — bounded waste (`timeout × #misses`), correctly classified "not cached", and the from-scratch build never runs.
+- Use the lightweight `_gallery` target (one PNG + the flow's small `6_report.json`), never `_final`.
+
+A design is **cached** iff its bounded build exits 0; otherwise it's **genuinely missing** — preserve its existing row (Step 6).  (For a whole-sweep audit you may instead batch with `--keep_going --build_event_json_file=…` and read `targetCompleted.completed.success` from the BEP, but only *after* warm-up and still under an overall `timeout`; the per-design form above is the safe default because it bounds each miss independently.)
+
+### 5c. Per cached design: versioned image + thumbnail
+
+For each design whose `_gallery` succeeded (`sha` from Step 4):
+
+```bash
 new_img="$WT/figures/${leaf}_${platform}_${sha}.png"
 old_img=$(ls "$WT"/figures/${leaf}_${platform}_*.png 2>/dev/null | grep -v "_${sha}.png$" | head -1)
 cp "bazel-bin/designs/$design_dir/${leaf}_gallery.png" "$new_img"
 [[ -n "$old_img" ]] && git -C "$WT" rm -f "$old_img"
 git -C "$WT" add "$new_img"
 
-# Generate the versioned thumbnail, delete the previous one.
 python3 tools/gallery/make_thumbnails.py "$WT/figures"   # rebuilds thumbs/ for any new PNG
 new_thumb="$WT/figures/thumbs/${leaf}_${platform}_${sha}.jpg"
 old_thumb=$(ls "$WT"/figures/thumbs/${leaf}_${platform}_*.jpg "$WT"/figures/thumbs/${leaf}_${platform}.jpg 2>/dev/null | grep -v "_${sha}.jpg$" | head -1)
 [[ -n "$old_thumb" ]] && git -C "$WT" rm -f "$old_thumb"
 git -C "$WT" add "$new_thumb"
 ```
+
+Then read `bazel-bin/designs/$design_dir/logs/$platform/<top>/base/6_report.json` (+ `reports/.../6_finish.rpt`) for QoR — both are flow outputs already materialized by the cached gallery build.
 
 Capture QoR from the JSON using the same metric keys `tools/summary.sh` reads:
 
@@ -249,14 +284,13 @@ Surface the change set to the user, list any designs that were skipped because t
 ```
 > Locating webpage worktree at /home/mrg/HighTide/webpage … clean (origin/webpage @ 1d9ccec4).
 > Image set already fully versioned — no migration.
-> Sweep: 56 (platform, design) pairs.
->   asap7/cnn         a1b2c3d  STALE (data-commit changed)
->     ./tools/fetch_cache.sh asap7 cnn → cached
->     bazel build //designs/asap7/cnn:cnn_gallery → 0.4s, cache hit
->     wrote figures/cnn_asap7_a1b2c3d.png (replaces cnn_asap7.png)
->   sky130hd/NVDLA/partition_c   stale  NOT CACHED → skipped
->   …
-> Rewrote results.html (56 rows, 1 skipped → preserved as comment).
+> Sweep: 56 (platform, design) pairs; 41 stale vs results.html data-commit.
+> Cache: localhost endpoint (http://127.0.0.1:8080), Cloudflare bypassed.
+> Batched: bazel build 56 _gallery --keep_going --build_event_json_file …
+>   BEP: 53 _gallery succeeded (cached), 3 genuinely missing
+>        (asap7/floonoc, nangate45/floonoc, sky130hd/NVDLA/partition_c).
+>   wrote figures/cnn_asap7_a1b2c3d.png (replaces cnn_asap7_<old>.png)  … ×53
+> Rewrote results.html (56 rows, 3 missing → preserved as comment).
 > Rewrote gallery.html (38 image references updated).
 > Updated index.html design portfolio: 12 rows, 3 platform badges added (cnn nangate45, gemmini sky130hd, sha3 sky130hd), 1 removed (floonoc nangate45 → cache cold).
 > Diff:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ Requires an Ubuntu machine with [Bazelisk](https://github.com/bazelbuild/bazelis
 ## Build Commands
 
 ```bash
-# Build the full RTL-to-GDS flow for one design
-bazel build //designs/asap7/lfsr:lfsr_final
+# Build the full RTL-to-GDS flow for one design (through the gallery
+# render — caches the layout PNG too, so update-results is a pure fetch)
+bazel build //designs/asap7/lfsr:lfsr_gallery
 
 # Build a design across all available platforms
 bazel build //designs/asap7/minimax:minimax_final \
@@ -35,7 +36,7 @@ bazel build //designs/asap7/lfsr:lfsr_synth
 bazel build //designs/asap7/lfsr:lfsr_place
 ```
 
-Note: `hightide_design()` exposes only the per-stage `orfs_flow` targets (`_synth` … `_final`) plus `_generate_abstract` / `_generate_metadata`. There is no aggregate `:<design>` target — use `:<design>_final` for the full flow.
+Note: `hightide_design()` exposes the per-stage `orfs_flow` targets (`_synth` … `_final`), `_generate_abstract` / `_generate_metadata`, and `_<design>_gallery` (renders the layout PNG; `src = :<design>_final`). There is no aggregate `:<design>` target. **Build `:<design>_gallery` for sweeps** — it runs the whole flow *and* renders+caches the gallery image, so `update-results` (and k8s/run.sh, which now targets `_gallery`) becomes a pure cache fetch with no per-design local re-render. Use `:<design>_final` only when you explicitly don't want the image.
 
 ## Architecture
 

--- a/k8s/run.sh
+++ b/k8s/run.sh
@@ -194,7 +194,11 @@ discover_designs() {
 
     local relpath="${dir#$REPO_DIR/designs/}"
     local platform="${relpath%%/*}"
-    local target="//designs/$relpath:${name}_final"
+    # Build through the gallery, not just _final: <name>_gallery has
+    # src=:<name>_final, so this runs the whole RTL-to-GDS flow AND
+    # renders+caches the gallery PNG. That makes update-results a pure
+    # fast cache fetch instead of re-rendering every design locally.
+    local target="//designs/$relpath:${name}_gallery"
 
     echo "$platform|$name|$relpath|$target"
   done

--- a/tools/fetch_cache.sh
+++ b/tools/fetch_cache.sh
@@ -19,7 +19,10 @@ set -uo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_DIR"
 
-REMOTE_CACHE="https://cache.hightide-benchmarks.dev"
+# Defaults to the public Cloudflare-fronted endpoint. On the host that
+# actually runs bazel-remote, export REMOTE_CACHE=http://127.0.0.1:8080
+# to hit it directly — ~100x lower latency and no Cloudflare 100 MB cap.
+REMOTE_CACHE="${REMOTE_CACHE:-https://cache.hightide-benchmarks.dev}"
 TIMEOUT=300
 STAGE="final"
 FILTER_PLATFORM=""


### PR DESCRIPTION
Follow-up to #145 (migration-step removal, already merged). Captures the cache-fetch method rework learned this session.

**`tools/fetch_cache.sh`** — honor a `REMOTE_CACHE` env override. On the host running `bazel-remote`, `export REMOTE_CACHE=http://127.0.0.1:8080` to hit it directly: ~100× lower latency and no Cloudflare 100 MB cap. Default (public Cloudflare URL) unchanged for k8s / other users.

**`update-results` Step 5 rewrite** — the old per-design `fetch_cache --timeout` loop is structurally broken:
- A single timeout can't span the design-size range (tiny `lfsr` ↔ huge `NyuziProcessor`).
- Cold Bazel analysis of the 56-design repo is ~250 s — a short per-design timeout SIGKILLs designs *mid-analysis* and mislabels them NOT CACHED before the cache is ever queried.

New method:
1. Bypass Cloudflare on the cache host (localhost endpoint, via the gitignored host-local `.bazelrc.user` or `--remote_cache`).
2. **Warm the Bazel server once** with a no-timeout build of a known-cached design — pays the ~250 s cold full-repo analysis a single time (also a cache-soundness probe).
3. **Then per-design `timeout 240 bazel build <design>_gallery`** on the warm server. The per-design bound is **kept and mandatory**: a `_gallery` target is *not* a cache-only probe — an uncached design runs the entire RTL-to-GDS flow (hours) to synthesize the image, so each must be bounded so an uncached one fails fast instead of kicking off a multi-hour build. Post-warm, a cache hit completes in seconds, so 240 s doesn't false-negative hits.
4. Use the lightweight `_gallery` target, never `_final` (multi-GB ODB/GDS).

No behavior change for the normal cached path; this makes the sweep correct and fast on the cache host and prevents both false-negative "missing" lists and accidental multi-hour from-scratch builds.