### PR TITLE
k8s job: install xvfb so _gallery render works on NRP

### DIFF
--- a/k8s/job-template.yaml
+++ b/k8s/job-template.yaml
@@ -43,8 +43,12 @@ spec:
           #   libx11-xcb1 + libxcb-* + libxkbcommon-x11-0 — runtime deps for
           #     OpenROAD built with --@openroad//:platform=gui (bazel-orfs .bazelrc);
           #     binary DT_NEEDEDs libX11-xcb.so.1 even when run headlessly
+          #   xvfb — provides xvfb-run + a virtual X server so the
+          #     <design>_gallery render (xvfb-run + OpenROAD -gui) works
+          #     headlessly on k8s; without it the gallery action fails
+          #     with "xvfb-run: command not found" (Error 127)
           apt-get update -qq && apt-get install -y -qq \
-            curl git build-essential time libxml2 \
+            curl git build-essential time libxml2 xvfb \
             python3 python3-yaml python3-numpy \
             libx11-xcb1 libxcb-cursor0 libxcb-icccm4 libxcb-image0 \
             libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 \


### PR DESCRIPTION
Follow-up fix to #146. That PR pointed `k8s/run.sh` at `:<name>_gallery` so k8s builds cache the layout PNG alongside the flow — but the `ubuntu:24.04` build container's apt list installs the libX11/libxcb GUI *runtime* libraries and **not the `xvfb` package itself**.

The gallery action runs `xvfb-run -a $(OPENROAD_EXE) -exit -gui … final_image.tcl`. On every k8s `_gallery` job this failed with:

```
bash: line 1: xvfb-run: command not found
make: *** Error 127 — Target //designs/<...>:<...>_gallery failed
```

So jobs cached `_final` (bazel uploads completed actions before the render) but never the PNG, and reported `Failed`. One-line fix: add `xvfb` to the apt install list so the headless `xvfb-run` + virtual X server is present and the gallery render succeeds on NRP.

Verified root cause from a live failed pod (`mrg-hightide-nangate45-litepci`): the flow downloaded `6_final.odb` fine, then died at `xvfb-run: command not found`.