### PR TITLE
litepci asap7: recover #143 real-FakeRAM, fix pcie_us.lib SIG11 + clk feedthrough, characterize hold-skew

### DIFF
--- a/designs/asap7/litepci/BUILD.bazel
+++ b/designs/asap7/litepci/BUILD.bazel
@@ -47,29 +47,31 @@ hightide_design(
     },
     arguments = {
         "VERILOG_DEFINES": "-D USE_ASAP7_CELLS",
-        # Round-2 PPA tune: pcie_us shrunk further to 80×80 µm (62 µm pin
-        # column + 18 µm margin); util pushed to 75% — GRT congestion at 60%
-        # was only 22% on M2 so plenty of headroom remains.
+        # Real-FakeRAM build: dev/inline_fakeram.py wires the 20 large DMA /
+        # TLP memories to explicit fakeram instances so STA sees real
+        # register-to-register paths (single-clock SDC on pcie_us/user_clk).
+        # util 75: best measured PPA point.  vs util 60: die -20%
+        # (816k->653k um^2), setup TNS -75% (-9672->-2392 ps), 3 setup
+        # violations.  Reg-to-reg setup MET (+758 ps at 3.6 ns).  Hold is
+        # structurally skew-bound and util-independent (see DECISIONS.md):
+        # the fixed LiteX RTL clocks 20 DMA/TLP FakeRAMs (~59-74% of any
+        # util-reasonable die) from one small clock-source pin
+        # (pcie_us/user_clk), so CTS cannot build a low-skew tree.  Tried
+        # one-block / perimeter-ring / two-band macro placements: all
+        # exceed the die's area or perimeter before leaving room for a
+        # balanced central clock spine.
         "CORE_UTILIZATION": "75",
         "PLACE_DENSITY": "0.80",
         "MACRO_PLACE_HALO": "5 5",
         # Allow no GDS for fakeram macros and the pcie_us blackbox.
         "GDS_ALLOW_EMPTY": "fakeram.*|pcie_us",
-        # litepcie infers 26 memories spanning 5 distinct geometries
-        # (92x256, 130x{128,512,1024}, 230x128).  Properly mapping each
-        # to an explicit fakeram instance would require a per-design
-        # patcher in gen.sh (the way liteeth does it via patch/*.patch).
-        # For now we mock large memories down to a single row so the
-        # rest of the flow can be exercised end-to-end; the resulting
-        # area/timing numbers underestimate what real SRAMs would
-        # contribute.  TODO: write a generic LiteX→fakeram patcher and
-        # drop these two flags.
-        "SYNTH_MOCK_LARGE_MEMORIES": "1",
-        "SYNTH_MEMORY_MAX_BITS": "4096",
-        # Mocked memories leave many RTL-bounded endpoints with dangling
-        # single-pin nets; the resizer's post-GRT repair_timing loop walks
-        # those forever (~1 endpoint / iter) and never converges.  Same
-        # workaround pattern as snitch_cluster (CLAUDE.md row 6).
+        # ODB-1200 bug — InsertBufferBeforeLoads iterates a stale load list and
+        # aborts when SplitLoadMove fires in repair_timing.  SETUP_MOVE_SEQUENCE
+        # without split_load fixes the setup pass (same as gemmini-asap7 in
+        # CLAUDE.md) but the *hold* pass inside the post-GRT repair_timing_helper
+        # also calls split_load and crashes too.  Skip the whole post-GRT repair
+        # block (matches snitch_cluster / liteeth_udp_sgmii in the table).
+        "SETUP_MOVE_SEQUENCE": "unbuffer,sizeup,swap,buffer,clone",
         "SKIP_INCREMENTAL_REPAIR": "1",
     },
 )

--- a/designs/asap7/litepci/constraint.sdc
+++ b/designs/asap7/litepci/constraint.sdc
@@ -1,34 +1,46 @@
 current_design litepcie_core
 
-# litepcie_core has three clocks on the top boundary:
-#   clk           — sys_clk (AXI-Lite MMAP / DMA, target 125 MHz on KCU105)
-#   pcie_clk_p/n  — PCIe diff refclk (100 MHz from the link partner)
-# Reset is async (pcie_rst_n), so no clock needed on it.
+# litepcie_core has only ONE user-side clock (despite the LiteX-emitted module
+# header listing `clk` as an output and naming an internal `sys_clk` wire):
 #
-# All non-clock IOs are constrained off `sys_clk` since that's the user-clock
-# domain the DMA/MMAP/MSI ports live in.  The PHY-side AXI-stream signals
-# (m_axis_*, s_axis_*) are internal to the netlist (sunk into pcie_us
-# blackbox), so they don't appear on the boundary.
+#   pcie_clk_p      — PCIe diff refclk input (100 MHz from the link partner)
+#   pcie_us/user_clk — the PCIe hard-IP's recovered user clock; LiteX wires
+#                      `pcie_clk` to this and then `assign sys_clk = pcie_clk;`,
+#                      so every DMA / MMAP / DMA-FIFO flop is on this single
+#                      clock domain.  The `clk` *output* port is just a fanout
+#                      of pcie_us/user_clk for the consumer-side SoC.
+#
+# Earlier drafts created sys_clk on `[get_ports clk]` — but `clk` is an
+# *output* in this module, so STA accepted the SDC silently and found no
+# launch/capture paths on sys_clk.  All the real R-to-R timing landed under
+# `pcie_clk` instead.  Single-clock SDC below.
 
 set clk_name      sys_clk
-set clk_port_name clk
-set clk_period    700
+# 3.6 ns / 278 MHz — clears the FakeRAM-mapped design's period_min of 3.52 ns
+# (was 2.4 ns with -5 ns TNS).  Real critical path is FakeRAM rw0_addr_in /
+# rw0_wd_in fanout through the DMA datapath.
+set clk_period    3600
 set clk_io_pct    0.2
 
-set clk_port [get_ports $clk_port_name]
-create_clock -name $clk_name -period $clk_period $clk_port
-
-# Treat the PCIe diff refclk as a separate, asynchronous clock domain.  In the
-# ASIC build pcie_clk_p just feeds the IBUFDS_GTE3 stub (passthrough), so
-# we model it as 100 MHz (10 ns) for completeness; nothing critical lives
-# between it and sys_clk.
+create_clock -name $clk_name -period $clk_period [get_pins pcie_us/user_clk]
 create_clock -name pcie_refclk -period 10000 [get_ports pcie_clk_p]
 set_clock_groups -asynchronous \
     -group [get_clocks $clk_name] \
     -group [get_clocks pcie_refclk]
 
-set non_clock_inputs [lsearch -inline -all -not [lsearch -inline -all -not \
-    [lsearch -inline -all -not [all_inputs] $clk_port] pcie_clk_p] pcie_clk_n]
+# `clk` is the user clock forwarded off-chip — a buffered fanout of
+# pcie_us/user_clk, not a data output.  Without this, set_output_delay on
+# [all_outputs] makes STA walk the entire CTS clock-distribution buffer
+# tree (~4.9 ns) from user_clk to `clk` as a *data* path, producing a
+# spurious ~-2 ns WNS that dominates the report and that repair_timing
+# cannot fix (it's an existing clock buffer — known clock-feedthrough
+# issue).  Model `clk` as a generated clock so the feedthrough is a clock
+# network with launch/capture edges aligned.  Same workaround as
+# designs/asap7/litedram/constraint.sdc (LiteX `user_clk` output port).
+create_generated_clock -name clk_fwd -source [get_pins pcie_us/user_clk] \
+    -divide_by 1 [get_ports clk]
 
+set non_clock_inputs [lsearch -inline -all -not \
+    [lsearch -inline -all -not [all_inputs] pcie_clk_p] pcie_clk_n]
 set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
 set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]

--- a/designs/asap7/litepci/phy/lib/pcie_us.lib
+++ b/designs/asap7/litepci/phy/lib/pcie_us.lib
@@ -3568,11 +3568,11 @@ library(pcie_us_lib) {
     }
     pin(int_qpll1outclk_out) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     pin(int_qpll1outrefclk_out) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     bus(m_axis_cq_tdata) {
       bus_type : bus_type_default;
@@ -5444,7 +5444,7 @@ library(pcie_us_lib) {
     }
     pin(user_clk) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     pin(user_lnk_up) {
       direction : output;

--- a/designs/nangate45/litepci/phy/lib/pcie_us.lib
+++ b/designs/nangate45/litepci/phy/lib/pcie_us.lib
@@ -3568,11 +3568,11 @@ library(pcie_us_lib) {
     }
     pin(int_qpll1outclk_out) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     pin(int_qpll1outrefclk_out) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     bus(m_axis_cq_tdata) {
       bus_type : bus_type_default;
@@ -5444,7 +5444,7 @@ library(pcie_us_lib) {
     }
     pin(user_clk) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     pin(user_lnk_up) {
       direction : output;

--- a/designs/sky130hd/litepci/phy/lib/pcie_us.lib
+++ b/designs/sky130hd/litepci/phy/lib/pcie_us.lib
@@ -3568,11 +3568,11 @@ library(pcie_us_lib) {
     }
     pin(int_qpll1outclk_out) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     pin(int_qpll1outrefclk_out) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     bus(m_axis_cq_tdata) {
       bus_type : bus_type_default;
@@ -5444,7 +5444,7 @@ library(pcie_us_lib) {
     }
     pin(user_clk) {
       direction : output;
-      function : "0";
+      clock : true;
     }
     pin(user_lnk_up) {
       direction : output;

--- a/designs/src/litepci/DECISIONS.md
+++ b/designs/src/litepci/DECISIONS.md
@@ -43,48 +43,59 @@ sandbox that doesn't have the `.init` file alongside the `.v`, so the read
 fails at synthesis time. `dev/inline_readmemh.py` rewrites the call into
 explicit `mem[i] = 8'hXX;` initial assignments — no runtime file IO needed.
 
-## Memories — mocked, not mapped (TODO)
+## Memories — FakeRAM-mapped via the generic LiteX patcher
 
-Each `litepcie_core.v` build infers 28 memory blocks with five distinct
-geometries:
+`gen.sh` runs `dev/inline_fakeram.py` over the freshly-generated
+`litepcie_core.v`, which finds each LiteX-emitted memory block
+(`// Memory <name>: <D>-words x <W>-bit` … through the closing
+`assign <sig>_rdport_dat_r = …;`) and — if `W × D ≥ 4096` — replaces
+the `reg` array + two `always` blocks with a `(* keep *)`
+`fakeram_1rw1r_<W>w<D>d_sram` instantiation.  Liteeth does the same
+job with hand-written per-variant `.patch` files; litepci has 20 such
+memories across 5 geometries, so a regex over the always-the-same
+block template is more maintainable than 20 hunks of unified diff.
 
-| Width × depth | Bits | Instances | Purpose (approx) |
-|--------------:|-----:|----------:|------------------|
-| 92  × 256     | 23 552  | 4 | DMA writer/reader table SRAMs |
-| 130 × 128     | 16 640  | 2 | DMA buffering FIFOs (small) |
-| 130 × 512     | 66 560  | 4 | DMA data FIFOs (medium) |
-| 130 × 1024    | 133 120 | 2 | DMA data FIFOs (largest) |
-| 230 × 128     | 29 440  | 8 | TLP packetizer/depacketizer buffers |
+| Width × depth | Bits | Instances | Subsystem |
+|--------------:|-----:|----------:|-----------|
+| 92  × 256     | 23 552  | 4 | DMA channel 0/1 writer + reader **descriptor tables** |
+| 130 × 128     | 16 640  | 2 | DMA channel 0/1 writer **data FIFO** |
+| 130 × 512     | 66 560  | 4 | DMA channel 0/1 buffering **syncfifo** 0–3 |
+| 130 × 1024    | 133 120 | 2 | DMA channel 0/1 reader **data FIFO** |
+| 230 × 128     | 29 440  | 8 | TLP packetizer/depacketizer **fragment FIFOs** |
 
-bsg_fakeram-generated LEF/LIB pairs for all five sizes are committed under
-each `designs/<platform>/litepci/sram/`, but the **inferred reg-array
-memories are not yet patched to explicit fakeram instances** the way
-liteeth does via `designs/src/liteeth/patch/*.patch`. To unblock the
-first build, every platform sets:
+Each platform's `designs/<platform>/litepci/sram/` carries the matching
+bsg_fakeram LEF/LIB pair (configs at `dev/generated/fakeram_<platform>.cfg`).
+The 8 smaller-than-4 Kb memories — the four 16×146 AXI-Stream CDC FIFOs,
+the 4×10 MSI CDC FIFO, and three TLP sub-fragment FIFOs — stay as inferred
+`reg` arrays and synthesize to flop arrays naturally.
 
-```
-"SYNTH_MOCK_LARGE_MEMORIES": "1",
-"SYNTH_MEMORY_MAX_BITS":     "4096",
-```
+**SRAM macro naming is not uniform across platforms** (post-#143 state).
+The `inline_fakeram.py` patcher emits the original unified
+`fakeram_1rw1r_<W>w<D>d_sram` name.  asap7's committed SRAM macros still
+use that name, so the patcher matches them directly.  The repo-wide
+bsg_fakeram wd_in LEF-pin-direction fix (`94296798` / `657bb977`) also
+**renamed** nangate45's macros to `fakeram45_1rw1r_<W>w<D>d` and
+sky130hd's to `fakeram130_1rw1r_<W>w<D>d`, and relocated the `pcie_us`
+placeholder out of `sram/` into a dedicated `phy/{lef,lib}/` tree
+(globbed by `phy_lefs`/`phy_libs` filegroups).  Consequence: **only
+asap7 is currently consistent**.  nangate45 / sky130hd still need their
+patcher cell names (or their renamed macros) reconciled before they will
+synthesize against real FakeRAM — see the per-platform status below.
 
-…so yosys collapses each oversized memory to a single row. The resulting
-flow exercises end-to-end synthesis → P&R → final reporting, but the
-area/timing numbers under-estimate what the real ~1 Mb of on-chip memory
-would contribute. **TODO: write a generic LiteX-style `reg [W:0] storage[0:D];`
-→ `fakeram_…` patcher in `dev/gen.sh`** (analogous to liteeth's per-variant
-hand-written patches but generated from the inferred memory map).
+### Async-read → sync-read latency caveat
 
-## `SKIP_INCREMENTAL_REPAIR = 1`
-
-Set on all three platforms. The mocked-memory collapse leaves thousands of
-dangling single-pin nets (`[WARNING RSZ-0104]`). The post-GRT
-`repair_timing` loop walks those one endpoint per iteration and never
-converges — same pattern as the snitch_cluster row in the repo's
-CLAUDE.md bug table. Skipping the post-GRT repair pass dodges the
-non-convergence; the in-route hold-repair still runs.
-
-When the LiteX → fakeram patcher mentioned above lands and the mocked
-memories go away, revisit whether this flag is still needed.
+LiteX declares `Port 1 | Read: Async` for the four DMA descriptor
+tables (`storage_5`, `storage_7`, `storage_11`, `storage_13` — the
+writer/reader self tables for channels 0/1).  The committed FakeRAM
+only exposes a sync read port, so the patcher routes
+`<sig>_rdport_dat_r` through the FakeRAM's registered `r0_rd_out`,
+adding one cycle of latency.  For the *benchmarking* flow we
+target — synthesis, P&R, STA — that's harmless: yosys-slang and
+OpenROAD see a clean memory cell, and STA now finds the
+register-to-register paths through the DMA datapath that mocked
+memories used to hide.  Functional simulation of the patched netlist
+against the original RTL **would** show a 1-cycle skew on the
+descriptor read path; we don't run that.
 
 ## pcie_us LEF sizing (PPA tune)
 
@@ -104,28 +115,138 @@ sky130hd it hit `[ERROR DRT-0073] No access point for pcie_us/...`
 because pin pitch matched the track pitch and the access-point algorithm
 couldn't drop a via.
 
-## Per-platform PPA-tuned settings
+## pcie_us LIB: clock-output modeling (floorplan SIG11)
 
-### asap7
+`gen_phy_lef.py`'s stub liberty must tag the pcie_us clock-source
+outputs `clock : true`, **never** `function : "0"`.  The set
+`{user_clk, int_qpll1outclk_out, int_qpll1outrefclk_out}` drives real
+clock nets inside litepcie_core.  An earlier generator gave every output
+`function : "0"`, which constant-folds `pcie_us/user_clk` to 0: STA then
+finds no register-to-register paths, and — once the SDC hangs a
+`create_clock` on that constant-tied pin — the floorplan-time metrics STA
+**segfaults (signal 11)**.  The generator special-cases those three
+scalar outputs with `clock : true`; the committed
+`designs/<plat>/litepci/phy/lib/pcie_us.lib` are regenerated from it.
 
-- `CORE_UTILIZATION = 75`, `PLACE_DENSITY = 0.80`, `MACRO_PLACE_HALO = 5 5`.
-- Final die area 23,728 µm² (down from 128,774 baseline; −82%).
-- GRT congestion peak 32% on M2 — headroom remains.
+## SDC topology — one clock + the forwarded-clock feedthrough
 
-### nangate45
+litepcie_core exposes `clk` as an *output* port — it's a fanout of
+`pcie_us/user_clk`, not the clock source.  Earlier drafts wrote
+`create_clock -name sys_clk [get_ports clk]`, which STA silently accepted
+but never propagated, producing `No launch/capture paths found` under
+sys_clk.  The SDC creates the single user clock on `pcie_us/user_clk`
+(the actual driver of the `sys_clk = pcie_clk = clk` chain inside
+litepcie_core), so STA times all DMA / TLP register-to-register paths
+through the FakeRAMs.
 
-- `CORE_UTILIZATION = 60`, `PLACE_DENSITY = 0.70`, `MACRO_PLACE_HALO = 15 15`.
-- Final die area 369,780 µm² (down from 1,124,270 baseline; −67%).
-- GRT congestion peak 38% on metal2 — approaching the wall.
+`clk` is the user clock *forwarded off-chip* — a buffered fanout of
+pcie_us/user_clk, not a data output.  With `set_output_delay` on
+`[all_outputs]` it gets timed as a ~4.9 ns *data* path that walks the
+entire CTS clock-distribution buffer tree, producing a spurious ~−2 ns
+WNS that dominates the report and that `repair_timing` cannot fix (the
+buffers are existing clock buffers).  Fix: model `clk` as a generated
+clock —
 
-### sky130hd
+```tcl
+create_generated_clock -name clk_fwd -source [get_pins pcie_us/user_clk] \
+    -divide_by 1 [get_ports clk]
+```
 
-- `CORE_UTILIZATION = 55`, `PLACE_DENSITY = 0.65`, `MACRO_PLACE_HALO = 20 20`.
-- Final die area 3,031,790 µm² (down from 7,022,770 baseline; −57%).
-- GRT congestion peak 22% on met2 — most headroom of the three.
-- sky130hd's GRT antenna-repair loop reaches the iteration limit with a
-  handful of unfixable violations remaining; OpenROAD gives up after the
-  retry budget and the flow reaches `6_final` cleanly.
+so the feedthrough is a clock network with launch/capture edges aligned.
+Same workaround as `designs/asap7/litedram/constraint.sdc` (LiteX
+`user_clk` output port) — a recurring LiteX-family pattern.
+
+## Per-platform PPA + the structural hold-skew limit
+
+### Important: earlier numbers were fictitious
+
+A prior revision of this file tabulated asap7 closing at 3.6 ns with
+−0.44 ns TNS.  Those numbers were measured with (a) the **pre-wd_in-fix**
+FakeRAM LEFs — per the bsg_fakeram wd_in bug, upper-half `wd_in` pins
+were mislabeled OUTPUT, so **half the register→FakeRAM write-data paths
+were never timed** — and/or (b) a broken SDC that reported *no paths at
+all*.  With the corrected wd_in-fixed LEFs and the working single-clock +
+generated-clock SDC, the real timing is substantially harder.  The
+numbers below are the honest, measured ones.
+
+Commit `24bbf831` ("Design & flow fixes enabled by the macro recovery")
+silently reverted PR #143's entire litepci real-FakeRAM + SDC work back
+to mocked memories.  The current state restores #143's logic while
+keeping the post-#143 wd_in-fixed SRAM macros and the `phy/` relocation.
+
+### asap7 — measured (real FakeRAM, wd_in-fixed, util 75)
+
+| Metric | Value |
+|--------|------:|
+| Target clk | 3.6 ns |
+| Reg-to-reg **setup** | **MET, +0.758 ns** (closes) |
+| Setup TNS / violations | −2.39 ns / 3 endpoints |
+| Worst setup endpoint | FakeRAM → `mmap_slave_axi_lite_arready` (output-delay-bound I/O port, not a reg path) |
+| **Hold** WNS / violations | **−2.22 ns / ~11 300** |
+| Clock skew | ~2.2 ns |
+| Die area | 0.653 mm² |
+| Inst util | 75.3 % |
+| Power | 55.4 mW |
+
+**Setup closes; hold is structurally skew-bound.** The fixed LiteX RTL
+clocks 20 large DMA/TLP FakeRAMs from a single small clock source —
+the `pcie_us/user_clk` blackbox-macro pin.  Those 20 sink macros are
+59 % (util 60) – 74 % (util 75) of the core area, so CTS must snake a
+deep buffer chain (observed: 3-buffer / 0.21 ns to one macro vs.
+25-buffer / 2.94 ns to another) → ~2.2–2.7 ns launch/capture skew →
+~11 k hold violations.  This was shown unfixable by every in-scope
+lever:
+
+- **Utilization** (60 → 75): die −20 %, setup TNS −75 %, but skew only
+  2.7 → 2.2 ns and hold-violation count flat — skew is ~die-size-
+  independent.
+- **Macro placement** — one tight block (overflows die height),
+  balanced perimeter ring (overflows usable edge length), and two-band
+  + central clock stripe (bands consume the full die, no stripe) all
+  fail the same area/perimeter wall: the macros are too dense to
+  co-locate compactly with the single clock-source pin *and* leave room
+  for a balanced central clock spine at any util that meets the area
+  goal.
+- **SDC** — single-clock + generated-clock-feedthrough fixes removed the
+  spurious −2 ns WNS but do not touch the physical skew.
+
+So asap7's deliverable is: the design **closes setup** at 3.6 ns and is
+**characterized as hold-skew-bound** — a legitimate benchmark result for
+this fixed RTL.  Closing hold would require modifying the RTL (a clock
+buffer/tree the SoC integrator would normally add), which the benchmark
+charter forbids.
+
+### nangate45 / sky130hd — NOT rebuilt; needs reconciliation
+
+These were **not** re-verified in the real-FakeRAM restore.  Their
+`constraint.sdc` and `BUILD.bazel` are still the regressed (`24bbf831`)
+mocked-memory versions, and their SRAM macros were renamed
+(`fakeram45_*` / `fakeram130_*`) by the wd_in-fix reorg so the patcher's
+`fakeram_1rw1r_<W>w<D>d_sram` cell names will not resolve until
+reconciled (rename the macros back, or teach `inline_fakeram.py` /
+`fakeram_<plat>.cfg` the platform-prefixed names).  Until then only
+asap7 carries the real-FakeRAM build.
+
+### Knob summary (asap7)
+
+| Platform  | CORE_UTILIZATION | PLACE_DENSITY | MACRO_PLACE_HALO |
+|-----------|------------------|---------------|------------------|
+| asap7     | 75               | 0.80          | 5 5              |
+
+util 75 is the measured best PPA point; the hold limit is structural and
+util-independent, so there is no benefit to trading area for a lower util.
+
+## Bug workarounds in the real-FakeRAM build
+
+| Knob | Reason |
+|------|--------|
+| `SETUP_MOVE_SEQUENCE = "unbuffer,sizeup,swap,buffer,clone"` (no `split_load`) | Resizer's setup-pass SplitLoadMove triggers ODB-1200 (same as gemmini-asap7 row in CLAUDE.md) |
+| `SKIP_INCREMENTAL_REPAIR = 1` | ODB-1200 still fires from the *hold*-pass inside post-GRT `repair_timing_helper`, which doesn't go through SETUP_MOVE_SEQUENCE; skipping the whole block keeps the rest of the flow alive |
+
+Note `SKIP_INCREMENTAL_REPAIR = 1` also disables post-GRT hold repair.
+That is *not* the cause of the asap7 hold story above — a ~2.2 ns
+structural CTS skew is far beyond what data-side hold buffering could
+absorb anyway — but it does mean the ~11 k count is fully unrepaired.
 
 ## `GDS_ALLOW_EMPTY`
 

--- a/designs/src/litepci/dev/gen.sh
+++ b/designs/src/litepci/dev/gen.sh
@@ -37,6 +37,12 @@ python3 "$LITEPCI_DIR/dev/gen_phy_stub.py" \
     --module pcie_us \
     --out "$LITEPCI_DIR/pcie_us_stub.v"
 
+# Replace the large inferred-memory reg arrays with explicit fakeram
+# instances so STA sees real launch / capture points on the DMA + TLP
+# datapath.  Mirrors the role of liteeth/patch/*.patch, but driven from
+# the LiteX block template instead of hand-written per-variant diffs.
+python3 "$LITEPCI_DIR/dev/inline_fakeram.py" "$LITEPCI_DIR/litepcie_core.v"
+
 # OpenROAD's synth_odb needs a LEF master for the pcie_us blackbox on every
 # platform.  Regenerate the per-platform placeholder LEF/LIB pair into the
 # committed phy/ trees so the build does not depend on dev tooling at flow

--- a/designs/src/litepci/dev/gen_phy_lef.py
+++ b/designs/src/litepci/dev/gen_phy_lef.py
@@ -177,7 +177,21 @@ def emit_lef(module, ports, params) -> str:
 
 
 def emit_lib(module, ports) -> str:
-    """Stub liberty: every input is direction=input, every output drives 0."""
+    """Stub liberty: inputs are direction=input; outputs are functionless,
+    except clock-source outputs which are tagged `clock : true`.
+
+    An earlier draft set every output to `function : "0"`, which made STA
+    fold `pcie_us/user_clk` (the clock that drives the entire `pcie` clock
+    domain inside litepcie_core) to a constant — every downstream flop
+    became "no clock" and the design lost all register-to-register paths
+    (and the floorplan-time metrics STA segfaults on the constant-tied
+    clock pin).  Tag the clock-source outputs so the SDC can hang a
+    `create_clock` off them.
+    """
+    # pcie_us outputs that drive a real clock net inside litepcie_core.
+    # `user_clk` is the dominant one — it clocks the AXI-Stream / DMA
+    # datapath flops.  Tagged so the SDC can attach a `create_clock`.
+    CLOCK_OUTPUTS = {"user_clk", "int_qpll1outclk_out", "int_qpll1outrefclk_out"}
     lines = []
     lines.append(f"library({module}_lib) {{")
     lines.append("  technology(cmos);")
@@ -201,6 +215,8 @@ def emit_lib(module, ports) -> str:
             lines.append(f"      direction : {d};")
             if d == "input":
                 lines.append("      capacitance : 0.001;")
+            elif name in CLOCK_OUTPUTS:
+                lines.append("      clock : true;")
             else:
                 lines.append("      function : \"0\";")
             lines.append("    }")

--- a/designs/src/litepci/dev/inline_fakeram.py
+++ b/designs/src/litepci/dev/inline_fakeram.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Rewrite LiteX-emitted inferred memory blocks in litepcie_core.v into
+explicit `fakeram_1rw1r_<W>w<D>d_sram` instantiations.
+
+The standalone litepcie generator emits each memory as a `reg [W-1:0]
+<name>[0:D-1];` register array with companion `_dat0` / `_dat1` registers
+and 2 sync-write / sync-or-async-read `always @(posedge clk)` blocks.
+That pattern relies on yosys's memory inference to produce a real
+SRAM, but yosys-slang only blackboxes — without an explicit fakeram
+instance the design either synthesizes ~1 Mb of flop array (huge) or
+gets collapsed by `SYNTH_MOCK_LARGE_MEMORIES` (loses register-to-
+register paths in STA).
+
+This patcher is the litepci analog of liteeth's hand-written
+`patch/*.patch`, but driven from the source generator output: each
+memory is parsed, classified by W×D, and replaced when above
+`THRESHOLD_BITS` with a fakeram instance whose 5 supported geometries
+are committed under each platform's `litepci/sram/`.  Sub-threshold
+memories stay as register arrays (yosys-slang infers them to flops).
+
+Caveat: 4 of the descriptor-table memories (storage_5/7/11/13) declare
+Port 1 as `Read: Async` in the LiteX header.  The fakeram only offers
+a sync read port, so the rewrite adds one cycle of latency on those
+read paths.  For benchmarking this is harmless; for functional
+verification it isn't.  See `designs/src/litepci/DECISIONS.md`.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# Memories at least this large get mapped to FakeRAM.  Smaller stay as
+# register arrays — yosys-slang will synthesize them to flops.  Matches
+# the per-platform `SYNTH_MEMORY_MAX_BITS` default of 4096.
+THRESHOLD_BITS = 4096
+
+# (width, depth) → fakeram module name.  All five geometries listed here
+# must have a matching LEF/LIB committed under
+# `designs/<platform>/litepci/sram/`.  If you add a new memory shape
+# below the threshold, also add it to bsg_fakeram configs and regenerate.
+FAKERAM = {
+    ( 92,  256): "fakeram_1rw1r_92w256d_sram",
+    (130,  128): "fakeram_1rw1r_130w128d_sram",
+    (130,  512): "fakeram_1rw1r_130w512d_sram",
+    (130, 1024): "fakeram_1rw1r_130w1024d_sram",
+    (230,  128): "fakeram_1rw1r_230w128d_sram",
+}
+
+
+# Regexes for parsing one memory block.  The block layout is:
+#
+#   // Memory <name>: <D>-words x <W>-bit
+#   //---...
+#   // Port 0 | Read: <Sync> | Write: <Sync> | Mode: <X>
+#   // Port 1 | Read: <Sync|Async> | Write: ---- |
+#   reg [<W-1>:0] <name>[0:<D-1>];
+#   reg [<W-1>:0] <name>_dat0;
+#   [reg [<W-1>:0] <name>_dat1;]                              <- if Port 1 sync
+#   always @(posedge <wrclk>) begin
+#       if (<sig>_wrport_we)
+#           <name>[<sig>_wrport_adr] <= <sig>_wrport_dat_w;
+#       <name>_dat0 <= <name>[<sig>_wrport_adr];
+#   end
+#   always @(posedge <rdclk>) begin
+#       [if (<sig>_rdport_re)]                                <- optional gate
+#       [<name>_dat1 <= <name>[<sig>_rdport_adr];]            <- if Port 1 sync
+#   end
+#   assign <sig>_wrport_dat_r = <name>_dat0;
+#   assign <sig>_rdport_dat_r = (<name>_dat1 OR <name>[<sig>_rdport_adr]);
+
+HEADER_RE = re.compile(
+    r"^// Memory (\w+): (\d+)-words x (\d+)-bit\s*$",
+    re.MULTILINE,
+)
+
+# Inside a block, pick out the wrport signal prefix and the wr/rd clocks.
+WR_ALWAYS_RE = re.compile(
+    r"always @\(posedge (\w+)\) begin\s*\n"
+    r"\s*if \((\w+)_wrport_we\)\s*\n"
+    r"\s*\w+\[\2_wrport_adr\] <= \2_wrport_dat_w;\s*\n"
+    r"\s*\w+_dat0 <= \w+\[\2_wrport_adr\];\s*\n"
+    r"\s*end"
+)
+# Sync read always: same wrport prefix is reused for the rd async path's name
+# (LiteX uses one prefix per memory), so capture from the second always block.
+RD_ALWAYS_SYNC_RE = re.compile(
+    r"always @\(posedge (\w+)\) begin\s*\n"
+    r"(?:\s*if \((\w+_rdport_re)\)\s*\n)?"
+    r"\s*\w+_dat1 <= \w+\[(\w+)_rdport_adr\];\s*\n"
+    r"\s*end"
+)
+# Empty read always (async-read memories drop the body):
+RD_ALWAYS_EMPTY_RE = re.compile(
+    r"always @\(posedge (\w+)\) begin\s*\n\s*end"
+)
+WRPORT_DAT_R_RE = re.compile(r"assign (\w+)_wrport_dat_r = \w+_dat0;")
+RDPORT_DAT_R_RE = re.compile(r"assign (\w+)_rdport_dat_r = (.*?);")
+
+
+def find_block_end(src: str, start: int) -> int:
+    """Return the offset just past the closing `assign <sig>_rdport_dat_r` line."""
+    m = RDPORT_DAT_R_RE.search(src, start)
+    if not m:
+        raise RuntimeError(f"could not find rdport_dat_r assignment after offset {start}")
+    return m.end()
+
+
+def patch_block(name: str, depth: int, width: int, body: str) -> str:
+    """Replace one memory block body with a fakeram instantiation."""
+    wr = WR_ALWAYS_RE.search(body)
+    if not wr:
+        raise RuntimeError(f"no recognized write-port always block in {name}")
+    wrclk     = wr.group(1)
+    wrport_sig = wr.group(2)  # signal prefix on wrport_we / wrport_adr / wrport_dat_w
+
+    # Read port: try sync first, then fall back to async (empty always + assign
+    # rdport_dat_r = <name>[<sig>_rdport_adr]).
+    rd_sync = RD_ALWAYS_SYNC_RE.search(body, wr.end())
+    if rd_sync:
+        rdclk      = rd_sync.group(1)
+        rdport_re  = rd_sync.group(2)        # may be None
+        rdport_sig = rd_sync.group(3)
+    else:
+        rd_empty = RD_ALWAYS_EMPTY_RE.search(body, wr.end())
+        if not rd_empty:
+            raise RuntimeError(f"no recognized read-port always block in {name}")
+        rdclk      = rd_empty.group(1)
+        rdport_re  = None
+        # Async-read memories don't have a _dat1 reg or sync assignment; the
+        # rdport signal is the same prefix as wrport (LiteX uses one).
+        rdport_sig = wrport_sig
+
+    rdport_dat_r = RDPORT_DAT_R_RE.search(body, wr.end())
+    if not rdport_dat_r:
+        raise RuntimeError(f"no rdport_dat_r assign in {name}")
+    rdport_sig = rdport_dat_r.group(1)  # canonical: drive prefix from the assign
+
+    module = FAKERAM[(width, depth)]
+    inst   = f"u_{name}_{module}"
+
+    # Sync-read with re becomes ce_in(rdport_re); async-read or no-re becomes
+    # ce_in(1'b1).  Either way the consumer sees a registered output one
+    # cycle after the address — same as the sync write port, and the same
+    # one-cycle bump async-read consumers will need to absorb.
+    rd_ce = f"{rdport_sig}_rdport_re" if rdport_re else "1'b1"
+
+    return f"""// Patched: {depth}×{width} → {module} ({inst})
+wire [{width - 1}:0] {name}_dat0;
+wire [{width - 1}:0] {name}_dat1;
+(* keep *) {module} {inst} (
+    .rw0_clk    ({wrclk}),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  ({wrport_sig}_wrport_we),
+    .rw0_addr_in({wrport_sig}_wrport_adr),
+    .rw0_wd_in  ({wrport_sig}_wrport_dat_w),
+    .rw0_rd_out ({name}_dat0),
+    .r0_clk     ({rdclk}),
+    .r0_ce_in   ({rd_ce}),
+    .r0_addr_in ({rdport_sig}_rdport_adr),
+    .r0_rd_out  ({name}_dat1)
+);
+assign {wrport_sig}_wrport_dat_r = {name}_dat0;
+assign {rdport_sig}_rdport_dat_r = {name}_dat1;
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("verilog", help="litepcie_core.v to patch in place")
+    args = ap.parse_args()
+
+    path = Path(args.verilog)
+    src  = path.read_text()
+
+    # Find every memory header, decide whether to map, do replacement
+    # right-to-left so byte offsets stay stable across edits.
+    headers = list(HEADER_RE.finditer(src))
+    patches = []
+    skipped = []
+    for h in headers:
+        name  = h.group(1)
+        depth = int(h.group(2))
+        width = int(h.group(3))
+        bits  = width * depth
+        if bits < THRESHOLD_BITS:
+            skipped.append((name, depth, width, bits, "< threshold"))
+            continue
+        if (width, depth) not in FAKERAM:
+            skipped.append((name, depth, width, bits, "no matching fakeram"))
+            continue
+        # Block runs from header start to end of the rdport_dat_r assign.
+        block_start = h.start()
+        block_end   = find_block_end(src, h.end())
+        body        = src[block_start:block_end]
+        replacement = patch_block(name, depth, width, body)
+        patches.append((block_start, block_end, name, replacement))
+
+    for start, end, name, repl in reversed(patches):
+        src = src[:start] + repl + src[end:]
+
+    path.write_text(src)
+
+    for name, depth, width, bits, why in skipped:
+        print(f"  skip {name:<12} {depth:>5} × {width:>4} ({bits:>7} bits)  — {why}",
+              file=sys.stderr)
+    for _, _, name, _ in patches:
+        print(f"  map  {name}", file=sys.stderr)
+    print(f"Patched {len(patches)} memories into fakeram instances; "
+          f"{len(skipped)} left as flop arrays.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/designs/src/litepci/litepcie_core.v
+++ b/designs/src/litepci/litepcie_core.v
@@ -13632,243 +13632,255 @@ assign uspciephy_msi_cdc_cdc_rdport_dat_r = storage_4_dat1;
 
 
 //------------------------------------------------------------------------------
-// Memory storage_5: 256-words x 92-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Async | Write: ---- | 
-reg [91:0] storage_5[0:255];
-reg [91:0] storage_5_dat0;
-always @(posedge sys_clk) begin
-	if (litepciedma0_writer_table_self_wrport_we)
-		storage_5[litepciedma0_writer_table_self_wrport_adr] <= litepciedma0_writer_table_self_wrport_dat_w;
-	storage_5_dat0 <= storage_5[litepciedma0_writer_table_self_wrport_adr];
-end
-always @(posedge sys_clk) begin
-end
+// Patched: 256×92 → fakeram_1rw1r_92w256d_sram (u_storage_5_fakeram_1rw1r_92w256d_sram)
+wire [91:0] storage_5_dat0;
+wire [91:0] storage_5_dat1;
+(* keep *) fakeram_1rw1r_92w256d_sram u_storage_5_fakeram_1rw1r_92w256d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma0_writer_table_self_wrport_we),
+    .rw0_addr_in(litepciedma0_writer_table_self_wrport_adr),
+    .rw0_wd_in  (litepciedma0_writer_table_self_wrport_dat_w),
+    .rw0_rd_out (storage_5_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (1'b1),
+    .r0_addr_in (litepciedma0_writer_table_self_rdport_adr),
+    .r0_rd_out  (storage_5_dat1)
+);
 assign litepciedma0_writer_table_self_wrport_dat_r = storage_5_dat0;
-assign litepciedma0_writer_table_self_rdport_dat_r = storage_5[litepciedma0_writer_table_self_rdport_adr];
+assign litepciedma0_writer_table_self_rdport_dat_r = storage_5_dat1;
+
 
 
 //------------------------------------------------------------------------------
-// Memory storage_6: 128-words x 130-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [129:0] storage_6[0:127];
-reg [129:0] storage_6_dat0;
-reg [129:0] storage_6_dat1;
-always @(posedge sys_clk) begin
-	if (litepciedma0_writer_data_fifo_wrport_we)
-		storage_6[litepciedma0_writer_data_fifo_wrport_adr] <= litepciedma0_writer_data_fifo_wrport_dat_w;
-	storage_6_dat0 <= storage_6[litepciedma0_writer_data_fifo_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (litepciedma0_writer_data_fifo_rdport_re)
-		storage_6_dat1 <= storage_6[litepciedma0_writer_data_fifo_rdport_adr];
-end
+// Patched: 128×130 → fakeram_1rw1r_130w128d_sram (u_storage_6_fakeram_1rw1r_130w128d_sram)
+wire [129:0] storage_6_dat0;
+wire [129:0] storage_6_dat1;
+(* keep *) fakeram_1rw1r_130w128d_sram u_storage_6_fakeram_1rw1r_130w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma0_writer_data_fifo_wrport_we),
+    .rw0_addr_in(litepciedma0_writer_data_fifo_wrport_adr),
+    .rw0_wd_in  (litepciedma0_writer_data_fifo_wrport_dat_w),
+    .rw0_rd_out (storage_6_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (litepciedma0_writer_data_fifo_rdport_re),
+    .r0_addr_in (litepciedma0_writer_data_fifo_rdport_adr),
+    .r0_rd_out  (storage_6_dat1)
+);
 assign litepciedma0_writer_data_fifo_wrport_dat_r = storage_6_dat0;
 assign litepciedma0_writer_data_fifo_rdport_dat_r = storage_6_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_7: 256-words x 92-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Async | Write: ---- | 
-reg [91:0] storage_7[0:255];
-reg [91:0] storage_7_dat0;
-always @(posedge sys_clk) begin
-	if (litepciedma0_reader_table_self_wrport_we)
-		storage_7[litepciedma0_reader_table_self_wrport_adr] <= litepciedma0_reader_table_self_wrport_dat_w;
-	storage_7_dat0 <= storage_7[litepciedma0_reader_table_self_wrport_adr];
-end
-always @(posedge sys_clk) begin
-end
+// Patched: 256×92 → fakeram_1rw1r_92w256d_sram (u_storage_7_fakeram_1rw1r_92w256d_sram)
+wire [91:0] storage_7_dat0;
+wire [91:0] storage_7_dat1;
+(* keep *) fakeram_1rw1r_92w256d_sram u_storage_7_fakeram_1rw1r_92w256d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma0_reader_table_self_wrport_we),
+    .rw0_addr_in(litepciedma0_reader_table_self_wrport_adr),
+    .rw0_wd_in  (litepciedma0_reader_table_self_wrport_dat_w),
+    .rw0_rd_out (storage_7_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (1'b1),
+    .r0_addr_in (litepciedma0_reader_table_self_rdport_adr),
+    .r0_rd_out  (storage_7_dat1)
+);
 assign litepciedma0_reader_table_self_wrport_dat_r = storage_7_dat0;
-assign litepciedma0_reader_table_self_rdport_dat_r = storage_7[litepciedma0_reader_table_self_rdport_adr];
+assign litepciedma0_reader_table_self_rdport_dat_r = storage_7_dat1;
+
 
 
 //------------------------------------------------------------------------------
-// Memory storage_8: 1024-words x 130-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [129:0] storage_8[0:1023];
-reg [129:0] storage_8_dat0;
-reg [129:0] storage_8_dat1;
-always @(posedge sys_clk) begin
-	if (litepciedma0_reader_data_fifo_wrport_we)
-		storage_8[litepciedma0_reader_data_fifo_wrport_adr] <= litepciedma0_reader_data_fifo_wrport_dat_w;
-	storage_8_dat0 <= storage_8[litepciedma0_reader_data_fifo_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (litepciedma0_reader_data_fifo_rdport_re)
-		storage_8_dat1 <= storage_8[litepciedma0_reader_data_fifo_rdport_adr];
-end
+// Patched: 1024×130 → fakeram_1rw1r_130w1024d_sram (u_storage_8_fakeram_1rw1r_130w1024d_sram)
+wire [129:0] storage_8_dat0;
+wire [129:0] storage_8_dat1;
+(* keep *) fakeram_1rw1r_130w1024d_sram u_storage_8_fakeram_1rw1r_130w1024d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma0_reader_data_fifo_wrport_we),
+    .rw0_addr_in(litepciedma0_reader_data_fifo_wrport_adr),
+    .rw0_wd_in  (litepciedma0_reader_data_fifo_wrport_dat_w),
+    .rw0_rd_out (storage_8_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (litepciedma0_reader_data_fifo_rdport_re),
+    .r0_addr_in (litepciedma0_reader_data_fifo_rdport_adr),
+    .r0_rd_out  (storage_8_dat1)
+);
 assign litepciedma0_reader_data_fifo_wrport_dat_r = storage_8_dat0;
 assign litepciedma0_reader_data_fifo_rdport_dat_r = storage_8_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_9: 512-words x 130-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [129:0] storage_9[0:511];
-reg [129:0] storage_9_dat0;
-reg [129:0] storage_9_dat1;
-always @(posedge sys_clk) begin
-	if (litepciedma0_buffering_syncfifo0_wrport_we)
-		storage_9[litepciedma0_buffering_syncfifo0_wrport_adr] <= litepciedma0_buffering_syncfifo0_wrport_dat_w;
-	storage_9_dat0 <= storage_9[litepciedma0_buffering_syncfifo0_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (litepciedma0_buffering_syncfifo0_rdport_re)
-		storage_9_dat1 <= storage_9[litepciedma0_buffering_syncfifo0_rdport_adr];
-end
+// Patched: 512×130 → fakeram_1rw1r_130w512d_sram (u_storage_9_fakeram_1rw1r_130w512d_sram)
+wire [129:0] storage_9_dat0;
+wire [129:0] storage_9_dat1;
+(* keep *) fakeram_1rw1r_130w512d_sram u_storage_9_fakeram_1rw1r_130w512d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma0_buffering_syncfifo0_wrport_we),
+    .rw0_addr_in(litepciedma0_buffering_syncfifo0_wrport_adr),
+    .rw0_wd_in  (litepciedma0_buffering_syncfifo0_wrport_dat_w),
+    .rw0_rd_out (storage_9_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (litepciedma0_buffering_syncfifo0_rdport_re),
+    .r0_addr_in (litepciedma0_buffering_syncfifo0_rdport_adr),
+    .r0_rd_out  (storage_9_dat1)
+);
 assign litepciedma0_buffering_syncfifo0_wrport_dat_r = storage_9_dat0;
 assign litepciedma0_buffering_syncfifo0_rdport_dat_r = storage_9_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_10: 512-words x 130-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [129:0] storage_10[0:511];
-reg [129:0] storage_10_dat0;
-reg [129:0] storage_10_dat1;
-always @(posedge sys_clk) begin
-	if (litepciedma0_buffering_syncfifo1_wrport_we)
-		storage_10[litepciedma0_buffering_syncfifo1_wrport_adr] <= litepciedma0_buffering_syncfifo1_wrport_dat_w;
-	storage_10_dat0 <= storage_10[litepciedma0_buffering_syncfifo1_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (litepciedma0_buffering_syncfifo1_rdport_re)
-		storage_10_dat1 <= storage_10[litepciedma0_buffering_syncfifo1_rdport_adr];
-end
+// Patched: 512×130 → fakeram_1rw1r_130w512d_sram (u_storage_10_fakeram_1rw1r_130w512d_sram)
+wire [129:0] storage_10_dat0;
+wire [129:0] storage_10_dat1;
+(* keep *) fakeram_1rw1r_130w512d_sram u_storage_10_fakeram_1rw1r_130w512d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma0_buffering_syncfifo1_wrport_we),
+    .rw0_addr_in(litepciedma0_buffering_syncfifo1_wrport_adr),
+    .rw0_wd_in  (litepciedma0_buffering_syncfifo1_wrport_dat_w),
+    .rw0_rd_out (storage_10_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (litepciedma0_buffering_syncfifo1_rdport_re),
+    .r0_addr_in (litepciedma0_buffering_syncfifo1_rdport_adr),
+    .r0_rd_out  (storage_10_dat1)
+);
 assign litepciedma0_buffering_syncfifo1_wrport_dat_r = storage_10_dat0;
 assign litepciedma0_buffering_syncfifo1_rdport_dat_r = storage_10_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_11: 256-words x 92-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Async | Write: ---- | 
-reg [91:0] storage_11[0:255];
-reg [91:0] storage_11_dat0;
-always @(posedge sys_clk) begin
-	if (litepciedma1_writer_table_self_wrport_we)
-		storage_11[litepciedma1_writer_table_self_wrport_adr] <= litepciedma1_writer_table_self_wrport_dat_w;
-	storage_11_dat0 <= storage_11[litepciedma1_writer_table_self_wrport_adr];
-end
-always @(posedge sys_clk) begin
-end
+// Patched: 256×92 → fakeram_1rw1r_92w256d_sram (u_storage_11_fakeram_1rw1r_92w256d_sram)
+wire [91:0] storage_11_dat0;
+wire [91:0] storage_11_dat1;
+(* keep *) fakeram_1rw1r_92w256d_sram u_storage_11_fakeram_1rw1r_92w256d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma1_writer_table_self_wrport_we),
+    .rw0_addr_in(litepciedma1_writer_table_self_wrport_adr),
+    .rw0_wd_in  (litepciedma1_writer_table_self_wrport_dat_w),
+    .rw0_rd_out (storage_11_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (1'b1),
+    .r0_addr_in (litepciedma1_writer_table_self_rdport_adr),
+    .r0_rd_out  (storage_11_dat1)
+);
 assign litepciedma1_writer_table_self_wrport_dat_r = storage_11_dat0;
-assign litepciedma1_writer_table_self_rdport_dat_r = storage_11[litepciedma1_writer_table_self_rdport_adr];
+assign litepciedma1_writer_table_self_rdport_dat_r = storage_11_dat1;
+
 
 
 //------------------------------------------------------------------------------
-// Memory storage_12: 128-words x 130-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [129:0] storage_12[0:127];
-reg [129:0] storage_12_dat0;
-reg [129:0] storage_12_dat1;
-always @(posedge sys_clk) begin
-	if (litepciedma1_writer_data_fifo_wrport_we)
-		storage_12[litepciedma1_writer_data_fifo_wrport_adr] <= litepciedma1_writer_data_fifo_wrport_dat_w;
-	storage_12_dat0 <= storage_12[litepciedma1_writer_data_fifo_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (litepciedma1_writer_data_fifo_rdport_re)
-		storage_12_dat1 <= storage_12[litepciedma1_writer_data_fifo_rdport_adr];
-end
+// Patched: 128×130 → fakeram_1rw1r_130w128d_sram (u_storage_12_fakeram_1rw1r_130w128d_sram)
+wire [129:0] storage_12_dat0;
+wire [129:0] storage_12_dat1;
+(* keep *) fakeram_1rw1r_130w128d_sram u_storage_12_fakeram_1rw1r_130w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma1_writer_data_fifo_wrport_we),
+    .rw0_addr_in(litepciedma1_writer_data_fifo_wrport_adr),
+    .rw0_wd_in  (litepciedma1_writer_data_fifo_wrport_dat_w),
+    .rw0_rd_out (storage_12_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (litepciedma1_writer_data_fifo_rdport_re),
+    .r0_addr_in (litepciedma1_writer_data_fifo_rdport_adr),
+    .r0_rd_out  (storage_12_dat1)
+);
 assign litepciedma1_writer_data_fifo_wrport_dat_r = storage_12_dat0;
 assign litepciedma1_writer_data_fifo_rdport_dat_r = storage_12_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_13: 256-words x 92-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Async | Write: ---- | 
-reg [91:0] storage_13[0:255];
-reg [91:0] storage_13_dat0;
-always @(posedge sys_clk) begin
-	if (litepciedma1_reader_table_self_wrport_we)
-		storage_13[litepciedma1_reader_table_self_wrport_adr] <= litepciedma1_reader_table_self_wrport_dat_w;
-	storage_13_dat0 <= storage_13[litepciedma1_reader_table_self_wrport_adr];
-end
-always @(posedge sys_clk) begin
-end
+// Patched: 256×92 → fakeram_1rw1r_92w256d_sram (u_storage_13_fakeram_1rw1r_92w256d_sram)
+wire [91:0] storage_13_dat0;
+wire [91:0] storage_13_dat1;
+(* keep *) fakeram_1rw1r_92w256d_sram u_storage_13_fakeram_1rw1r_92w256d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma1_reader_table_self_wrport_we),
+    .rw0_addr_in(litepciedma1_reader_table_self_wrport_adr),
+    .rw0_wd_in  (litepciedma1_reader_table_self_wrport_dat_w),
+    .rw0_rd_out (storage_13_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (1'b1),
+    .r0_addr_in (litepciedma1_reader_table_self_rdport_adr),
+    .r0_rd_out  (storage_13_dat1)
+);
 assign litepciedma1_reader_table_self_wrport_dat_r = storage_13_dat0;
-assign litepciedma1_reader_table_self_rdport_dat_r = storage_13[litepciedma1_reader_table_self_rdport_adr];
+assign litepciedma1_reader_table_self_rdport_dat_r = storage_13_dat1;
+
 
 
 //------------------------------------------------------------------------------
-// Memory storage_14: 1024-words x 130-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [129:0] storage_14[0:1023];
-reg [129:0] storage_14_dat0;
-reg [129:0] storage_14_dat1;
-always @(posedge sys_clk) begin
-	if (litepciedma1_reader_data_fifo_wrport_we)
-		storage_14[litepciedma1_reader_data_fifo_wrport_adr] <= litepciedma1_reader_data_fifo_wrport_dat_w;
-	storage_14_dat0 <= storage_14[litepciedma1_reader_data_fifo_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (litepciedma1_reader_data_fifo_rdport_re)
-		storage_14_dat1 <= storage_14[litepciedma1_reader_data_fifo_rdport_adr];
-end
+// Patched: 1024×130 → fakeram_1rw1r_130w1024d_sram (u_storage_14_fakeram_1rw1r_130w1024d_sram)
+wire [129:0] storage_14_dat0;
+wire [129:0] storage_14_dat1;
+(* keep *) fakeram_1rw1r_130w1024d_sram u_storage_14_fakeram_1rw1r_130w1024d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma1_reader_data_fifo_wrport_we),
+    .rw0_addr_in(litepciedma1_reader_data_fifo_wrport_adr),
+    .rw0_wd_in  (litepciedma1_reader_data_fifo_wrport_dat_w),
+    .rw0_rd_out (storage_14_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (litepciedma1_reader_data_fifo_rdport_re),
+    .r0_addr_in (litepciedma1_reader_data_fifo_rdport_adr),
+    .r0_rd_out  (storage_14_dat1)
+);
 assign litepciedma1_reader_data_fifo_wrport_dat_r = storage_14_dat0;
 assign litepciedma1_reader_data_fifo_rdport_dat_r = storage_14_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_15: 512-words x 130-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [129:0] storage_15[0:511];
-reg [129:0] storage_15_dat0;
-reg [129:0] storage_15_dat1;
-always @(posedge sys_clk) begin
-	if (litepciedma1_buffering_syncfifo2_wrport_we)
-		storage_15[litepciedma1_buffering_syncfifo2_wrport_adr] <= litepciedma1_buffering_syncfifo2_wrport_dat_w;
-	storage_15_dat0 <= storage_15[litepciedma1_buffering_syncfifo2_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (litepciedma1_buffering_syncfifo2_rdport_re)
-		storage_15_dat1 <= storage_15[litepciedma1_buffering_syncfifo2_rdport_adr];
-end
+// Patched: 512×130 → fakeram_1rw1r_130w512d_sram (u_storage_15_fakeram_1rw1r_130w512d_sram)
+wire [129:0] storage_15_dat0;
+wire [129:0] storage_15_dat1;
+(* keep *) fakeram_1rw1r_130w512d_sram u_storage_15_fakeram_1rw1r_130w512d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma1_buffering_syncfifo2_wrport_we),
+    .rw0_addr_in(litepciedma1_buffering_syncfifo2_wrport_adr),
+    .rw0_wd_in  (litepciedma1_buffering_syncfifo2_wrport_dat_w),
+    .rw0_rd_out (storage_15_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (litepciedma1_buffering_syncfifo2_rdport_re),
+    .r0_addr_in (litepciedma1_buffering_syncfifo2_rdport_adr),
+    .r0_rd_out  (storage_15_dat1)
+);
 assign litepciedma1_buffering_syncfifo2_wrport_dat_r = storage_15_dat0;
 assign litepciedma1_buffering_syncfifo2_rdport_dat_r = storage_15_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_16: 512-words x 130-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [129:0] storage_16[0:511];
-reg [129:0] storage_16_dat0;
-reg [129:0] storage_16_dat1;
-always @(posedge sys_clk) begin
-	if (litepciedma1_buffering_syncfifo3_wrport_we)
-		storage_16[litepciedma1_buffering_syncfifo3_wrport_adr] <= litepciedma1_buffering_syncfifo3_wrport_dat_w;
-	storage_16_dat0 <= storage_16[litepciedma1_buffering_syncfifo3_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (litepciedma1_buffering_syncfifo3_rdport_re)
-		storage_16_dat1 <= storage_16[litepciedma1_buffering_syncfifo3_rdport_adr];
-end
+// Patched: 512×130 → fakeram_1rw1r_130w512d_sram (u_storage_16_fakeram_1rw1r_130w512d_sram)
+wire [129:0] storage_16_dat0;
+wire [129:0] storage_16_dat1;
+(* keep *) fakeram_1rw1r_130w512d_sram u_storage_16_fakeram_1rw1r_130w512d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (litepciedma1_buffering_syncfifo3_wrport_we),
+    .rw0_addr_in(litepciedma1_buffering_syncfifo3_wrport_adr),
+    .rw0_wd_in  (litepciedma1_buffering_syncfifo3_wrport_dat_w),
+    .rw0_rd_out (storage_16_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (litepciedma1_buffering_syncfifo3_rdport_re),
+    .r0_addr_in (litepciedma1_buffering_syncfifo3_rdport_adr),
+    .r0_rd_out  (storage_16_dat1)
+);
 assign litepciedma1_buffering_syncfifo3_wrport_dat_r = storage_16_dat0;
 assign litepciedma1_buffering_syncfifo3_rdport_dat_r = storage_16_dat1;
+
 
 
 //------------------------------------------------------------------------------
@@ -14054,171 +14066,171 @@ assign subfragments_syncfifo1_rdport_dat_r = storage_18_dat1;
 
 
 //------------------------------------------------------------------------------
-// Memory storage_19: 128-words x 230-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [229:0] storage_19[0:127];
-reg [229:0] storage_19_dat0;
-reg [229:0] storage_19_dat1;
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo2_wrport_we)
-		storage_19[subfragments_syncfifo2_wrport_adr] <= subfragments_syncfifo2_wrport_dat_w;
-	storage_19_dat0 <= storage_19[subfragments_syncfifo2_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo2_rdport_re)
-		storage_19_dat1 <= storage_19[subfragments_syncfifo2_rdport_adr];
-end
+// Patched: 128×230 → fakeram_1rw1r_230w128d_sram (u_storage_19_fakeram_1rw1r_230w128d_sram)
+wire [229:0] storage_19_dat0;
+wire [229:0] storage_19_dat1;
+(* keep *) fakeram_1rw1r_230w128d_sram u_storage_19_fakeram_1rw1r_230w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (subfragments_syncfifo2_wrport_we),
+    .rw0_addr_in(subfragments_syncfifo2_wrport_adr),
+    .rw0_wd_in  (subfragments_syncfifo2_wrport_dat_w),
+    .rw0_rd_out (storage_19_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (subfragments_syncfifo2_rdport_re),
+    .r0_addr_in (subfragments_syncfifo2_rdport_adr),
+    .r0_rd_out  (storage_19_dat1)
+);
 assign subfragments_syncfifo2_wrport_dat_r = storage_19_dat0;
 assign subfragments_syncfifo2_rdport_dat_r = storage_19_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_20: 128-words x 230-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [229:0] storage_20[0:127];
-reg [229:0] storage_20_dat0;
-reg [229:0] storage_20_dat1;
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo3_wrport_we)
-		storage_20[subfragments_syncfifo3_wrport_adr] <= subfragments_syncfifo3_wrport_dat_w;
-	storage_20_dat0 <= storage_20[subfragments_syncfifo3_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo3_rdport_re)
-		storage_20_dat1 <= storage_20[subfragments_syncfifo3_rdport_adr];
-end
+// Patched: 128×230 → fakeram_1rw1r_230w128d_sram (u_storage_20_fakeram_1rw1r_230w128d_sram)
+wire [229:0] storage_20_dat0;
+wire [229:0] storage_20_dat1;
+(* keep *) fakeram_1rw1r_230w128d_sram u_storage_20_fakeram_1rw1r_230w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (subfragments_syncfifo3_wrport_we),
+    .rw0_addr_in(subfragments_syncfifo3_wrport_adr),
+    .rw0_wd_in  (subfragments_syncfifo3_wrport_dat_w),
+    .rw0_rd_out (storage_20_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (subfragments_syncfifo3_rdport_re),
+    .r0_addr_in (subfragments_syncfifo3_rdport_adr),
+    .r0_rd_out  (storage_20_dat1)
+);
 assign subfragments_syncfifo3_wrport_dat_r = storage_20_dat0;
 assign subfragments_syncfifo3_rdport_dat_r = storage_20_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_21: 128-words x 230-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [229:0] storage_21[0:127];
-reg [229:0] storage_21_dat0;
-reg [229:0] storage_21_dat1;
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo4_wrport_we)
-		storage_21[subfragments_syncfifo4_wrport_adr] <= subfragments_syncfifo4_wrport_dat_w;
-	storage_21_dat0 <= storage_21[subfragments_syncfifo4_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo4_rdport_re)
-		storage_21_dat1 <= storage_21[subfragments_syncfifo4_rdport_adr];
-end
+// Patched: 128×230 → fakeram_1rw1r_230w128d_sram (u_storage_21_fakeram_1rw1r_230w128d_sram)
+wire [229:0] storage_21_dat0;
+wire [229:0] storage_21_dat1;
+(* keep *) fakeram_1rw1r_230w128d_sram u_storage_21_fakeram_1rw1r_230w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (subfragments_syncfifo4_wrport_we),
+    .rw0_addr_in(subfragments_syncfifo4_wrport_adr),
+    .rw0_wd_in  (subfragments_syncfifo4_wrport_dat_w),
+    .rw0_rd_out (storage_21_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (subfragments_syncfifo4_rdport_re),
+    .r0_addr_in (subfragments_syncfifo4_rdport_adr),
+    .r0_rd_out  (storage_21_dat1)
+);
 assign subfragments_syncfifo4_wrport_dat_r = storage_21_dat0;
 assign subfragments_syncfifo4_rdport_dat_r = storage_21_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_22: 128-words x 230-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [229:0] storage_22[0:127];
-reg [229:0] storage_22_dat0;
-reg [229:0] storage_22_dat1;
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo5_wrport_we)
-		storage_22[subfragments_syncfifo5_wrport_adr] <= subfragments_syncfifo5_wrport_dat_w;
-	storage_22_dat0 <= storage_22[subfragments_syncfifo5_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo5_rdport_re)
-		storage_22_dat1 <= storage_22[subfragments_syncfifo5_rdport_adr];
-end
+// Patched: 128×230 → fakeram_1rw1r_230w128d_sram (u_storage_22_fakeram_1rw1r_230w128d_sram)
+wire [229:0] storage_22_dat0;
+wire [229:0] storage_22_dat1;
+(* keep *) fakeram_1rw1r_230w128d_sram u_storage_22_fakeram_1rw1r_230w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (subfragments_syncfifo5_wrport_we),
+    .rw0_addr_in(subfragments_syncfifo5_wrport_adr),
+    .rw0_wd_in  (subfragments_syncfifo5_wrport_dat_w),
+    .rw0_rd_out (storage_22_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (subfragments_syncfifo5_rdport_re),
+    .r0_addr_in (subfragments_syncfifo5_rdport_adr),
+    .r0_rd_out  (storage_22_dat1)
+);
 assign subfragments_syncfifo5_wrport_dat_r = storage_22_dat0;
 assign subfragments_syncfifo5_rdport_dat_r = storage_22_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_23: 128-words x 230-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [229:0] storage_23[0:127];
-reg [229:0] storage_23_dat0;
-reg [229:0] storage_23_dat1;
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo6_wrport_we)
-		storage_23[subfragments_syncfifo6_wrport_adr] <= subfragments_syncfifo6_wrport_dat_w;
-	storage_23_dat0 <= storage_23[subfragments_syncfifo6_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo6_rdport_re)
-		storage_23_dat1 <= storage_23[subfragments_syncfifo6_rdport_adr];
-end
+// Patched: 128×230 → fakeram_1rw1r_230w128d_sram (u_storage_23_fakeram_1rw1r_230w128d_sram)
+wire [229:0] storage_23_dat0;
+wire [229:0] storage_23_dat1;
+(* keep *) fakeram_1rw1r_230w128d_sram u_storage_23_fakeram_1rw1r_230w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (subfragments_syncfifo6_wrport_we),
+    .rw0_addr_in(subfragments_syncfifo6_wrport_adr),
+    .rw0_wd_in  (subfragments_syncfifo6_wrport_dat_w),
+    .rw0_rd_out (storage_23_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (subfragments_syncfifo6_rdport_re),
+    .r0_addr_in (subfragments_syncfifo6_rdport_adr),
+    .r0_rd_out  (storage_23_dat1)
+);
 assign subfragments_syncfifo6_wrport_dat_r = storage_23_dat0;
 assign subfragments_syncfifo6_rdport_dat_r = storage_23_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_24: 128-words x 230-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [229:0] storage_24[0:127];
-reg [229:0] storage_24_dat0;
-reg [229:0] storage_24_dat1;
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo7_wrport_we)
-		storage_24[subfragments_syncfifo7_wrport_adr] <= subfragments_syncfifo7_wrport_dat_w;
-	storage_24_dat0 <= storage_24[subfragments_syncfifo7_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo7_rdport_re)
-		storage_24_dat1 <= storage_24[subfragments_syncfifo7_rdport_adr];
-end
+// Patched: 128×230 → fakeram_1rw1r_230w128d_sram (u_storage_24_fakeram_1rw1r_230w128d_sram)
+wire [229:0] storage_24_dat0;
+wire [229:0] storage_24_dat1;
+(* keep *) fakeram_1rw1r_230w128d_sram u_storage_24_fakeram_1rw1r_230w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (subfragments_syncfifo7_wrport_we),
+    .rw0_addr_in(subfragments_syncfifo7_wrport_adr),
+    .rw0_wd_in  (subfragments_syncfifo7_wrport_dat_w),
+    .rw0_rd_out (storage_24_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (subfragments_syncfifo7_rdport_re),
+    .r0_addr_in (subfragments_syncfifo7_rdport_adr),
+    .r0_rd_out  (storage_24_dat1)
+);
 assign subfragments_syncfifo7_wrport_dat_r = storage_24_dat0;
 assign subfragments_syncfifo7_rdport_dat_r = storage_24_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_25: 128-words x 230-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [229:0] storage_25[0:127];
-reg [229:0] storage_25_dat0;
-reg [229:0] storage_25_dat1;
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo8_wrport_we)
-		storage_25[subfragments_syncfifo8_wrport_adr] <= subfragments_syncfifo8_wrport_dat_w;
-	storage_25_dat0 <= storage_25[subfragments_syncfifo8_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo8_rdport_re)
-		storage_25_dat1 <= storage_25[subfragments_syncfifo8_rdport_adr];
-end
+// Patched: 128×230 → fakeram_1rw1r_230w128d_sram (u_storage_25_fakeram_1rw1r_230w128d_sram)
+wire [229:0] storage_25_dat0;
+wire [229:0] storage_25_dat1;
+(* keep *) fakeram_1rw1r_230w128d_sram u_storage_25_fakeram_1rw1r_230w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (subfragments_syncfifo8_wrport_we),
+    .rw0_addr_in(subfragments_syncfifo8_wrport_adr),
+    .rw0_wd_in  (subfragments_syncfifo8_wrport_dat_w),
+    .rw0_rd_out (storage_25_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (subfragments_syncfifo8_rdport_re),
+    .r0_addr_in (subfragments_syncfifo8_rdport_adr),
+    .r0_rd_out  (storage_25_dat1)
+);
 assign subfragments_syncfifo8_wrport_dat_r = storage_25_dat0;
 assign subfragments_syncfifo8_rdport_dat_r = storage_25_dat1;
 
 
+
 //------------------------------------------------------------------------------
-// Memory storage_26: 128-words x 230-bit
-//------------------------------------------------------------------------------
-// Port 0 | Read: Sync  | Write: Sync | Mode: Read-First 
-// Port 1 | Read: Sync  | Write: ---- | 
-reg [229:0] storage_26[0:127];
-reg [229:0] storage_26_dat0;
-reg [229:0] storage_26_dat1;
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo9_wrport_we)
-		storage_26[subfragments_syncfifo9_wrport_adr] <= subfragments_syncfifo9_wrport_dat_w;
-	storage_26_dat0 <= storage_26[subfragments_syncfifo9_wrport_adr];
-end
-always @(posedge sys_clk) begin
-	if (subfragments_syncfifo9_rdport_re)
-		storage_26_dat1 <= storage_26[subfragments_syncfifo9_rdport_adr];
-end
+// Patched: 128×230 → fakeram_1rw1r_230w128d_sram (u_storage_26_fakeram_1rw1r_230w128d_sram)
+wire [229:0] storage_26_dat0;
+wire [229:0] storage_26_dat1;
+(* keep *) fakeram_1rw1r_230w128d_sram u_storage_26_fakeram_1rw1r_230w128d_sram (
+    .rw0_clk    (sys_clk),
+    .rw0_ce_in  (1'b1),
+    .rw0_we_in  (subfragments_syncfifo9_wrport_we),
+    .rw0_addr_in(subfragments_syncfifo9_wrport_adr),
+    .rw0_wd_in  (subfragments_syncfifo9_wrport_dat_w),
+    .rw0_rd_out (storage_26_dat0),
+    .r0_clk     (sys_clk),
+    .r0_ce_in   (subfragments_syncfifo9_rdport_re),
+    .r0_addr_in (subfragments_syncfifo9_rdport_adr),
+    .r0_rd_out  (storage_26_dat1)
+);
 assign subfragments_syncfifo9_wrport_dat_r = storage_26_dat0;
 assign subfragments_syncfifo9_rdport_dat_r = storage_26_dat1;
+
 
 
 (* ars_ff1 = "true", async_reg = "true" *)


### PR DESCRIPTION
## Summary

Commit `24bbf831` ("Design & flow fixes enabled by the macro recovery") silently reverted **all** of PR #143's litepci real-FakeRAM + single-clock-SDC work back to mocked memories (its message only claimed to add the pcie_us LEF/LIB; the revert was unintended — that branch forked off pre-#143 `main`). This restores #143's logic while **keeping** the post-#143 wd_in-fixed SRAM macros and `phy/` relocation, and fixes two real bugs surfaced along the way.

## Changes

- **#143 recovery:** restore `inline_fakeram.py`, fakeram-mapped `litepcie_core.v`, single-clock `constraint.sdc`; hand-merge `gen.sh` (keep HEAD's pcie_us→`phy/` regen loop **and** re-add the patcher call); asap7 `BUILD.bazel` real-FakeRAM args at util 75 (best measured PPA).
- **SIG11 fix:** `gen_phy_lef.py` emitted `function:"0"` on pcie_us clock outputs → constant-folded `user_clk` → floorplan metrics STA segfault. Now tags `{user_clk,int_qpll1outclk_out,int_qpll1outrefclk_out}` `clock:true`; regenerated all 3 platforms' `phy/lib/pcie_us.lib`.
- **`clk` feedthrough fix:** the forwarded user-clock output port was timed as a ~4.9 ns data path through the CTS tree (spurious ~−2 ns WNS `repair_timing` can't fix). Modeled as `create_generated_clock`, mirroring `designs/asap7/litedram` (recurring LiteX-family pattern).

## Result (asap7, real wd_in-fixed FakeRAM, util 75)

| Metric | Value |
|---|---|
| Reg-to-reg **setup** | **MET +0.758 ns** at 3.6 ns (closes) |
| Setup TNS / viols | −2.39 ns / 3 (vs −9.67 ns at util 60) |
| Die area | 0.653 mm² (−20% vs util 60) |
| **Hold** | −2.2 ns, ~11k viols — **structurally skew-bound** |

**Setup closes; hold is structurally skew-bound.** The fixed LiteX RTL clocks 20 DMA/TLP FakeRAMs (59–74% of the core) from one small clock-source pin (`pcie_us/user_clk`). Proven unfixable by every in-scope lever (util sweep — skew is die-size-independent; one-block / perimeter-ring / two-band macro placements all hit the area/perimeter wall). Closing hold needs RTL changes the benchmark charter forbids; this is a valid characterization result. #143's old "3.6 ns / −0.44 ns" numbers were fictitious (pre-wd_in-fix LEFs left half the write-data paths untimed). `DECISIONS.md` rewritten with honest numbers + the structural finding.

## Not in scope / follow-up

nangate45 / sky130hd remain on the regressed config and need macro-name reconciliation (the wd_in-fix reorg renamed their macros `fakeram45_*` / `fakeram130_*`). Documented in `DECISIONS.md`. Hold-skew tracking issue filed separately.