### PR TITLE
ternip: scale up hightide.svh (D=2560, TmatmulParallelism=256, VectorParallelism=8)

### DIFF
--- a/designs/src/ternip/config/hightide.svh
+++ b/designs/src/ternip/config/hightide.svh
@@ -1,7 +1,7 @@
 
-localparam int D = 1024;
-localparam int TmatmulParallelism = 64;
-localparam int VectorParallelism = 1;
+localparam int D = 2560;
+localparam int TmatmulParallelism = 256;
+localparam int VectorParallelism = 8;
 localparam int LutParallelism = 1;
 
 localparam int FixedPointPrecision = 16;


### PR DESCRIPTION
## Summary

Bumps the asap7 ternip accelerator's `config/hightide.svh` parameters to a larger, more representative configuration:

- `D` 1024 → **2560**
- `TmatmulParallelism` 64 → **256**
- `VectorParallelism` 1 → **8**

`FixedPointPrecision` (16) and `FixedPointExponent` (-5) are unchanged.

## Notes

- `hightide.svh` is the config the bazel build loads (`-DCONFIG_FILENAME=\"config/hightide.svh\"`); the upstream `generic.svh` is left untouched.
- These larger parameters change the inferred memory shapes (vector_registers, importvector, exportvector). The `ternip_pipelined_mem_fakeram7.v` memory-wrapper generate block and the corresponding FakeRAM macros need to be regenerated to match the new shapes — that work is tracked separately. Until then an asap7 `_final` build of this branch is degenerate (memory logic optimized away).

This PR is the parameter bump only; merge once the matching memory-wrapper / macro update lands.