### PR TITLE
bazel: rewrite flaky GNU download hosts to byte-identical netcologne mirror

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,11 @@ build --remote_cache_compression
 # Local disk cache as fallback
 build --disk_cache=~/.cache/bazel-disk-cache
 
+# Mirror flaky GNU hosts (download.savannah.gnu.org, ftp.gnu.org) to a byte-
+# identical netcologne mirror. Applies to all commands so module resolution
+# during analysis uses it too. See tools/downloader.cfg for context.
+common --downloader_config=tools/downloader.cfg
+
 # bazel-orfs pip dependencies require Python 3.13
 build --@rules_python//python/config_settings:python_version=3.13
 

--- a/tools/downloader.cfg
+++ b/tools/downloader.cfg
@@ -1,0 +1,20 @@
+# Bazel download rewrite config (--downloader_config).
+#
+# download.savannah.gnu.org chronically times out (global GNU-infra
+# outages, observed 2026-05-19 unreachable from both the build host and
+# NRP k8s nodes). It is the BCR source URL for the `freetype` module
+# (transitive: harfbuzz -> freetype), so when it is down EVERY HighTide
+# bazel build fails in analysis with "no such package '@@freetype+//'".
+#
+# Rewrite that one path to mirror.netcologne.de, which serves the
+# byte-identical release tarball (sha256 matches the BCR integrity
+# sha256-XDqOePeyTCCyW1TuV11tqkAAel9O6ihFhhw0CbMCF0c= exactly), so
+# BCR's pinned integrity + patches still apply unchanged.
+rewrite download\.savannah\.gnu\.org/releases/freetype/(.*) mirror.netcologne.de/savannah/freetype/$1
+
+# Same outage class hit ftp.gnu.org (glpk-5.0, make-4.4.1) during PPA campaign
+# #2 round-2 build: every NRP pod's analysis aborted with
+# "no such package '@@glpk+//'" because coin-or-lemon depends on glpk via BCR
+# and the BCR source URL is ftp.gnu.org. netcologne mirrors the entire GNU
+# tree byte-identically (verified sha256 == BCR integrity sha256-ShAT7r...).
+rewrite ftp\.gnu\.org/gnu/(.*) mirror.netcologne.de/gnu/$1


### PR DESCRIPTION
## Summary

Two new files (`tools/downloader.cfg`) / lines (`.bazelrc`) that solve a real and recurring class of build failure on the National Research Platform (NRP) k8s cluster.

## The bug

Bazel's BCR `source.json` for the `freetype` and `glpk` modules points at `download.savannah.gnu.org` and `ftp.gnu.org` respectively. Both hosts intermittently time out from NRP nodes (observed 2026-05-19 unreachable from both the build host and every NRP node sampled). When either host is down, **every HighTide bazel build** — including `bazel info`, `bazel query`, any `bazel build` — aborts in analysis with:

```
ERROR: no such package '@@freetype+//':
   java.io.IOException: Error downloading [https://download.savannah.gnu.org/...]
```

or

```
ERROR: no such package '@@glpk+//':
   java.io.IOException: Error downloading [http://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz]
```

This is because BCR resolves the module's `http_archive()` during analysis (before any target action runs), so the analysis itself fails.

## The fix

Bazel's `--downloader_config` lets you rewrite specific source URLs while keeping the BCR-pinned integrity intact. We rewrite both flaky GNU hosts to `mirror.netcologne.de`, which mirrors the entire GNU + Savannah trees with byte-identical tarballs (sha256 verified to match the BCR `integrity` field for both `freetype-2.13.3` and `glpk-5.0`). Bazel still validates the downloaded bytes against the BCR integrity before extraction, so security/integrity is preserved.

```
rewrite download\.savannah\.gnu\.org/releases/freetype/(.*) mirror.netcologne.de/savannah/freetype/$1
rewrite ftp\.gnu\.org/gnu/(.*)                              mirror.netcologne.de/gnu/$1
```

The `common --downloader_config=tools/downloader.cfg` line in `.bazelrc` applies the rewrite to every command (info / query / build / fetch / sync).

## Why it matters beyond this campaign

Even without the GNU-infra outage, those hosts are flaky and slow from many academic-network egresses. Pointing at netcologne is faster and more reliable for everyone, not just NRP users. The change is opt-in if anyone wants the original behavior (just delete the line in `.bazelrc`).

## Validation

- `bazel info` and a clean `bazel fetch` complete normally with the rewrite active.
- `tools/downloader.cfg` was used to land 6 designs in PPA campaign #2 ([#157](https://github.com/VLSIDA/HighTide/pull/157)) that had been silently fast-failing on the GNU hosts.