### PR TITLE
litepci-nangate45: rename FakeRAM macros to unified _sram naming

### DIFF
--- a/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_130w1024d_sram.lef
+++ b/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_130w1024d_sram.lef
@@ -1,7 +1,7 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram45_1rw1r_130w1024d
-  FOREIGN fakeram45_1rw1r_130w1024d 0 0 ;
+MACRO fakeram_1rw1r_130w1024d_sram
+  FOREIGN fakeram_1rw1r_130w1024d_sram 0 0 ;
   SYMMETRY X Y R90 ;
   SIZE 603.820 BY 571.200 ;
   CLASS BLOCK ;
@@ -4304,6 +4304,6 @@ MACRO fakeram45_1rw1r_130w1024d
     LAYER OVERLAP ;
     RECT 0 0 603.820 571.200 ;
   END
-END fakeram45_1rw1r_130w1024d
+END fakeram_1rw1r_130w1024d_sram
 
 END LIBRARY

--- a/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_130w128d_sram.lef
+++ b/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_130w128d_sram.lef
@@ -1,9 +1,9 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram45_1rw1r_130w512d
-  FOREIGN fakeram45_1rw1r_130w512d 0 0 ;
+MACRO fakeram_1rw1r_130w128d_sram
+  FOREIGN fakeram_1rw1r_130w128d_sram 0 0 ;
   SYMMETRY X Y R90 ;
-  SIZE 376.960 BY 452.200 ;
+  SIZE 188.290 BY 259.000 ;
   CLASS BLOCK ;
   PIN rw0_wd_in[0]
     DIRECTION INPUT ;
@@ -20,7 +20,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 11.445 0.210 11.515 ;
+      RECT 0.000 7.105 0.210 7.175 ;
     END
   END rw0_wd_in[1]
   PIN rw0_wd_in[2]
@@ -29,7 +29,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 22.085 0.210 22.155 ;
+      RECT 0.000 13.405 0.210 13.475 ;
     END
   END rw0_wd_in[2]
   PIN rw0_wd_in[3]
@@ -38,7 +38,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 32.725 0.210 32.795 ;
+      RECT 0.000 19.705 0.210 19.775 ;
     END
   END rw0_wd_in[3]
   PIN rw0_wd_in[4]
@@ -47,7 +47,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 43.365 0.210 43.435 ;
+      RECT 0.000 26.005 0.210 26.075 ;
     END
   END rw0_wd_in[4]
   PIN rw0_wd_in[5]
@@ -56,7 +56,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 54.005 0.210 54.075 ;
+      RECT 0.000 32.305 0.210 32.375 ;
     END
   END rw0_wd_in[5]
   PIN rw0_wd_in[6]
@@ -65,7 +65,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 64.645 0.210 64.715 ;
+      RECT 0.000 38.605 0.210 38.675 ;
     END
   END rw0_wd_in[6]
   PIN rw0_wd_in[7]
@@ -74,7 +74,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 75.285 0.210 75.355 ;
+      RECT 0.000 44.905 0.210 44.975 ;
     END
   END rw0_wd_in[7]
   PIN rw0_wd_in[8]
@@ -83,7 +83,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 85.925 0.210 85.995 ;
+      RECT 0.000 51.205 0.210 51.275 ;
     END
   END rw0_wd_in[8]
   PIN rw0_wd_in[9]
@@ -92,7 +92,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 96.565 0.210 96.635 ;
+      RECT 0.000 57.505 0.210 57.575 ;
     END
   END rw0_wd_in[9]
   PIN rw0_wd_in[10]
@@ -101,7 +101,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 107.205 0.210 107.275 ;
+      RECT 0.000 63.805 0.210 63.875 ;
     END
   END rw0_wd_in[10]
   PIN rw0_wd_in[11]
@@ -110,7 +110,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 117.845 0.210 117.915 ;
+      RECT 0.000 70.105 0.210 70.175 ;
     END
   END rw0_wd_in[11]
   PIN rw0_wd_in[12]
@@ -119,7 +119,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 128.485 0.210 128.555 ;
+      RECT 0.000 76.405 0.210 76.475 ;
     END
   END rw0_wd_in[12]
   PIN rw0_wd_in[13]
@@ -128,7 +128,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 139.125 0.210 139.195 ;
+      RECT 0.000 82.705 0.210 82.775 ;
     END
   END rw0_wd_in[13]
   PIN rw0_wd_in[14]
@@ -137,7 +137,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 149.765 0.210 149.835 ;
+      RECT 0.000 89.005 0.210 89.075 ;
     END
   END rw0_wd_in[14]
   PIN rw0_wd_in[15]
@@ -146,7 +146,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 160.405 0.210 160.475 ;
+      RECT 0.000 95.305 0.210 95.375 ;
     END
   END rw0_wd_in[15]
   PIN rw0_wd_in[16]
@@ -155,7 +155,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 171.045 0.210 171.115 ;
+      RECT 0.000 101.605 0.210 101.675 ;
     END
   END rw0_wd_in[16]
   PIN rw0_wd_in[17]
@@ -164,7 +164,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 181.685 0.210 181.755 ;
+      RECT 0.000 107.905 0.210 107.975 ;
     END
   END rw0_wd_in[17]
   PIN rw0_wd_in[18]
@@ -173,7 +173,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 192.325 0.210 192.395 ;
+      RECT 0.000 114.205 0.210 114.275 ;
     END
   END rw0_wd_in[18]
   PIN rw0_wd_in[19]
@@ -182,7 +182,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 202.965 0.210 203.035 ;
+      RECT 0.000 120.505 0.210 120.575 ;
     END
   END rw0_wd_in[19]
   PIN rw0_wd_in[20]
@@ -191,7 +191,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 213.605 0.210 213.675 ;
+      RECT 0.000 126.805 0.210 126.875 ;
     END
   END rw0_wd_in[20]
   PIN rw0_wd_in[21]
@@ -200,7 +200,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 224.245 0.210 224.315 ;
+      RECT 0.000 133.105 0.210 133.175 ;
     END
   END rw0_wd_in[21]
   PIN rw0_wd_in[22]
@@ -209,7 +209,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 234.885 0.210 234.955 ;
+      RECT 0.000 139.405 0.210 139.475 ;
     END
   END rw0_wd_in[22]
   PIN rw0_wd_in[23]
@@ -218,7 +218,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 245.525 0.210 245.595 ;
+      RECT 0.000 145.705 0.210 145.775 ;
     END
   END rw0_wd_in[23]
   PIN rw0_wd_in[24]
@@ -227,7 +227,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 256.165 0.210 256.235 ;
+      RECT 0.000 152.005 0.210 152.075 ;
     END
   END rw0_wd_in[24]
   PIN rw0_wd_in[25]
@@ -236,7 +236,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 266.805 0.210 266.875 ;
+      RECT 0.000 158.305 0.210 158.375 ;
     END
   END rw0_wd_in[25]
   PIN rw0_wd_in[26]
@@ -245,7 +245,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 277.445 0.210 277.515 ;
+      RECT 0.000 164.605 0.210 164.675 ;
     END
   END rw0_wd_in[26]
   PIN rw0_wd_in[27]
@@ -254,7 +254,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 288.085 0.210 288.155 ;
+      RECT 0.000 170.905 0.210 170.975 ;
     END
   END rw0_wd_in[27]
   PIN rw0_wd_in[28]
@@ -263,7 +263,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 298.725 0.210 298.795 ;
+      RECT 0.000 177.205 0.210 177.275 ;
     END
   END rw0_wd_in[28]
   PIN rw0_wd_in[29]
@@ -272,7 +272,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 309.365 0.210 309.435 ;
+      RECT 0.000 183.505 0.210 183.575 ;
     END
   END rw0_wd_in[29]
   PIN rw0_wd_in[30]
@@ -281,7 +281,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 320.005 0.210 320.075 ;
+      RECT 0.000 189.805 0.210 189.875 ;
     END
   END rw0_wd_in[30]
   PIN rw0_wd_in[31]
@@ -290,7 +290,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 330.645 0.210 330.715 ;
+      RECT 0.000 196.105 0.210 196.175 ;
     END
   END rw0_wd_in[31]
   PIN rw0_wd_in[32]
@@ -299,7 +299,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 341.285 0.210 341.355 ;
+      RECT 0.000 202.405 0.210 202.475 ;
     END
   END rw0_wd_in[32]
   PIN rw0_wd_in[33]
@@ -308,7 +308,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 0.805 376.960 0.875 ;
+      RECT 188.080 0.805 188.290 0.875 ;
     END
   END rw0_wd_in[33]
   PIN rw0_wd_in[34]
@@ -317,7 +317,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 11.445 376.960 11.515 ;
+      RECT 188.080 7.105 188.290 7.175 ;
     END
   END rw0_wd_in[34]
   PIN rw0_wd_in[35]
@@ -326,7 +326,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 22.085 376.960 22.155 ;
+      RECT 188.080 13.405 188.290 13.475 ;
     END
   END rw0_wd_in[35]
   PIN rw0_wd_in[36]
@@ -335,7 +335,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 32.725 376.960 32.795 ;
+      RECT 188.080 19.705 188.290 19.775 ;
     END
   END rw0_wd_in[36]
   PIN rw0_wd_in[37]
@@ -344,7 +344,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 43.365 376.960 43.435 ;
+      RECT 188.080 26.005 188.290 26.075 ;
     END
   END rw0_wd_in[37]
   PIN rw0_wd_in[38]
@@ -353,7 +353,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 54.005 376.960 54.075 ;
+      RECT 188.080 32.305 188.290 32.375 ;
     END
   END rw0_wd_in[38]
   PIN rw0_wd_in[39]
@@ -362,7 +362,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 64.645 376.960 64.715 ;
+      RECT 188.080 38.605 188.290 38.675 ;
     END
   END rw0_wd_in[39]
   PIN rw0_wd_in[40]
@@ -371,7 +371,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 75.285 376.960 75.355 ;
+      RECT 188.080 44.905 188.290 44.975 ;
     END
   END rw0_wd_in[40]
   PIN rw0_wd_in[41]
@@ -380,7 +380,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 85.925 376.960 85.995 ;
+      RECT 188.080 51.205 188.290 51.275 ;
     END
   END rw0_wd_in[41]
   PIN rw0_wd_in[42]
@@ -389,7 +389,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 96.565 376.960 96.635 ;
+      RECT 188.080 57.505 188.290 57.575 ;
     END
   END rw0_wd_in[42]
   PIN rw0_wd_in[43]
@@ -398,7 +398,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 107.205 376.960 107.275 ;
+      RECT 188.080 63.805 188.290 63.875 ;
     END
   END rw0_wd_in[43]
   PIN rw0_wd_in[44]
@@ -407,7 +407,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 117.845 376.960 117.915 ;
+      RECT 188.080 70.105 188.290 70.175 ;
     END
   END rw0_wd_in[44]
   PIN rw0_wd_in[45]
@@ -416,7 +416,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 128.485 376.960 128.555 ;
+      RECT 188.080 76.405 188.290 76.475 ;
     END
   END rw0_wd_in[45]
   PIN rw0_wd_in[46]
@@ -425,7 +425,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 139.125 376.960 139.195 ;
+      RECT 188.080 82.705 188.290 82.775 ;
     END
   END rw0_wd_in[46]
   PIN rw0_wd_in[47]
@@ -434,7 +434,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 149.765 376.960 149.835 ;
+      RECT 188.080 89.005 188.290 89.075 ;
     END
   END rw0_wd_in[47]
   PIN rw0_wd_in[48]
@@ -443,7 +443,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 160.405 376.960 160.475 ;
+      RECT 188.080 95.305 188.290 95.375 ;
     END
   END rw0_wd_in[48]
   PIN rw0_wd_in[49]
@@ -452,7 +452,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 171.045 376.960 171.115 ;
+      RECT 188.080 101.605 188.290 101.675 ;
     END
   END rw0_wd_in[49]
   PIN rw0_wd_in[50]
@@ -461,7 +461,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 181.685 376.960 181.755 ;
+      RECT 188.080 107.905 188.290 107.975 ;
     END
   END rw0_wd_in[50]
   PIN rw0_wd_in[51]
@@ -470,7 +470,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 192.325 376.960 192.395 ;
+      RECT 188.080 114.205 188.290 114.275 ;
     END
   END rw0_wd_in[51]
   PIN rw0_wd_in[52]
@@ -479,7 +479,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 202.965 376.960 203.035 ;
+      RECT 188.080 120.505 188.290 120.575 ;
     END
   END rw0_wd_in[52]
   PIN rw0_wd_in[53]
@@ -488,7 +488,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 213.605 376.960 213.675 ;
+      RECT 188.080 126.805 188.290 126.875 ;
     END
   END rw0_wd_in[53]
   PIN rw0_wd_in[54]
@@ -497,7 +497,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 224.245 376.960 224.315 ;
+      RECT 188.080 133.105 188.290 133.175 ;
     END
   END rw0_wd_in[54]
   PIN rw0_wd_in[55]
@@ -506,7 +506,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 234.885 376.960 234.955 ;
+      RECT 188.080 139.405 188.290 139.475 ;
     END
   END rw0_wd_in[55]
   PIN rw0_wd_in[56]
@@ -515,7 +515,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 245.525 376.960 245.595 ;
+      RECT 188.080 145.705 188.290 145.775 ;
     END
   END rw0_wd_in[56]
   PIN rw0_wd_in[57]
@@ -524,7 +524,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 256.165 376.960 256.235 ;
+      RECT 188.080 152.005 188.290 152.075 ;
     END
   END rw0_wd_in[57]
   PIN rw0_wd_in[58]
@@ -533,7 +533,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 266.805 376.960 266.875 ;
+      RECT 188.080 158.305 188.290 158.375 ;
     END
   END rw0_wd_in[58]
   PIN rw0_wd_in[59]
@@ -542,7 +542,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 277.445 376.960 277.515 ;
+      RECT 188.080 164.605 188.290 164.675 ;
     END
   END rw0_wd_in[59]
   PIN rw0_wd_in[60]
@@ -551,7 +551,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 288.085 376.960 288.155 ;
+      RECT 188.080 170.905 188.290 170.975 ;
     END
   END rw0_wd_in[60]
   PIN rw0_wd_in[61]
@@ -560,7 +560,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 298.725 376.960 298.795 ;
+      RECT 188.080 177.205 188.290 177.275 ;
     END
   END rw0_wd_in[61]
   PIN rw0_wd_in[62]
@@ -569,7 +569,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 309.365 376.960 309.435 ;
+      RECT 188.080 183.505 188.290 183.575 ;
     END
   END rw0_wd_in[62]
   PIN rw0_wd_in[63]
@@ -578,7 +578,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 320.005 376.960 320.075 ;
+      RECT 188.080 189.805 188.290 189.875 ;
     END
   END rw0_wd_in[63]
   PIN rw0_wd_in[64]
@@ -587,7 +587,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 330.645 376.960 330.715 ;
+      RECT 188.080 196.105 188.290 196.175 ;
     END
   END rw0_wd_in[64]
   PIN rw0_wd_in[65]
@@ -605,7 +605,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 3.005 0.000 3.075 0.210 ;
+      RECT 2.055 0.000 2.125 0.210 ;
     END
   END rw0_wd_in[66]
   PIN rw0_wd_in[67]
@@ -614,7 +614,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 4.905 0.000 4.975 0.210 ;
+      RECT 3.005 0.000 3.075 0.210 ;
     END
   END rw0_wd_in[67]
   PIN rw0_wd_in[68]
@@ -623,7 +623,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 6.805 0.000 6.875 0.210 ;
+      RECT 3.955 0.000 4.025 0.210 ;
     END
   END rw0_wd_in[68]
   PIN rw0_wd_in[69]
@@ -632,7 +632,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 8.705 0.000 8.775 0.210 ;
+      RECT 4.905 0.000 4.975 0.210 ;
     END
   END rw0_wd_in[69]
   PIN rw0_wd_in[70]
@@ -641,7 +641,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 10.605 0.000 10.675 0.210 ;
+      RECT 5.855 0.000 5.925 0.210 ;
     END
   END rw0_wd_in[70]
   PIN rw0_wd_in[71]
@@ -650,7 +650,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 12.505 0.000 12.575 0.210 ;
+      RECT 6.805 0.000 6.875 0.210 ;
     END
   END rw0_wd_in[71]
   PIN rw0_wd_in[72]
@@ -659,7 +659,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 14.405 0.000 14.475 0.210 ;
+      RECT 7.755 0.000 7.825 0.210 ;
     END
   END rw0_wd_in[72]
   PIN rw0_wd_in[73]
@@ -668,7 +668,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 16.305 0.000 16.375 0.210 ;
+      RECT 8.705 0.000 8.775 0.210 ;
     END
   END rw0_wd_in[73]
   PIN rw0_wd_in[74]
@@ -677,7 +677,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 18.205 0.000 18.275 0.210 ;
+      RECT 9.655 0.000 9.725 0.210 ;
     END
   END rw0_wd_in[74]
   PIN rw0_wd_in[75]
@@ -686,7 +686,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 20.105 0.000 20.175 0.210 ;
+      RECT 10.605 0.000 10.675 0.210 ;
     END
   END rw0_wd_in[75]
   PIN rw0_wd_in[76]
@@ -695,7 +695,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 22.005 0.000 22.075 0.210 ;
+      RECT 11.555 0.000 11.625 0.210 ;
     END
   END rw0_wd_in[76]
   PIN rw0_wd_in[77]
@@ -704,7 +704,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 23.905 0.000 23.975 0.210 ;
+      RECT 12.505 0.000 12.575 0.210 ;
     END
   END rw0_wd_in[77]
   PIN rw0_wd_in[78]
@@ -713,7 +713,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 25.805 0.000 25.875 0.210 ;
+      RECT 13.455 0.000 13.525 0.210 ;
     END
   END rw0_wd_in[78]
   PIN rw0_wd_in[79]
@@ -722,7 +722,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 27.705 0.000 27.775 0.210 ;
+      RECT 14.405 0.000 14.475 0.210 ;
     END
   END rw0_wd_in[79]
   PIN rw0_wd_in[80]
@@ -731,7 +731,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 29.605 0.000 29.675 0.210 ;
+      RECT 15.355 0.000 15.425 0.210 ;
     END
   END rw0_wd_in[80]
   PIN rw0_wd_in[81]
@@ -740,7 +740,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 31.505 0.000 31.575 0.210 ;
+      RECT 16.305 0.000 16.375 0.210 ;
     END
   END rw0_wd_in[81]
   PIN rw0_wd_in[82]
@@ -749,7 +749,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 33.405 0.000 33.475 0.210 ;
+      RECT 17.255 0.000 17.325 0.210 ;
     END
   END rw0_wd_in[82]
   PIN rw0_wd_in[83]
@@ -758,7 +758,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 35.305 0.000 35.375 0.210 ;
+      RECT 18.205 0.000 18.275 0.210 ;
     END
   END rw0_wd_in[83]
   PIN rw0_wd_in[84]
@@ -767,7 +767,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 37.205 0.000 37.275 0.210 ;
+      RECT 19.155 0.000 19.225 0.210 ;
     END
   END rw0_wd_in[84]
   PIN rw0_wd_in[85]
@@ -776,7 +776,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 39.105 0.000 39.175 0.210 ;
+      RECT 20.105 0.000 20.175 0.210 ;
     END
   END rw0_wd_in[85]
   PIN rw0_wd_in[86]
@@ -785,7 +785,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 41.005 0.000 41.075 0.210 ;
+      RECT 21.055 0.000 21.125 0.210 ;
     END
   END rw0_wd_in[86]
   PIN rw0_wd_in[87]
@@ -794,7 +794,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 42.905 0.000 42.975 0.210 ;
+      RECT 22.005 0.000 22.075 0.210 ;
     END
   END rw0_wd_in[87]
   PIN rw0_wd_in[88]
@@ -803,7 +803,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 44.805 0.000 44.875 0.210 ;
+      RECT 22.955 0.000 23.025 0.210 ;
     END
   END rw0_wd_in[88]
   PIN rw0_wd_in[89]
@@ -812,7 +812,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 46.705 0.000 46.775 0.210 ;
+      RECT 23.905 0.000 23.975 0.210 ;
     END
   END rw0_wd_in[89]
   PIN rw0_wd_in[90]
@@ -821,7 +821,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 48.605 0.000 48.675 0.210 ;
+      RECT 24.855 0.000 24.925 0.210 ;
     END
   END rw0_wd_in[90]
   PIN rw0_wd_in[91]
@@ -830,7 +830,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 50.505 0.000 50.575 0.210 ;
+      RECT 25.805 0.000 25.875 0.210 ;
     END
   END rw0_wd_in[91]
   PIN rw0_wd_in[92]
@@ -839,7 +839,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 52.405 0.000 52.475 0.210 ;
+      RECT 26.755 0.000 26.825 0.210 ;
     END
   END rw0_wd_in[92]
   PIN rw0_wd_in[93]
@@ -848,7 +848,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 54.305 0.000 54.375 0.210 ;
+      RECT 27.705 0.000 27.775 0.210 ;
     END
   END rw0_wd_in[93]
   PIN rw0_wd_in[94]
@@ -857,7 +857,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 56.205 0.000 56.275 0.210 ;
+      RECT 28.655 0.000 28.725 0.210 ;
     END
   END rw0_wd_in[94]
   PIN rw0_wd_in[95]
@@ -866,7 +866,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 58.105 0.000 58.175 0.210 ;
+      RECT 29.605 0.000 29.675 0.210 ;
     END
   END rw0_wd_in[95]
   PIN rw0_wd_in[96]
@@ -875,7 +875,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 60.005 0.000 60.075 0.210 ;
+      RECT 30.555 0.000 30.625 0.210 ;
     END
   END rw0_wd_in[96]
   PIN rw0_wd_in[97]
@@ -884,7 +884,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 61.905 0.000 61.975 0.210 ;
+      RECT 31.505 0.000 31.575 0.210 ;
     END
   END rw0_wd_in[97]
   PIN rw0_wd_in[98]
@@ -893,7 +893,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 63.805 0.000 63.875 0.210 ;
+      RECT 32.455 0.000 32.525 0.210 ;
     END
   END rw0_wd_in[98]
   PIN rw0_wd_in[99]
@@ -902,7 +902,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 65.705 0.000 65.775 0.210 ;
+      RECT 33.405 0.000 33.475 0.210 ;
     END
   END rw0_wd_in[99]
   PIN rw0_wd_in[100]
@@ -911,7 +911,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 67.605 0.000 67.675 0.210 ;
+      RECT 34.355 0.000 34.425 0.210 ;
     END
   END rw0_wd_in[100]
   PIN rw0_wd_in[101]
@@ -920,7 +920,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 69.505 0.000 69.575 0.210 ;
+      RECT 35.305 0.000 35.375 0.210 ;
     END
   END rw0_wd_in[101]
   PIN rw0_wd_in[102]
@@ -929,7 +929,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 71.405 0.000 71.475 0.210 ;
+      RECT 36.255 0.000 36.325 0.210 ;
     END
   END rw0_wd_in[102]
   PIN rw0_wd_in[103]
@@ -938,7 +938,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 73.305 0.000 73.375 0.210 ;
+      RECT 37.205 0.000 37.275 0.210 ;
     END
   END rw0_wd_in[103]
   PIN rw0_wd_in[104]
@@ -947,7 +947,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 75.205 0.000 75.275 0.210 ;
+      RECT 38.155 0.000 38.225 0.210 ;
     END
   END rw0_wd_in[104]
   PIN rw0_wd_in[105]
@@ -956,7 +956,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 77.105 0.000 77.175 0.210 ;
+      RECT 39.105 0.000 39.175 0.210 ;
     END
   END rw0_wd_in[105]
   PIN rw0_wd_in[106]
@@ -965,7 +965,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 79.005 0.000 79.075 0.210 ;
+      RECT 40.055 0.000 40.125 0.210 ;
     END
   END rw0_wd_in[106]
   PIN rw0_wd_in[107]
@@ -974,7 +974,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 80.905 0.000 80.975 0.210 ;
+      RECT 41.005 0.000 41.075 0.210 ;
     END
   END rw0_wd_in[107]
   PIN rw0_wd_in[108]
@@ -983,7 +983,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 82.805 0.000 82.875 0.210 ;
+      RECT 41.955 0.000 42.025 0.210 ;
     END
   END rw0_wd_in[108]
   PIN rw0_wd_in[109]
@@ -992,7 +992,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 84.705 0.000 84.775 0.210 ;
+      RECT 42.905 0.000 42.975 0.210 ;
     END
   END rw0_wd_in[109]
   PIN rw0_wd_in[110]
@@ -1001,7 +1001,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 86.605 0.000 86.675 0.210 ;
+      RECT 43.855 0.000 43.925 0.210 ;
     END
   END rw0_wd_in[110]
   PIN rw0_wd_in[111]
@@ -1010,7 +1010,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 88.505 0.000 88.575 0.210 ;
+      RECT 44.805 0.000 44.875 0.210 ;
     END
   END rw0_wd_in[111]
   PIN rw0_wd_in[112]
@@ -1019,7 +1019,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 90.405 0.000 90.475 0.210 ;
+      RECT 45.755 0.000 45.825 0.210 ;
     END
   END rw0_wd_in[112]
   PIN rw0_wd_in[113]
@@ -1028,7 +1028,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 92.305 0.000 92.375 0.210 ;
+      RECT 46.705 0.000 46.775 0.210 ;
     END
   END rw0_wd_in[113]
   PIN rw0_wd_in[114]
@@ -1037,7 +1037,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 94.205 0.000 94.275 0.210 ;
+      RECT 47.655 0.000 47.725 0.210 ;
     END
   END rw0_wd_in[114]
   PIN rw0_wd_in[115]
@@ -1046,7 +1046,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 96.105 0.000 96.175 0.210 ;
+      RECT 48.605 0.000 48.675 0.210 ;
     END
   END rw0_wd_in[115]
   PIN rw0_wd_in[116]
@@ -1055,7 +1055,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 98.005 0.000 98.075 0.210 ;
+      RECT 49.555 0.000 49.625 0.210 ;
     END
   END rw0_wd_in[116]
   PIN rw0_wd_in[117]
@@ -1064,7 +1064,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 99.905 0.000 99.975 0.210 ;
+      RECT 50.505 0.000 50.575 0.210 ;
     END
   END rw0_wd_in[117]
   PIN rw0_wd_in[118]
@@ -1073,7 +1073,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 101.805 0.000 101.875 0.210 ;
+      RECT 51.455 0.000 51.525 0.210 ;
     END
   END rw0_wd_in[118]
   PIN rw0_wd_in[119]
@@ -1082,7 +1082,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 103.705 0.000 103.775 0.210 ;
+      RECT 52.405 0.000 52.475 0.210 ;
     END
   END rw0_wd_in[119]
   PIN rw0_wd_in[120]
@@ -1091,7 +1091,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 105.605 0.000 105.675 0.210 ;
+      RECT 53.355 0.000 53.425 0.210 ;
     END
   END rw0_wd_in[120]
   PIN rw0_wd_in[121]
@@ -1100,7 +1100,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 107.505 0.000 107.575 0.210 ;
+      RECT 54.305 0.000 54.375 0.210 ;
     END
   END rw0_wd_in[121]
   PIN rw0_wd_in[122]
@@ -1109,7 +1109,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 109.405 0.000 109.475 0.210 ;
+      RECT 55.255 0.000 55.325 0.210 ;
     END
   END rw0_wd_in[122]
   PIN rw0_wd_in[123]
@@ -1118,7 +1118,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 111.305 0.000 111.375 0.210 ;
+      RECT 56.205 0.000 56.275 0.210 ;
     END
   END rw0_wd_in[123]
   PIN rw0_wd_in[124]
@@ -1127,7 +1127,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 113.205 0.000 113.275 0.210 ;
+      RECT 57.155 0.000 57.225 0.210 ;
     END
   END rw0_wd_in[124]
   PIN rw0_wd_in[125]
@@ -1136,7 +1136,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 115.105 0.000 115.175 0.210 ;
+      RECT 58.105 0.000 58.175 0.210 ;
     END
   END rw0_wd_in[125]
   PIN rw0_wd_in[126]
@@ -1145,7 +1145,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 117.005 0.000 117.075 0.210 ;
+      RECT 59.055 0.000 59.125 0.210 ;
     END
   END rw0_wd_in[126]
   PIN rw0_wd_in[127]
@@ -1154,7 +1154,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 118.905 0.000 118.975 0.210 ;
+      RECT 60.005 0.000 60.075 0.210 ;
     END
   END rw0_wd_in[127]
   PIN rw0_wd_in[128]
@@ -1163,7 +1163,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 120.805 0.000 120.875 0.210 ;
+      RECT 60.955 0.000 61.025 0.210 ;
     END
   END rw0_wd_in[128]
   PIN rw0_wd_in[129]
@@ -1172,7 +1172,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 122.705 0.000 122.775 0.210 ;
+      RECT 61.905 0.000 61.975 0.210 ;
     END
   END rw0_wd_in[129]
   PIN rw0_rd_out[0]
@@ -1181,7 +1181,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 124.605 0.000 124.675 0.210 ;
+      RECT 62.855 0.000 62.925 0.210 ;
     END
   END rw0_rd_out[0]
   PIN rw0_rd_out[1]
@@ -1190,7 +1190,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 126.505 0.000 126.575 0.210 ;
+      RECT 63.805 0.000 63.875 0.210 ;
     END
   END rw0_rd_out[1]
   PIN rw0_rd_out[2]
@@ -1199,7 +1199,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 128.405 0.000 128.475 0.210 ;
+      RECT 64.755 0.000 64.825 0.210 ;
     END
   END rw0_rd_out[2]
   PIN rw0_rd_out[3]
@@ -1208,7 +1208,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 130.305 0.000 130.375 0.210 ;
+      RECT 65.705 0.000 65.775 0.210 ;
     END
   END rw0_rd_out[3]
   PIN rw0_rd_out[4]
@@ -1217,7 +1217,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 132.205 0.000 132.275 0.210 ;
+      RECT 66.655 0.000 66.725 0.210 ;
     END
   END rw0_rd_out[4]
   PIN rw0_rd_out[5]
@@ -1226,7 +1226,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 134.105 0.000 134.175 0.210 ;
+      RECT 67.605 0.000 67.675 0.210 ;
     END
   END rw0_rd_out[5]
   PIN rw0_rd_out[6]
@@ -1235,7 +1235,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 136.005 0.000 136.075 0.210 ;
+      RECT 68.555 0.000 68.625 0.210 ;
     END
   END rw0_rd_out[6]
   PIN rw0_rd_out[7]
@@ -1244,7 +1244,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 137.905 0.000 137.975 0.210 ;
+      RECT 69.505 0.000 69.575 0.210 ;
     END
   END rw0_rd_out[7]
   PIN rw0_rd_out[8]
@@ -1253,7 +1253,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 139.805 0.000 139.875 0.210 ;
+      RECT 70.455 0.000 70.525 0.210 ;
     END
   END rw0_rd_out[8]
   PIN rw0_rd_out[9]
@@ -1262,7 +1262,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 141.705 0.000 141.775 0.210 ;
+      RECT 71.405 0.000 71.475 0.210 ;
     END
   END rw0_rd_out[9]
   PIN rw0_rd_out[10]
@@ -1271,7 +1271,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 143.605 0.000 143.675 0.210 ;
+      RECT 72.355 0.000 72.425 0.210 ;
     END
   END rw0_rd_out[10]
   PIN rw0_rd_out[11]
@@ -1280,7 +1280,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 145.505 0.000 145.575 0.210 ;
+      RECT 73.305 0.000 73.375 0.210 ;
     END
   END rw0_rd_out[11]
   PIN rw0_rd_out[12]
@@ -1289,7 +1289,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 147.405 0.000 147.475 0.210 ;
+      RECT 74.255 0.000 74.325 0.210 ;
     END
   END rw0_rd_out[12]
   PIN rw0_rd_out[13]
@@ -1298,7 +1298,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 149.305 0.000 149.375 0.210 ;
+      RECT 75.205 0.000 75.275 0.210 ;
     END
   END rw0_rd_out[13]
   PIN rw0_rd_out[14]
@@ -1307,7 +1307,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 151.205 0.000 151.275 0.210 ;
+      RECT 76.155 0.000 76.225 0.210 ;
     END
   END rw0_rd_out[14]
   PIN rw0_rd_out[15]
@@ -1316,7 +1316,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 153.105 0.000 153.175 0.210 ;
+      RECT 77.105 0.000 77.175 0.210 ;
     END
   END rw0_rd_out[15]
   PIN rw0_rd_out[16]
@@ -1325,7 +1325,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 155.005 0.000 155.075 0.210 ;
+      RECT 78.055 0.000 78.125 0.210 ;
     END
   END rw0_rd_out[16]
   PIN rw0_rd_out[17]
@@ -1334,7 +1334,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 156.905 0.000 156.975 0.210 ;
+      RECT 79.005 0.000 79.075 0.210 ;
     END
   END rw0_rd_out[17]
   PIN rw0_rd_out[18]
@@ -1343,7 +1343,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 158.805 0.000 158.875 0.210 ;
+      RECT 79.955 0.000 80.025 0.210 ;
     END
   END rw0_rd_out[18]
   PIN rw0_rd_out[19]
@@ -1352,7 +1352,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 160.705 0.000 160.775 0.210 ;
+      RECT 80.905 0.000 80.975 0.210 ;
     END
   END rw0_rd_out[19]
   PIN rw0_rd_out[20]
@@ -1361,7 +1361,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 162.605 0.000 162.675 0.210 ;
+      RECT 81.855 0.000 81.925 0.210 ;
     END
   END rw0_rd_out[20]
   PIN rw0_rd_out[21]
@@ -1370,7 +1370,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 164.505 0.000 164.575 0.210 ;
+      RECT 82.805 0.000 82.875 0.210 ;
     END
   END rw0_rd_out[21]
   PIN rw0_rd_out[22]
@@ -1379,7 +1379,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 166.405 0.000 166.475 0.210 ;
+      RECT 83.755 0.000 83.825 0.210 ;
     END
   END rw0_rd_out[22]
   PIN rw0_rd_out[23]
@@ -1388,7 +1388,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 168.305 0.000 168.375 0.210 ;
+      RECT 84.705 0.000 84.775 0.210 ;
     END
   END rw0_rd_out[23]
   PIN rw0_rd_out[24]
@@ -1397,7 +1397,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 170.205 0.000 170.275 0.210 ;
+      RECT 85.655 0.000 85.725 0.210 ;
     END
   END rw0_rd_out[24]
   PIN rw0_rd_out[25]
@@ -1406,7 +1406,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 172.105 0.000 172.175 0.210 ;
+      RECT 86.605 0.000 86.675 0.210 ;
     END
   END rw0_rd_out[25]
   PIN rw0_rd_out[26]
@@ -1415,7 +1415,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 174.005 0.000 174.075 0.210 ;
+      RECT 87.555 0.000 87.625 0.210 ;
     END
   END rw0_rd_out[26]
   PIN rw0_rd_out[27]
@@ -1424,7 +1424,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 175.905 0.000 175.975 0.210 ;
+      RECT 88.505 0.000 88.575 0.210 ;
     END
   END rw0_rd_out[27]
   PIN rw0_rd_out[28]
@@ -1433,7 +1433,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 177.805 0.000 177.875 0.210 ;
+      RECT 89.455 0.000 89.525 0.210 ;
     END
   END rw0_rd_out[28]
   PIN rw0_rd_out[29]
@@ -1442,7 +1442,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 179.705 0.000 179.775 0.210 ;
+      RECT 90.405 0.000 90.475 0.210 ;
     END
   END rw0_rd_out[29]
   PIN rw0_rd_out[30]
@@ -1451,7 +1451,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 181.605 0.000 181.675 0.210 ;
+      RECT 91.355 0.000 91.425 0.210 ;
     END
   END rw0_rd_out[30]
   PIN rw0_rd_out[31]
@@ -1460,7 +1460,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 183.505 0.000 183.575 0.210 ;
+      RECT 92.305 0.000 92.375 0.210 ;
     END
   END rw0_rd_out[31]
   PIN rw0_rd_out[32]
@@ -1469,7 +1469,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 185.405 0.000 185.475 0.210 ;
+      RECT 93.255 0.000 93.325 0.210 ;
     END
   END rw0_rd_out[32]
   PIN rw0_rd_out[33]
@@ -1478,7 +1478,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 187.305 0.000 187.375 0.210 ;
+      RECT 94.205 0.000 94.275 0.210 ;
     END
   END rw0_rd_out[33]
   PIN rw0_rd_out[34]
@@ -1487,7 +1487,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 189.205 0.000 189.275 0.210 ;
+      RECT 95.155 0.000 95.225 0.210 ;
     END
   END rw0_rd_out[34]
   PIN rw0_rd_out[35]
@@ -1496,7 +1496,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 191.105 0.000 191.175 0.210 ;
+      RECT 96.105 0.000 96.175 0.210 ;
     END
   END rw0_rd_out[35]
   PIN rw0_rd_out[36]
@@ -1505,7 +1505,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 193.005 0.000 193.075 0.210 ;
+      RECT 97.055 0.000 97.125 0.210 ;
     END
   END rw0_rd_out[36]
   PIN rw0_rd_out[37]
@@ -1514,7 +1514,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 194.905 0.000 194.975 0.210 ;
+      RECT 98.005 0.000 98.075 0.210 ;
     END
   END rw0_rd_out[37]
   PIN rw0_rd_out[38]
@@ -1523,7 +1523,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 196.805 0.000 196.875 0.210 ;
+      RECT 98.955 0.000 99.025 0.210 ;
     END
   END rw0_rd_out[38]
   PIN rw0_rd_out[39]
@@ -1532,7 +1532,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 198.705 0.000 198.775 0.210 ;
+      RECT 99.905 0.000 99.975 0.210 ;
     END
   END rw0_rd_out[39]
   PIN rw0_rd_out[40]
@@ -1541,7 +1541,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 200.605 0.000 200.675 0.210 ;
+      RECT 100.855 0.000 100.925 0.210 ;
     END
   END rw0_rd_out[40]
   PIN rw0_rd_out[41]
@@ -1550,7 +1550,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 202.505 0.000 202.575 0.210 ;
+      RECT 101.805 0.000 101.875 0.210 ;
     END
   END rw0_rd_out[41]
   PIN rw0_rd_out[42]
@@ -1559,7 +1559,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 204.405 0.000 204.475 0.210 ;
+      RECT 102.755 0.000 102.825 0.210 ;
     END
   END rw0_rd_out[42]
   PIN rw0_rd_out[43]
@@ -1568,7 +1568,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 206.305 0.000 206.375 0.210 ;
+      RECT 103.705 0.000 103.775 0.210 ;
     END
   END rw0_rd_out[43]
   PIN rw0_rd_out[44]
@@ -1577,7 +1577,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 208.205 0.000 208.275 0.210 ;
+      RECT 104.655 0.000 104.725 0.210 ;
     END
   END rw0_rd_out[44]
   PIN rw0_rd_out[45]
@@ -1586,7 +1586,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 210.105 0.000 210.175 0.210 ;
+      RECT 105.605 0.000 105.675 0.210 ;
     END
   END rw0_rd_out[45]
   PIN rw0_rd_out[46]
@@ -1595,7 +1595,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 212.005 0.000 212.075 0.210 ;
+      RECT 106.555 0.000 106.625 0.210 ;
     END
   END rw0_rd_out[46]
   PIN rw0_rd_out[47]
@@ -1604,7 +1604,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 213.905 0.000 213.975 0.210 ;
+      RECT 107.505 0.000 107.575 0.210 ;
     END
   END rw0_rd_out[47]
   PIN rw0_rd_out[48]
@@ -1613,7 +1613,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 215.805 0.000 215.875 0.210 ;
+      RECT 108.455 0.000 108.525 0.210 ;
     END
   END rw0_rd_out[48]
   PIN rw0_rd_out[49]
@@ -1622,7 +1622,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 217.705 0.000 217.775 0.210 ;
+      RECT 109.405 0.000 109.475 0.210 ;
     END
   END rw0_rd_out[49]
   PIN rw0_rd_out[50]
@@ -1631,7 +1631,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 219.605 0.000 219.675 0.210 ;
+      RECT 110.355 0.000 110.425 0.210 ;
     END
   END rw0_rd_out[50]
   PIN rw0_rd_out[51]
@@ -1640,7 +1640,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 221.505 0.000 221.575 0.210 ;
+      RECT 111.305 0.000 111.375 0.210 ;
     END
   END rw0_rd_out[51]
   PIN rw0_rd_out[52]
@@ -1649,7 +1649,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 223.405 0.000 223.475 0.210 ;
+      RECT 112.255 0.000 112.325 0.210 ;
     END
   END rw0_rd_out[52]
   PIN rw0_rd_out[53]
@@ -1658,7 +1658,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 225.305 0.000 225.375 0.210 ;
+      RECT 113.205 0.000 113.275 0.210 ;
     END
   END rw0_rd_out[53]
   PIN rw0_rd_out[54]
@@ -1667,7 +1667,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 227.205 0.000 227.275 0.210 ;
+      RECT 114.155 0.000 114.225 0.210 ;
     END
   END rw0_rd_out[54]
   PIN rw0_rd_out[55]
@@ -1676,7 +1676,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 229.105 0.000 229.175 0.210 ;
+      RECT 115.105 0.000 115.175 0.210 ;
     END
   END rw0_rd_out[55]
   PIN rw0_rd_out[56]
@@ -1685,7 +1685,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 231.005 0.000 231.075 0.210 ;
+      RECT 116.055 0.000 116.125 0.210 ;
     END
   END rw0_rd_out[56]
   PIN rw0_rd_out[57]
@@ -1694,7 +1694,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 232.905 0.000 232.975 0.210 ;
+      RECT 117.005 0.000 117.075 0.210 ;
     END
   END rw0_rd_out[57]
   PIN rw0_rd_out[58]
@@ -1703,7 +1703,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 234.805 0.000 234.875 0.210 ;
+      RECT 117.955 0.000 118.025 0.210 ;
     END
   END rw0_rd_out[58]
   PIN rw0_rd_out[59]
@@ -1712,7 +1712,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 236.705 0.000 236.775 0.210 ;
+      RECT 118.905 0.000 118.975 0.210 ;
     END
   END rw0_rd_out[59]
   PIN rw0_rd_out[60]
@@ -1721,7 +1721,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 238.605 0.000 238.675 0.210 ;
+      RECT 119.855 0.000 119.925 0.210 ;
     END
   END rw0_rd_out[60]
   PIN rw0_rd_out[61]
@@ -1730,7 +1730,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 240.505 0.000 240.575 0.210 ;
+      RECT 120.805 0.000 120.875 0.210 ;
     END
   END rw0_rd_out[61]
   PIN rw0_rd_out[62]
@@ -1739,7 +1739,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 242.405 0.000 242.475 0.210 ;
+      RECT 121.755 0.000 121.825 0.210 ;
     END
   END rw0_rd_out[62]
   PIN rw0_rd_out[63]
@@ -1748,7 +1748,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 244.305 0.000 244.375 0.210 ;
+      RECT 122.705 0.000 122.775 0.210 ;
     END
   END rw0_rd_out[63]
   PIN rw0_rd_out[64]
@@ -1757,7 +1757,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 246.205 0.000 246.275 0.210 ;
+      RECT 123.655 0.000 123.725 0.210 ;
     END
   END rw0_rd_out[64]
   PIN rw0_rd_out[65]
@@ -1766,7 +1766,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 1.105 451.990 1.175 452.200 ;
+      RECT 1.105 258.790 1.175 259.000 ;
     END
   END rw0_rd_out[65]
   PIN rw0_rd_out[66]
@@ -1775,7 +1775,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 3.765 451.990 3.835 452.200 ;
+      RECT 2.435 258.790 2.505 259.000 ;
     END
   END rw0_rd_out[66]
   PIN rw0_rd_out[67]
@@ -1784,7 +1784,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 6.425 451.990 6.495 452.200 ;
+      RECT 3.765 258.790 3.835 259.000 ;
     END
   END rw0_rd_out[67]
   PIN rw0_rd_out[68]
@@ -1793,7 +1793,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 9.085 451.990 9.155 452.200 ;
+      RECT 5.095 258.790 5.165 259.000 ;
     END
   END rw0_rd_out[68]
   PIN rw0_rd_out[69]
@@ -1802,7 +1802,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 11.745 451.990 11.815 452.200 ;
+      RECT 6.425 258.790 6.495 259.000 ;
     END
   END rw0_rd_out[69]
   PIN rw0_rd_out[70]
@@ -1811,7 +1811,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 14.405 451.990 14.475 452.200 ;
+      RECT 7.755 258.790 7.825 259.000 ;
     END
   END rw0_rd_out[70]
   PIN rw0_rd_out[71]
@@ -1820,7 +1820,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 17.065 451.990 17.135 452.200 ;
+      RECT 9.085 258.790 9.155 259.000 ;
     END
   END rw0_rd_out[71]
   PIN rw0_rd_out[72]
@@ -1829,7 +1829,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 19.725 451.990 19.795 452.200 ;
+      RECT 10.415 258.790 10.485 259.000 ;
     END
   END rw0_rd_out[72]
   PIN rw0_rd_out[73]
@@ -1838,7 +1838,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 22.385 451.990 22.455 452.200 ;
+      RECT 11.745 258.790 11.815 259.000 ;
     END
   END rw0_rd_out[73]
   PIN rw0_rd_out[74]
@@ -1847,7 +1847,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 25.045 451.990 25.115 452.200 ;
+      RECT 13.075 258.790 13.145 259.000 ;
     END
   END rw0_rd_out[74]
   PIN rw0_rd_out[75]
@@ -1856,7 +1856,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 27.705 451.990 27.775 452.200 ;
+      RECT 14.405 258.790 14.475 259.000 ;
     END
   END rw0_rd_out[75]
   PIN rw0_rd_out[76]
@@ -1865,7 +1865,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 30.365 451.990 30.435 452.200 ;
+      RECT 15.735 258.790 15.805 259.000 ;
     END
   END rw0_rd_out[76]
   PIN rw0_rd_out[77]
@@ -1874,7 +1874,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 33.025 451.990 33.095 452.200 ;
+      RECT 17.065 258.790 17.135 259.000 ;
     END
   END rw0_rd_out[77]
   PIN rw0_rd_out[78]
@@ -1883,7 +1883,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 35.685 451.990 35.755 452.200 ;
+      RECT 18.395 258.790 18.465 259.000 ;
     END
   END rw0_rd_out[78]
   PIN rw0_rd_out[79]
@@ -1892,7 +1892,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 38.345 451.990 38.415 452.200 ;
+      RECT 19.725 258.790 19.795 259.000 ;
     END
   END rw0_rd_out[79]
   PIN rw0_rd_out[80]
@@ -1901,7 +1901,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 41.005 451.990 41.075 452.200 ;
+      RECT 21.055 258.790 21.125 259.000 ;
     END
   END rw0_rd_out[80]
   PIN rw0_rd_out[81]
@@ -1910,7 +1910,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 43.665 451.990 43.735 452.200 ;
+      RECT 22.385 258.790 22.455 259.000 ;
     END
   END rw0_rd_out[81]
   PIN rw0_rd_out[82]
@@ -1919,7 +1919,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 46.325 451.990 46.395 452.200 ;
+      RECT 23.715 258.790 23.785 259.000 ;
     END
   END rw0_rd_out[82]
   PIN rw0_rd_out[83]
@@ -1928,7 +1928,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 48.985 451.990 49.055 452.200 ;
+      RECT 25.045 258.790 25.115 259.000 ;
     END
   END rw0_rd_out[83]
   PIN rw0_rd_out[84]
@@ -1937,7 +1937,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 51.645 451.990 51.715 452.200 ;
+      RECT 26.375 258.790 26.445 259.000 ;
     END
   END rw0_rd_out[84]
   PIN rw0_rd_out[85]
@@ -1946,7 +1946,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 54.305 451.990 54.375 452.200 ;
+      RECT 27.705 258.790 27.775 259.000 ;
     END
   END rw0_rd_out[85]
   PIN rw0_rd_out[86]
@@ -1955,7 +1955,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 56.965 451.990 57.035 452.200 ;
+      RECT 29.035 258.790 29.105 259.000 ;
     END
   END rw0_rd_out[86]
   PIN rw0_rd_out[87]
@@ -1964,7 +1964,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 59.625 451.990 59.695 452.200 ;
+      RECT 30.365 258.790 30.435 259.000 ;
     END
   END rw0_rd_out[87]
   PIN rw0_rd_out[88]
@@ -1973,7 +1973,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 62.285 451.990 62.355 452.200 ;
+      RECT 31.695 258.790 31.765 259.000 ;
     END
   END rw0_rd_out[88]
   PIN rw0_rd_out[89]
@@ -1982,7 +1982,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 64.945 451.990 65.015 452.200 ;
+      RECT 33.025 258.790 33.095 259.000 ;
     END
   END rw0_rd_out[89]
   PIN rw0_rd_out[90]
@@ -1991,7 +1991,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 67.605 451.990 67.675 452.200 ;
+      RECT 34.355 258.790 34.425 259.000 ;
     END
   END rw0_rd_out[90]
   PIN rw0_rd_out[91]
@@ -2000,7 +2000,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 70.265 451.990 70.335 452.200 ;
+      RECT 35.685 258.790 35.755 259.000 ;
     END
   END rw0_rd_out[91]
   PIN rw0_rd_out[92]
@@ -2009,7 +2009,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 72.925 451.990 72.995 452.200 ;
+      RECT 37.015 258.790 37.085 259.000 ;
     END
   END rw0_rd_out[92]
   PIN rw0_rd_out[93]
@@ -2018,7 +2018,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 75.585 451.990 75.655 452.200 ;
+      RECT 38.345 258.790 38.415 259.000 ;
     END
   END rw0_rd_out[93]
   PIN rw0_rd_out[94]
@@ -2027,7 +2027,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 78.245 451.990 78.315 452.200 ;
+      RECT 39.675 258.790 39.745 259.000 ;
     END
   END rw0_rd_out[94]
   PIN rw0_rd_out[95]
@@ -2036,7 +2036,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 80.905 451.990 80.975 452.200 ;
+      RECT 41.005 258.790 41.075 259.000 ;
     END
   END rw0_rd_out[95]
   PIN rw0_rd_out[96]
@@ -2045,7 +2045,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 83.565 451.990 83.635 452.200 ;
+      RECT 42.335 258.790 42.405 259.000 ;
     END
   END rw0_rd_out[96]
   PIN rw0_rd_out[97]
@@ -2054,7 +2054,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 86.225 451.990 86.295 452.200 ;
+      RECT 43.665 258.790 43.735 259.000 ;
     END
   END rw0_rd_out[97]
   PIN rw0_rd_out[98]
@@ -2063,7 +2063,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 88.885 451.990 88.955 452.200 ;
+      RECT 44.995 258.790 45.065 259.000 ;
     END
   END rw0_rd_out[98]
   PIN rw0_rd_out[99]
@@ -2072,7 +2072,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 91.545 451.990 91.615 452.200 ;
+      RECT 46.325 258.790 46.395 259.000 ;
     END
   END rw0_rd_out[99]
   PIN rw0_rd_out[100]
@@ -2081,7 +2081,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 94.205 451.990 94.275 452.200 ;
+      RECT 47.655 258.790 47.725 259.000 ;
     END
   END rw0_rd_out[100]
   PIN rw0_rd_out[101]
@@ -2090,7 +2090,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 96.865 451.990 96.935 452.200 ;
+      RECT 48.985 258.790 49.055 259.000 ;
     END
   END rw0_rd_out[101]
   PIN rw0_rd_out[102]
@@ -2099,7 +2099,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 99.525 451.990 99.595 452.200 ;
+      RECT 50.315 258.790 50.385 259.000 ;
     END
   END rw0_rd_out[102]
   PIN rw0_rd_out[103]
@@ -2108,7 +2108,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 102.185 451.990 102.255 452.200 ;
+      RECT 51.645 258.790 51.715 259.000 ;
     END
   END rw0_rd_out[103]
   PIN rw0_rd_out[104]
@@ -2117,7 +2117,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 104.845 451.990 104.915 452.200 ;
+      RECT 52.975 258.790 53.045 259.000 ;
     END
   END rw0_rd_out[104]
   PIN rw0_rd_out[105]
@@ -2126,7 +2126,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 107.505 451.990 107.575 452.200 ;
+      RECT 54.305 258.790 54.375 259.000 ;
     END
   END rw0_rd_out[105]
   PIN rw0_rd_out[106]
@@ -2135,7 +2135,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 110.165 451.990 110.235 452.200 ;
+      RECT 55.635 258.790 55.705 259.000 ;
     END
   END rw0_rd_out[106]
   PIN rw0_rd_out[107]
@@ -2144,7 +2144,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 112.825 451.990 112.895 452.200 ;
+      RECT 56.965 258.790 57.035 259.000 ;
     END
   END rw0_rd_out[107]
   PIN rw0_rd_out[108]
@@ -2153,7 +2153,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 115.485 451.990 115.555 452.200 ;
+      RECT 58.295 258.790 58.365 259.000 ;
     END
   END rw0_rd_out[108]
   PIN rw0_rd_out[109]
@@ -2162,7 +2162,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 118.145 451.990 118.215 452.200 ;
+      RECT 59.625 258.790 59.695 259.000 ;
     END
   END rw0_rd_out[109]
   PIN rw0_rd_out[110]
@@ -2171,7 +2171,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 120.805 451.990 120.875 452.200 ;
+      RECT 60.955 258.790 61.025 259.000 ;
     END
   END rw0_rd_out[110]
   PIN rw0_rd_out[111]
@@ -2180,7 +2180,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 123.465 451.990 123.535 452.200 ;
+      RECT 62.285 258.790 62.355 259.000 ;
     END
   END rw0_rd_out[111]
   PIN rw0_rd_out[112]
@@ -2189,7 +2189,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 126.125 451.990 126.195 452.200 ;
+      RECT 63.615 258.790 63.685 259.000 ;
     END
   END rw0_rd_out[112]
   PIN rw0_rd_out[113]
@@ -2198,7 +2198,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 128.785 451.990 128.855 452.200 ;
+      RECT 64.945 258.790 65.015 259.000 ;
     END
   END rw0_rd_out[113]
   PIN rw0_rd_out[114]
@@ -2207,7 +2207,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 131.445 451.990 131.515 452.200 ;
+      RECT 66.275 258.790 66.345 259.000 ;
     END
   END rw0_rd_out[114]
   PIN rw0_rd_out[115]
@@ -2216,7 +2216,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 134.105 451.990 134.175 452.200 ;
+      RECT 67.605 258.790 67.675 259.000 ;
     END
   END rw0_rd_out[115]
   PIN rw0_rd_out[116]
@@ -2225,7 +2225,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 136.765 451.990 136.835 452.200 ;
+      RECT 68.935 258.790 69.005 259.000 ;
     END
   END rw0_rd_out[116]
   PIN rw0_rd_out[117]
@@ -2234,7 +2234,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 139.425 451.990 139.495 452.200 ;
+      RECT 70.265 258.790 70.335 259.000 ;
     END
   END rw0_rd_out[117]
   PIN rw0_rd_out[118]
@@ -2243,7 +2243,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 142.085 451.990 142.155 452.200 ;
+      RECT 71.595 258.790 71.665 259.000 ;
     END
   END rw0_rd_out[118]
   PIN rw0_rd_out[119]
@@ -2252,7 +2252,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 144.745 451.990 144.815 452.200 ;
+      RECT 72.925 258.790 72.995 259.000 ;
     END
   END rw0_rd_out[119]
   PIN rw0_rd_out[120]
@@ -2261,7 +2261,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 147.405 451.990 147.475 452.200 ;
+      RECT 74.255 258.790 74.325 259.000 ;
     END
   END rw0_rd_out[120]
   PIN rw0_rd_out[121]
@@ -2270,7 +2270,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 150.065 451.990 150.135 452.200 ;
+      RECT 75.585 258.790 75.655 259.000 ;
     END
   END rw0_rd_out[121]
   PIN rw0_rd_out[122]
@@ -2279,7 +2279,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 152.725 451.990 152.795 452.200 ;
+      RECT 76.915 258.790 76.985 259.000 ;
     END
   END rw0_rd_out[122]
   PIN rw0_rd_out[123]
@@ -2288,7 +2288,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 155.385 451.990 155.455 452.200 ;
+      RECT 78.245 258.790 78.315 259.000 ;
     END
   END rw0_rd_out[123]
   PIN rw0_rd_out[124]
@@ -2297,7 +2297,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 158.045 451.990 158.115 452.200 ;
+      RECT 79.575 258.790 79.645 259.000 ;
     END
   END rw0_rd_out[124]
   PIN rw0_rd_out[125]
@@ -2306,7 +2306,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 160.705 451.990 160.775 452.200 ;
+      RECT 80.905 258.790 80.975 259.000 ;
     END
   END rw0_rd_out[125]
   PIN rw0_rd_out[126]
@@ -2315,7 +2315,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 163.365 451.990 163.435 452.200 ;
+      RECT 82.235 258.790 82.305 259.000 ;
     END
   END rw0_rd_out[126]
   PIN rw0_rd_out[127]
@@ -2324,7 +2324,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 166.025 451.990 166.095 452.200 ;
+      RECT 83.565 258.790 83.635 259.000 ;
     END
   END rw0_rd_out[127]
   PIN rw0_rd_out[128]
@@ -2333,7 +2333,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 168.685 451.990 168.755 452.200 ;
+      RECT 84.895 258.790 84.965 259.000 ;
     END
   END rw0_rd_out[128]
   PIN rw0_rd_out[129]
@@ -2342,7 +2342,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 171.345 451.990 171.415 452.200 ;
+      RECT 86.225 258.790 86.295 259.000 ;
     END
   END rw0_rd_out[129]
   PIN r0_rd_out[0]
@@ -2351,7 +2351,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 248.105 0.000 248.175 0.210 ;
+      RECT 124.605 0.000 124.675 0.210 ;
     END
   END r0_rd_out[0]
   PIN r0_rd_out[1]
@@ -2360,7 +2360,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 250.005 0.000 250.075 0.210 ;
+      RECT 125.555 0.000 125.625 0.210 ;
     END
   END r0_rd_out[1]
   PIN r0_rd_out[2]
@@ -2369,7 +2369,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 251.905 0.000 251.975 0.210 ;
+      RECT 126.505 0.000 126.575 0.210 ;
     END
   END r0_rd_out[2]
   PIN r0_rd_out[3]
@@ -2378,7 +2378,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 253.805 0.000 253.875 0.210 ;
+      RECT 127.455 0.000 127.525 0.210 ;
     END
   END r0_rd_out[3]
   PIN r0_rd_out[4]
@@ -2387,7 +2387,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 255.705 0.000 255.775 0.210 ;
+      RECT 128.405 0.000 128.475 0.210 ;
     END
   END r0_rd_out[4]
   PIN r0_rd_out[5]
@@ -2396,7 +2396,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 257.605 0.000 257.675 0.210 ;
+      RECT 129.355 0.000 129.425 0.210 ;
     END
   END r0_rd_out[5]
   PIN r0_rd_out[6]
@@ -2405,7 +2405,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 259.505 0.000 259.575 0.210 ;
+      RECT 130.305 0.000 130.375 0.210 ;
     END
   END r0_rd_out[6]
   PIN r0_rd_out[7]
@@ -2414,7 +2414,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 261.405 0.000 261.475 0.210 ;
+      RECT 131.255 0.000 131.325 0.210 ;
     END
   END r0_rd_out[7]
   PIN r0_rd_out[8]
@@ -2423,7 +2423,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 263.305 0.000 263.375 0.210 ;
+      RECT 132.205 0.000 132.275 0.210 ;
     END
   END r0_rd_out[8]
   PIN r0_rd_out[9]
@@ -2432,7 +2432,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 265.205 0.000 265.275 0.210 ;
+      RECT 133.155 0.000 133.225 0.210 ;
     END
   END r0_rd_out[9]
   PIN r0_rd_out[10]
@@ -2441,7 +2441,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 267.105 0.000 267.175 0.210 ;
+      RECT 134.105 0.000 134.175 0.210 ;
     END
   END r0_rd_out[10]
   PIN r0_rd_out[11]
@@ -2450,7 +2450,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 269.005 0.000 269.075 0.210 ;
+      RECT 135.055 0.000 135.125 0.210 ;
     END
   END r0_rd_out[11]
   PIN r0_rd_out[12]
@@ -2459,7 +2459,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 270.905 0.000 270.975 0.210 ;
+      RECT 136.005 0.000 136.075 0.210 ;
     END
   END r0_rd_out[12]
   PIN r0_rd_out[13]
@@ -2468,7 +2468,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 272.805 0.000 272.875 0.210 ;
+      RECT 136.955 0.000 137.025 0.210 ;
     END
   END r0_rd_out[13]
   PIN r0_rd_out[14]
@@ -2477,7 +2477,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 274.705 0.000 274.775 0.210 ;
+      RECT 137.905 0.000 137.975 0.210 ;
     END
   END r0_rd_out[14]
   PIN r0_rd_out[15]
@@ -2486,7 +2486,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 276.605 0.000 276.675 0.210 ;
+      RECT 138.855 0.000 138.925 0.210 ;
     END
   END r0_rd_out[15]
   PIN r0_rd_out[16]
@@ -2495,7 +2495,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 278.505 0.000 278.575 0.210 ;
+      RECT 139.805 0.000 139.875 0.210 ;
     END
   END r0_rd_out[16]
   PIN r0_rd_out[17]
@@ -2504,7 +2504,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 280.405 0.000 280.475 0.210 ;
+      RECT 140.755 0.000 140.825 0.210 ;
     END
   END r0_rd_out[17]
   PIN r0_rd_out[18]
@@ -2513,7 +2513,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 282.305 0.000 282.375 0.210 ;
+      RECT 141.705 0.000 141.775 0.210 ;
     END
   END r0_rd_out[18]
   PIN r0_rd_out[19]
@@ -2522,7 +2522,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 284.205 0.000 284.275 0.210 ;
+      RECT 142.655 0.000 142.725 0.210 ;
     END
   END r0_rd_out[19]
   PIN r0_rd_out[20]
@@ -2531,7 +2531,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 286.105 0.000 286.175 0.210 ;
+      RECT 143.605 0.000 143.675 0.210 ;
     END
   END r0_rd_out[20]
   PIN r0_rd_out[21]
@@ -2540,7 +2540,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 288.005 0.000 288.075 0.210 ;
+      RECT 144.555 0.000 144.625 0.210 ;
     END
   END r0_rd_out[21]
   PIN r0_rd_out[22]
@@ -2549,7 +2549,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 289.905 0.000 289.975 0.210 ;
+      RECT 145.505 0.000 145.575 0.210 ;
     END
   END r0_rd_out[22]
   PIN r0_rd_out[23]
@@ -2558,7 +2558,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 291.805 0.000 291.875 0.210 ;
+      RECT 146.455 0.000 146.525 0.210 ;
     END
   END r0_rd_out[23]
   PIN r0_rd_out[24]
@@ -2567,7 +2567,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 293.705 0.000 293.775 0.210 ;
+      RECT 147.405 0.000 147.475 0.210 ;
     END
   END r0_rd_out[24]
   PIN r0_rd_out[25]
@@ -2576,7 +2576,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 295.605 0.000 295.675 0.210 ;
+      RECT 148.355 0.000 148.425 0.210 ;
     END
   END r0_rd_out[25]
   PIN r0_rd_out[26]
@@ -2585,7 +2585,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 297.505 0.000 297.575 0.210 ;
+      RECT 149.305 0.000 149.375 0.210 ;
     END
   END r0_rd_out[26]
   PIN r0_rd_out[27]
@@ -2594,7 +2594,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 299.405 0.000 299.475 0.210 ;
+      RECT 150.255 0.000 150.325 0.210 ;
     END
   END r0_rd_out[27]
   PIN r0_rd_out[28]
@@ -2603,7 +2603,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 301.305 0.000 301.375 0.210 ;
+      RECT 151.205 0.000 151.275 0.210 ;
     END
   END r0_rd_out[28]
   PIN r0_rd_out[29]
@@ -2612,7 +2612,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 303.205 0.000 303.275 0.210 ;
+      RECT 152.155 0.000 152.225 0.210 ;
     END
   END r0_rd_out[29]
   PIN r0_rd_out[30]
@@ -2621,7 +2621,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 305.105 0.000 305.175 0.210 ;
+      RECT 153.105 0.000 153.175 0.210 ;
     END
   END r0_rd_out[30]
   PIN r0_rd_out[31]
@@ -2630,7 +2630,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 307.005 0.000 307.075 0.210 ;
+      RECT 154.055 0.000 154.125 0.210 ;
     END
   END r0_rd_out[31]
   PIN r0_rd_out[32]
@@ -2639,7 +2639,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 308.905 0.000 308.975 0.210 ;
+      RECT 155.005 0.000 155.075 0.210 ;
     END
   END r0_rd_out[32]
   PIN r0_rd_out[33]
@@ -2648,7 +2648,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 310.805 0.000 310.875 0.210 ;
+      RECT 155.955 0.000 156.025 0.210 ;
     END
   END r0_rd_out[33]
   PIN r0_rd_out[34]
@@ -2657,7 +2657,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 312.705 0.000 312.775 0.210 ;
+      RECT 156.905 0.000 156.975 0.210 ;
     END
   END r0_rd_out[34]
   PIN r0_rd_out[35]
@@ -2666,7 +2666,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 314.605 0.000 314.675 0.210 ;
+      RECT 157.855 0.000 157.925 0.210 ;
     END
   END r0_rd_out[35]
   PIN r0_rd_out[36]
@@ -2675,7 +2675,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 316.505 0.000 316.575 0.210 ;
+      RECT 158.805 0.000 158.875 0.210 ;
     END
   END r0_rd_out[36]
   PIN r0_rd_out[37]
@@ -2684,7 +2684,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 318.405 0.000 318.475 0.210 ;
+      RECT 159.755 0.000 159.825 0.210 ;
     END
   END r0_rd_out[37]
   PIN r0_rd_out[38]
@@ -2693,7 +2693,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 320.305 0.000 320.375 0.210 ;
+      RECT 160.705 0.000 160.775 0.210 ;
     END
   END r0_rd_out[38]
   PIN r0_rd_out[39]
@@ -2702,7 +2702,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 322.205 0.000 322.275 0.210 ;
+      RECT 161.655 0.000 161.725 0.210 ;
     END
   END r0_rd_out[39]
   PIN r0_rd_out[40]
@@ -2711,7 +2711,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 324.105 0.000 324.175 0.210 ;
+      RECT 162.605 0.000 162.675 0.210 ;
     END
   END r0_rd_out[40]
   PIN r0_rd_out[41]
@@ -2720,7 +2720,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 326.005 0.000 326.075 0.210 ;
+      RECT 163.555 0.000 163.625 0.210 ;
     END
   END r0_rd_out[41]
   PIN r0_rd_out[42]
@@ -2729,7 +2729,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 327.905 0.000 327.975 0.210 ;
+      RECT 164.505 0.000 164.575 0.210 ;
     END
   END r0_rd_out[42]
   PIN r0_rd_out[43]
@@ -2738,7 +2738,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 329.805 0.000 329.875 0.210 ;
+      RECT 165.455 0.000 165.525 0.210 ;
     END
   END r0_rd_out[43]
   PIN r0_rd_out[44]
@@ -2747,7 +2747,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 331.705 0.000 331.775 0.210 ;
+      RECT 166.405 0.000 166.475 0.210 ;
     END
   END r0_rd_out[44]
   PIN r0_rd_out[45]
@@ -2756,7 +2756,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 333.605 0.000 333.675 0.210 ;
+      RECT 167.355 0.000 167.425 0.210 ;
     END
   END r0_rd_out[45]
   PIN r0_rd_out[46]
@@ -2765,7 +2765,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 335.505 0.000 335.575 0.210 ;
+      RECT 168.305 0.000 168.375 0.210 ;
     END
   END r0_rd_out[46]
   PIN r0_rd_out[47]
@@ -2774,7 +2774,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 337.405 0.000 337.475 0.210 ;
+      RECT 169.255 0.000 169.325 0.210 ;
     END
   END r0_rd_out[47]
   PIN r0_rd_out[48]
@@ -2783,7 +2783,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 339.305 0.000 339.375 0.210 ;
+      RECT 170.205 0.000 170.275 0.210 ;
     END
   END r0_rd_out[48]
   PIN r0_rd_out[49]
@@ -2792,7 +2792,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 341.205 0.000 341.275 0.210 ;
+      RECT 171.155 0.000 171.225 0.210 ;
     END
   END r0_rd_out[49]
   PIN r0_rd_out[50]
@@ -2801,7 +2801,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 343.105 0.000 343.175 0.210 ;
+      RECT 172.105 0.000 172.175 0.210 ;
     END
   END r0_rd_out[50]
   PIN r0_rd_out[51]
@@ -2810,7 +2810,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 345.005 0.000 345.075 0.210 ;
+      RECT 173.055 0.000 173.125 0.210 ;
     END
   END r0_rd_out[51]
   PIN r0_rd_out[52]
@@ -2819,7 +2819,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 346.905 0.000 346.975 0.210 ;
+      RECT 174.005 0.000 174.075 0.210 ;
     END
   END r0_rd_out[52]
   PIN r0_rd_out[53]
@@ -2828,7 +2828,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 348.805 0.000 348.875 0.210 ;
+      RECT 174.955 0.000 175.025 0.210 ;
     END
   END r0_rd_out[53]
   PIN r0_rd_out[54]
@@ -2837,7 +2837,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 350.705 0.000 350.775 0.210 ;
+      RECT 175.905 0.000 175.975 0.210 ;
     END
   END r0_rd_out[54]
   PIN r0_rd_out[55]
@@ -2846,7 +2846,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 352.605 0.000 352.675 0.210 ;
+      RECT 176.855 0.000 176.925 0.210 ;
     END
   END r0_rd_out[55]
   PIN r0_rd_out[56]
@@ -2855,7 +2855,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 354.505 0.000 354.575 0.210 ;
+      RECT 177.805 0.000 177.875 0.210 ;
     END
   END r0_rd_out[56]
   PIN r0_rd_out[57]
@@ -2864,7 +2864,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 356.405 0.000 356.475 0.210 ;
+      RECT 178.755 0.000 178.825 0.210 ;
     END
   END r0_rd_out[57]
   PIN r0_rd_out[58]
@@ -2873,7 +2873,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 358.305 0.000 358.375 0.210 ;
+      RECT 179.705 0.000 179.775 0.210 ;
     END
   END r0_rd_out[58]
   PIN r0_rd_out[59]
@@ -2882,7 +2882,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 360.205 0.000 360.275 0.210 ;
+      RECT 180.655 0.000 180.725 0.210 ;
     END
   END r0_rd_out[59]
   PIN r0_rd_out[60]
@@ -2891,7 +2891,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 362.105 0.000 362.175 0.210 ;
+      RECT 181.605 0.000 181.675 0.210 ;
     END
   END r0_rd_out[60]
   PIN r0_rd_out[61]
@@ -2900,7 +2900,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 364.005 0.000 364.075 0.210 ;
+      RECT 182.555 0.000 182.625 0.210 ;
     END
   END r0_rd_out[61]
   PIN r0_rd_out[62]
@@ -2909,7 +2909,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 365.905 0.000 365.975 0.210 ;
+      RECT 183.505 0.000 183.575 0.210 ;
     END
   END r0_rd_out[62]
   PIN r0_rd_out[63]
@@ -2918,7 +2918,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 367.805 0.000 367.875 0.210 ;
+      RECT 184.455 0.000 184.525 0.210 ;
     END
   END r0_rd_out[63]
   PIN r0_rd_out[64]
@@ -2927,7 +2927,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 369.705 0.000 369.775 0.210 ;
+      RECT 185.405 0.000 185.475 0.210 ;
     END
   END r0_rd_out[64]
   PIN r0_rd_out[65]
@@ -2936,7 +2936,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 174.005 451.990 174.075 452.200 ;
+      RECT 87.555 258.790 87.625 259.000 ;
     END
   END r0_rd_out[65]
   PIN r0_rd_out[66]
@@ -2945,7 +2945,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 176.665 451.990 176.735 452.200 ;
+      RECT 88.885 258.790 88.955 259.000 ;
     END
   END r0_rd_out[66]
   PIN r0_rd_out[67]
@@ -2954,7 +2954,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 179.325 451.990 179.395 452.200 ;
+      RECT 90.215 258.790 90.285 259.000 ;
     END
   END r0_rd_out[67]
   PIN r0_rd_out[68]
@@ -2963,7 +2963,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 181.985 451.990 182.055 452.200 ;
+      RECT 91.545 258.790 91.615 259.000 ;
     END
   END r0_rd_out[68]
   PIN r0_rd_out[69]
@@ -2972,7 +2972,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 184.645 451.990 184.715 452.200 ;
+      RECT 92.875 258.790 92.945 259.000 ;
     END
   END r0_rd_out[69]
   PIN r0_rd_out[70]
@@ -2981,7 +2981,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 187.305 451.990 187.375 452.200 ;
+      RECT 94.205 258.790 94.275 259.000 ;
     END
   END r0_rd_out[70]
   PIN r0_rd_out[71]
@@ -2990,7 +2990,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 189.965 451.990 190.035 452.200 ;
+      RECT 95.535 258.790 95.605 259.000 ;
     END
   END r0_rd_out[71]
   PIN r0_rd_out[72]
@@ -2999,7 +2999,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 192.625 451.990 192.695 452.200 ;
+      RECT 96.865 258.790 96.935 259.000 ;
     END
   END r0_rd_out[72]
   PIN r0_rd_out[73]
@@ -3008,7 +3008,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 195.285 451.990 195.355 452.200 ;
+      RECT 98.195 258.790 98.265 259.000 ;
     END
   END r0_rd_out[73]
   PIN r0_rd_out[74]
@@ -3017,7 +3017,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 197.945 451.990 198.015 452.200 ;
+      RECT 99.525 258.790 99.595 259.000 ;
     END
   END r0_rd_out[74]
   PIN r0_rd_out[75]
@@ -3026,7 +3026,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 200.605 451.990 200.675 452.200 ;
+      RECT 100.855 258.790 100.925 259.000 ;
     END
   END r0_rd_out[75]
   PIN r0_rd_out[76]
@@ -3035,7 +3035,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 203.265 451.990 203.335 452.200 ;
+      RECT 102.185 258.790 102.255 259.000 ;
     END
   END r0_rd_out[76]
   PIN r0_rd_out[77]
@@ -3044,7 +3044,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 205.925 451.990 205.995 452.200 ;
+      RECT 103.515 258.790 103.585 259.000 ;
     END
   END r0_rd_out[77]
   PIN r0_rd_out[78]
@@ -3053,7 +3053,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 208.585 451.990 208.655 452.200 ;
+      RECT 104.845 258.790 104.915 259.000 ;
     END
   END r0_rd_out[78]
   PIN r0_rd_out[79]
@@ -3062,7 +3062,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 211.245 451.990 211.315 452.200 ;
+      RECT 106.175 258.790 106.245 259.000 ;
     END
   END r0_rd_out[79]
   PIN r0_rd_out[80]
@@ -3071,7 +3071,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 213.905 451.990 213.975 452.200 ;
+      RECT 107.505 258.790 107.575 259.000 ;
     END
   END r0_rd_out[80]
   PIN r0_rd_out[81]
@@ -3080,7 +3080,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 216.565 451.990 216.635 452.200 ;
+      RECT 108.835 258.790 108.905 259.000 ;
     END
   END r0_rd_out[81]
   PIN r0_rd_out[82]
@@ -3089,7 +3089,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 219.225 451.990 219.295 452.200 ;
+      RECT 110.165 258.790 110.235 259.000 ;
     END
   END r0_rd_out[82]
   PIN r0_rd_out[83]
@@ -3098,7 +3098,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 221.885 451.990 221.955 452.200 ;
+      RECT 111.495 258.790 111.565 259.000 ;
     END
   END r0_rd_out[83]
   PIN r0_rd_out[84]
@@ -3107,7 +3107,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 224.545 451.990 224.615 452.200 ;
+      RECT 112.825 258.790 112.895 259.000 ;
     END
   END r0_rd_out[84]
   PIN r0_rd_out[85]
@@ -3116,7 +3116,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 227.205 451.990 227.275 452.200 ;
+      RECT 114.155 258.790 114.225 259.000 ;
     END
   END r0_rd_out[85]
   PIN r0_rd_out[86]
@@ -3125,7 +3125,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 229.865 451.990 229.935 452.200 ;
+      RECT 115.485 258.790 115.555 259.000 ;
     END
   END r0_rd_out[86]
   PIN r0_rd_out[87]
@@ -3134,7 +3134,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 232.525 451.990 232.595 452.200 ;
+      RECT 116.815 258.790 116.885 259.000 ;
     END
   END r0_rd_out[87]
   PIN r0_rd_out[88]
@@ -3143,7 +3143,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 235.185 451.990 235.255 452.200 ;
+      RECT 118.145 258.790 118.215 259.000 ;
     END
   END r0_rd_out[88]
   PIN r0_rd_out[89]
@@ -3152,7 +3152,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 237.845 451.990 237.915 452.200 ;
+      RECT 119.475 258.790 119.545 259.000 ;
     END
   END r0_rd_out[89]
   PIN r0_rd_out[90]
@@ -3161,7 +3161,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 240.505 451.990 240.575 452.200 ;
+      RECT 120.805 258.790 120.875 259.000 ;
     END
   END r0_rd_out[90]
   PIN r0_rd_out[91]
@@ -3170,7 +3170,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 243.165 451.990 243.235 452.200 ;
+      RECT 122.135 258.790 122.205 259.000 ;
     END
   END r0_rd_out[91]
   PIN r0_rd_out[92]
@@ -3179,7 +3179,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 245.825 451.990 245.895 452.200 ;
+      RECT 123.465 258.790 123.535 259.000 ;
     END
   END r0_rd_out[92]
   PIN r0_rd_out[93]
@@ -3188,7 +3188,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 248.485 451.990 248.555 452.200 ;
+      RECT 124.795 258.790 124.865 259.000 ;
     END
   END r0_rd_out[93]
   PIN r0_rd_out[94]
@@ -3197,7 +3197,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 251.145 451.990 251.215 452.200 ;
+      RECT 126.125 258.790 126.195 259.000 ;
     END
   END r0_rd_out[94]
   PIN r0_rd_out[95]
@@ -3206,7 +3206,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 253.805 451.990 253.875 452.200 ;
+      RECT 127.455 258.790 127.525 259.000 ;
     END
   END r0_rd_out[95]
   PIN r0_rd_out[96]
@@ -3215,7 +3215,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 256.465 451.990 256.535 452.200 ;
+      RECT 128.785 258.790 128.855 259.000 ;
     END
   END r0_rd_out[96]
   PIN r0_rd_out[97]
@@ -3224,7 +3224,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 259.125 451.990 259.195 452.200 ;
+      RECT 130.115 258.790 130.185 259.000 ;
     END
   END r0_rd_out[97]
   PIN r0_rd_out[98]
@@ -3233,7 +3233,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 261.785 451.990 261.855 452.200 ;
+      RECT 131.445 258.790 131.515 259.000 ;
     END
   END r0_rd_out[98]
   PIN r0_rd_out[99]
@@ -3242,7 +3242,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 264.445 451.990 264.515 452.200 ;
+      RECT 132.775 258.790 132.845 259.000 ;
     END
   END r0_rd_out[99]
   PIN r0_rd_out[100]
@@ -3251,7 +3251,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 267.105 451.990 267.175 452.200 ;
+      RECT 134.105 258.790 134.175 259.000 ;
     END
   END r0_rd_out[100]
   PIN r0_rd_out[101]
@@ -3260,7 +3260,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 269.765 451.990 269.835 452.200 ;
+      RECT 135.435 258.790 135.505 259.000 ;
     END
   END r0_rd_out[101]
   PIN r0_rd_out[102]
@@ -3269,7 +3269,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 272.425 451.990 272.495 452.200 ;
+      RECT 136.765 258.790 136.835 259.000 ;
     END
   END r0_rd_out[102]
   PIN r0_rd_out[103]
@@ -3278,7 +3278,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 275.085 451.990 275.155 452.200 ;
+      RECT 138.095 258.790 138.165 259.000 ;
     END
   END r0_rd_out[103]
   PIN r0_rd_out[104]
@@ -3287,7 +3287,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 277.745 451.990 277.815 452.200 ;
+      RECT 139.425 258.790 139.495 259.000 ;
     END
   END r0_rd_out[104]
   PIN r0_rd_out[105]
@@ -3296,7 +3296,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 280.405 451.990 280.475 452.200 ;
+      RECT 140.755 258.790 140.825 259.000 ;
     END
   END r0_rd_out[105]
   PIN r0_rd_out[106]
@@ -3305,7 +3305,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 283.065 451.990 283.135 452.200 ;
+      RECT 142.085 258.790 142.155 259.000 ;
     END
   END r0_rd_out[106]
   PIN r0_rd_out[107]
@@ -3314,7 +3314,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 285.725 451.990 285.795 452.200 ;
+      RECT 143.415 258.790 143.485 259.000 ;
     END
   END r0_rd_out[107]
   PIN r0_rd_out[108]
@@ -3323,7 +3323,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 288.385 451.990 288.455 452.200 ;
+      RECT 144.745 258.790 144.815 259.000 ;
     END
   END r0_rd_out[108]
   PIN r0_rd_out[109]
@@ -3332,7 +3332,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 291.045 451.990 291.115 452.200 ;
+      RECT 146.075 258.790 146.145 259.000 ;
     END
   END r0_rd_out[109]
   PIN r0_rd_out[110]
@@ -3341,7 +3341,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 293.705 451.990 293.775 452.200 ;
+      RECT 147.405 258.790 147.475 259.000 ;
     END
   END r0_rd_out[110]
   PIN r0_rd_out[111]
@@ -3350,7 +3350,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 296.365 451.990 296.435 452.200 ;
+      RECT 148.735 258.790 148.805 259.000 ;
     END
   END r0_rd_out[111]
   PIN r0_rd_out[112]
@@ -3359,7 +3359,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 299.025 451.990 299.095 452.200 ;
+      RECT 150.065 258.790 150.135 259.000 ;
     END
   END r0_rd_out[112]
   PIN r0_rd_out[113]
@@ -3368,7 +3368,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 301.685 451.990 301.755 452.200 ;
+      RECT 151.395 258.790 151.465 259.000 ;
     END
   END r0_rd_out[113]
   PIN r0_rd_out[114]
@@ -3377,7 +3377,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 304.345 451.990 304.415 452.200 ;
+      RECT 152.725 258.790 152.795 259.000 ;
     END
   END r0_rd_out[114]
   PIN r0_rd_out[115]
@@ -3386,7 +3386,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 307.005 451.990 307.075 452.200 ;
+      RECT 154.055 258.790 154.125 259.000 ;
     END
   END r0_rd_out[115]
   PIN r0_rd_out[116]
@@ -3395,7 +3395,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 309.665 451.990 309.735 452.200 ;
+      RECT 155.385 258.790 155.455 259.000 ;
     END
   END r0_rd_out[116]
   PIN r0_rd_out[117]
@@ -3404,7 +3404,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 312.325 451.990 312.395 452.200 ;
+      RECT 156.715 258.790 156.785 259.000 ;
     END
   END r0_rd_out[117]
   PIN r0_rd_out[118]
@@ -3413,7 +3413,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 314.985 451.990 315.055 452.200 ;
+      RECT 158.045 258.790 158.115 259.000 ;
     END
   END r0_rd_out[118]
   PIN r0_rd_out[119]
@@ -3422,7 +3422,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 317.645 451.990 317.715 452.200 ;
+      RECT 159.375 258.790 159.445 259.000 ;
     END
   END r0_rd_out[119]
   PIN r0_rd_out[120]
@@ -3431,7 +3431,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 320.305 451.990 320.375 452.200 ;
+      RECT 160.705 258.790 160.775 259.000 ;
     END
   END r0_rd_out[120]
   PIN r0_rd_out[121]
@@ -3440,7 +3440,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 322.965 451.990 323.035 452.200 ;
+      RECT 162.035 258.790 162.105 259.000 ;
     END
   END r0_rd_out[121]
   PIN r0_rd_out[122]
@@ -3449,7 +3449,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 325.625 451.990 325.695 452.200 ;
+      RECT 163.365 258.790 163.435 259.000 ;
     END
   END r0_rd_out[122]
   PIN r0_rd_out[123]
@@ -3458,7 +3458,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 328.285 451.990 328.355 452.200 ;
+      RECT 164.695 258.790 164.765 259.000 ;
     END
   END r0_rd_out[123]
   PIN r0_rd_out[124]
@@ -3467,7 +3467,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 330.945 451.990 331.015 452.200 ;
+      RECT 166.025 258.790 166.095 259.000 ;
     END
   END r0_rd_out[124]
   PIN r0_rd_out[125]
@@ -3476,7 +3476,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 333.605 451.990 333.675 452.200 ;
+      RECT 167.355 258.790 167.425 259.000 ;
     END
   END r0_rd_out[125]
   PIN r0_rd_out[126]
@@ -3485,7 +3485,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 336.265 451.990 336.335 452.200 ;
+      RECT 168.685 258.790 168.755 259.000 ;
     END
   END r0_rd_out[126]
   PIN r0_rd_out[127]
@@ -3494,7 +3494,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 338.925 451.990 338.995 452.200 ;
+      RECT 170.015 258.790 170.085 259.000 ;
     END
   END r0_rd_out[127]
   PIN r0_rd_out[128]
@@ -3503,7 +3503,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 341.585 451.990 341.655 452.200 ;
+      RECT 171.345 258.790 171.415 259.000 ;
     END
   END r0_rd_out[128]
   PIN r0_rd_out[129]
@@ -3512,7 +3512,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 344.245 451.990 344.315 452.200 ;
+      RECT 172.675 258.790 172.745 259.000 ;
     END
   END r0_rd_out[129]
   PIN rw0_addr_in[0]
@@ -3521,7 +3521,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 351.925 0.210 351.995 ;
+      RECT 0.000 208.705 0.210 208.775 ;
     END
   END rw0_addr_in[0]
   PIN rw0_addr_in[1]
@@ -3530,7 +3530,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 362.565 0.210 362.635 ;
+      RECT 0.000 215.005 0.210 215.075 ;
     END
   END rw0_addr_in[1]
   PIN rw0_addr_in[2]
@@ -3539,7 +3539,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 373.205 0.210 373.275 ;
+      RECT 0.000 221.305 0.210 221.375 ;
     END
   END rw0_addr_in[2]
   PIN rw0_addr_in[3]
@@ -3548,7 +3548,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 383.845 0.210 383.915 ;
+      RECT 0.000 227.605 0.210 227.675 ;
     END
   END rw0_addr_in[3]
   PIN rw0_addr_in[4]
@@ -3557,7 +3557,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 394.485 0.210 394.555 ;
+      RECT 188.080 202.405 188.290 202.475 ;
     END
   END rw0_addr_in[4]
   PIN rw0_addr_in[5]
@@ -3566,7 +3566,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 341.285 376.960 341.355 ;
+      RECT 188.080 208.705 188.290 208.775 ;
     END
   END rw0_addr_in[5]
   PIN rw0_addr_in[6]
@@ -3575,34 +3575,16 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 351.925 376.960 351.995 ;
+      RECT 188.080 215.005 188.290 215.075 ;
     END
   END rw0_addr_in[6]
-  PIN rw0_addr_in[7]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER metal3 ;
-      RECT 376.750 362.565 376.960 362.635 ;
-    END
-  END rw0_addr_in[7]
-  PIN rw0_addr_in[8]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER metal3 ;
-      RECT 376.750 373.205 376.960 373.275 ;
-    END
-  END rw0_addr_in[8]
   PIN r0_addr_in[0]
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 405.125 0.210 405.195 ;
+      RECT 0.000 233.905 0.210 233.975 ;
     END
   END r0_addr_in[0]
   PIN r0_addr_in[1]
@@ -3611,7 +3593,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 415.765 0.210 415.835 ;
+      RECT 0.000 240.205 0.210 240.275 ;
     END
   END r0_addr_in[1]
   PIN r0_addr_in[2]
@@ -3620,7 +3602,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 426.405 0.210 426.475 ;
+      RECT 0.000 246.505 0.210 246.575 ;
     END
   END r0_addr_in[2]
   PIN r0_addr_in[3]
@@ -3629,7 +3611,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 437.045 0.210 437.115 ;
+      RECT 0.000 252.805 0.210 252.875 ;
     END
   END r0_addr_in[3]
   PIN r0_addr_in[4]
@@ -3638,7 +3620,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 447.685 0.210 447.755 ;
+      RECT 188.080 221.305 188.290 221.375 ;
     END
   END r0_addr_in[4]
   PIN r0_addr_in[5]
@@ -3647,7 +3629,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 383.845 376.960 383.915 ;
+      RECT 188.080 227.605 188.290 227.675 ;
     END
   END r0_addr_in[5]
   PIN r0_addr_in[6]
@@ -3656,34 +3638,16 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 376.750 394.485 376.960 394.555 ;
+      RECT 188.080 233.905 188.290 233.975 ;
     END
   END r0_addr_in[6]
-  PIN r0_addr_in[7]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER metal3 ;
-      RECT 376.750 405.125 376.960 405.195 ;
-    END
-  END r0_addr_in[7]
-  PIN r0_addr_in[8]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER metal3 ;
-      RECT 376.750 415.765 376.960 415.835 ;
-    END
-  END r0_addr_in[8]
   PIN rw0_we_in
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 346.905 451.990 346.975 452.200 ;
+      RECT 174.005 258.790 174.075 259.000 ;
     END
   END rw0_we_in
   PIN rw0_ce_in
@@ -3692,7 +3656,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 349.565 451.990 349.635 452.200 ;
+      RECT 175.335 258.790 175.405 259.000 ;
     END
   END rw0_ce_in
   PIN rw0_clk
@@ -3701,7 +3665,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 352.225 451.990 352.295 452.200 ;
+      RECT 176.665 258.790 176.735 259.000 ;
     END
   END rw0_clk
   PIN r0_ce_in
@@ -3710,7 +3674,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 354.885 451.990 354.955 452.200 ;
+      RECT 177.995 258.790 178.065 259.000 ;
     END
   END r0_ce_in
   PIN r0_clk
@@ -3719,7 +3683,7 @@ MACRO fakeram45_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 357.545 451.990 357.615 452.200 ;
+      RECT 179.325 258.790 179.395 259.000 ;
     END
   END r0_clk
   PIN VSS
@@ -3727,174 +3691,90 @@ MACRO fakeram45_1rw1r_130w512d
     USE GROUND ;
     PORT
       LAYER metal4 ;
-      RECT 1.000 0.840 1.280 451.360 ;
-      RECT 3.240 0.840 3.520 451.360 ;
-      RECT 5.480 0.840 5.760 451.360 ;
-      RECT 7.720 0.840 8.000 451.360 ;
-      RECT 9.960 0.840 10.240 451.360 ;
-      RECT 12.200 0.840 12.480 451.360 ;
-      RECT 14.440 0.840 14.720 451.360 ;
-      RECT 16.680 0.840 16.960 451.360 ;
-      RECT 18.920 0.840 19.200 451.360 ;
-      RECT 21.160 0.840 21.440 451.360 ;
-      RECT 23.400 0.840 23.680 451.360 ;
-      RECT 25.640 0.840 25.920 451.360 ;
-      RECT 27.880 0.840 28.160 451.360 ;
-      RECT 30.120 0.840 30.400 451.360 ;
-      RECT 32.360 0.840 32.640 451.360 ;
-      RECT 34.600 0.840 34.880 451.360 ;
-      RECT 36.840 0.840 37.120 451.360 ;
-      RECT 39.080 0.840 39.360 451.360 ;
-      RECT 41.320 0.840 41.600 451.360 ;
-      RECT 43.560 0.840 43.840 451.360 ;
-      RECT 45.800 0.840 46.080 451.360 ;
-      RECT 48.040 0.840 48.320 451.360 ;
-      RECT 50.280 0.840 50.560 451.360 ;
-      RECT 52.520 0.840 52.800 451.360 ;
-      RECT 54.760 0.840 55.040 451.360 ;
-      RECT 57.000 0.840 57.280 451.360 ;
-      RECT 59.240 0.840 59.520 451.360 ;
-      RECT 61.480 0.840 61.760 451.360 ;
-      RECT 63.720 0.840 64.000 451.360 ;
-      RECT 65.960 0.840 66.240 451.360 ;
-      RECT 68.200 0.840 68.480 451.360 ;
-      RECT 70.440 0.840 70.720 451.360 ;
-      RECT 72.680 0.840 72.960 451.360 ;
-      RECT 74.920 0.840 75.200 451.360 ;
-      RECT 77.160 0.840 77.440 451.360 ;
-      RECT 79.400 0.840 79.680 451.360 ;
-      RECT 81.640 0.840 81.920 451.360 ;
-      RECT 83.880 0.840 84.160 451.360 ;
-      RECT 86.120 0.840 86.400 451.360 ;
-      RECT 88.360 0.840 88.640 451.360 ;
-      RECT 90.600 0.840 90.880 451.360 ;
-      RECT 92.840 0.840 93.120 451.360 ;
-      RECT 95.080 0.840 95.360 451.360 ;
-      RECT 97.320 0.840 97.600 451.360 ;
-      RECT 99.560 0.840 99.840 451.360 ;
-      RECT 101.800 0.840 102.080 451.360 ;
-      RECT 104.040 0.840 104.320 451.360 ;
-      RECT 106.280 0.840 106.560 451.360 ;
-      RECT 108.520 0.840 108.800 451.360 ;
-      RECT 110.760 0.840 111.040 451.360 ;
-      RECT 113.000 0.840 113.280 451.360 ;
-      RECT 115.240 0.840 115.520 451.360 ;
-      RECT 117.480 0.840 117.760 451.360 ;
-      RECT 119.720 0.840 120.000 451.360 ;
-      RECT 121.960 0.840 122.240 451.360 ;
-      RECT 124.200 0.840 124.480 451.360 ;
-      RECT 126.440 0.840 126.720 451.360 ;
-      RECT 128.680 0.840 128.960 451.360 ;
-      RECT 130.920 0.840 131.200 451.360 ;
-      RECT 133.160 0.840 133.440 451.360 ;
-      RECT 135.400 0.840 135.680 451.360 ;
-      RECT 137.640 0.840 137.920 451.360 ;
-      RECT 139.880 0.840 140.160 451.360 ;
-      RECT 142.120 0.840 142.400 451.360 ;
-      RECT 144.360 0.840 144.640 451.360 ;
-      RECT 146.600 0.840 146.880 451.360 ;
-      RECT 148.840 0.840 149.120 451.360 ;
-      RECT 151.080 0.840 151.360 451.360 ;
-      RECT 153.320 0.840 153.600 451.360 ;
-      RECT 155.560 0.840 155.840 451.360 ;
-      RECT 157.800 0.840 158.080 451.360 ;
-      RECT 160.040 0.840 160.320 451.360 ;
-      RECT 162.280 0.840 162.560 451.360 ;
-      RECT 164.520 0.840 164.800 451.360 ;
-      RECT 166.760 0.840 167.040 451.360 ;
-      RECT 169.000 0.840 169.280 451.360 ;
-      RECT 171.240 0.840 171.520 451.360 ;
-      RECT 173.480 0.840 173.760 451.360 ;
-      RECT 175.720 0.840 176.000 451.360 ;
-      RECT 177.960 0.840 178.240 451.360 ;
-      RECT 180.200 0.840 180.480 451.360 ;
-      RECT 182.440 0.840 182.720 451.360 ;
-      RECT 184.680 0.840 184.960 451.360 ;
-      RECT 186.920 0.840 187.200 451.360 ;
-      RECT 189.160 0.840 189.440 451.360 ;
-      RECT 191.400 0.840 191.680 451.360 ;
-      RECT 193.640 0.840 193.920 451.360 ;
-      RECT 195.880 0.840 196.160 451.360 ;
-      RECT 198.120 0.840 198.400 451.360 ;
-      RECT 200.360 0.840 200.640 451.360 ;
-      RECT 202.600 0.840 202.880 451.360 ;
-      RECT 204.840 0.840 205.120 451.360 ;
-      RECT 207.080 0.840 207.360 451.360 ;
-      RECT 209.320 0.840 209.600 451.360 ;
-      RECT 211.560 0.840 211.840 451.360 ;
-      RECT 213.800 0.840 214.080 451.360 ;
-      RECT 216.040 0.840 216.320 451.360 ;
-      RECT 218.280 0.840 218.560 451.360 ;
-      RECT 220.520 0.840 220.800 451.360 ;
-      RECT 222.760 0.840 223.040 451.360 ;
-      RECT 225.000 0.840 225.280 451.360 ;
-      RECT 227.240 0.840 227.520 451.360 ;
-      RECT 229.480 0.840 229.760 451.360 ;
-      RECT 231.720 0.840 232.000 451.360 ;
-      RECT 233.960 0.840 234.240 451.360 ;
-      RECT 236.200 0.840 236.480 451.360 ;
-      RECT 238.440 0.840 238.720 451.360 ;
-      RECT 240.680 0.840 240.960 451.360 ;
-      RECT 242.920 0.840 243.200 451.360 ;
-      RECT 245.160 0.840 245.440 451.360 ;
-      RECT 247.400 0.840 247.680 451.360 ;
-      RECT 249.640 0.840 249.920 451.360 ;
-      RECT 251.880 0.840 252.160 451.360 ;
-      RECT 254.120 0.840 254.400 451.360 ;
-      RECT 256.360 0.840 256.640 451.360 ;
-      RECT 258.600 0.840 258.880 451.360 ;
-      RECT 260.840 0.840 261.120 451.360 ;
-      RECT 263.080 0.840 263.360 451.360 ;
-      RECT 265.320 0.840 265.600 451.360 ;
-      RECT 267.560 0.840 267.840 451.360 ;
-      RECT 269.800 0.840 270.080 451.360 ;
-      RECT 272.040 0.840 272.320 451.360 ;
-      RECT 274.280 0.840 274.560 451.360 ;
-      RECT 276.520 0.840 276.800 451.360 ;
-      RECT 278.760 0.840 279.040 451.360 ;
-      RECT 281.000 0.840 281.280 451.360 ;
-      RECT 283.240 0.840 283.520 451.360 ;
-      RECT 285.480 0.840 285.760 451.360 ;
-      RECT 287.720 0.840 288.000 451.360 ;
-      RECT 289.960 0.840 290.240 451.360 ;
-      RECT 292.200 0.840 292.480 451.360 ;
-      RECT 294.440 0.840 294.720 451.360 ;
-      RECT 296.680 0.840 296.960 451.360 ;
-      RECT 298.920 0.840 299.200 451.360 ;
-      RECT 301.160 0.840 301.440 451.360 ;
-      RECT 303.400 0.840 303.680 451.360 ;
-      RECT 305.640 0.840 305.920 451.360 ;
-      RECT 307.880 0.840 308.160 451.360 ;
-      RECT 310.120 0.840 310.400 451.360 ;
-      RECT 312.360 0.840 312.640 451.360 ;
-      RECT 314.600 0.840 314.880 451.360 ;
-      RECT 316.840 0.840 317.120 451.360 ;
-      RECT 319.080 0.840 319.360 451.360 ;
-      RECT 321.320 0.840 321.600 451.360 ;
-      RECT 323.560 0.840 323.840 451.360 ;
-      RECT 325.800 0.840 326.080 451.360 ;
-      RECT 328.040 0.840 328.320 451.360 ;
-      RECT 330.280 0.840 330.560 451.360 ;
-      RECT 332.520 0.840 332.800 451.360 ;
-      RECT 334.760 0.840 335.040 451.360 ;
-      RECT 337.000 0.840 337.280 451.360 ;
-      RECT 339.240 0.840 339.520 451.360 ;
-      RECT 341.480 0.840 341.760 451.360 ;
-      RECT 343.720 0.840 344.000 451.360 ;
-      RECT 345.960 0.840 346.240 451.360 ;
-      RECT 348.200 0.840 348.480 451.360 ;
-      RECT 350.440 0.840 350.720 451.360 ;
-      RECT 352.680 0.840 352.960 451.360 ;
-      RECT 354.920 0.840 355.200 451.360 ;
-      RECT 357.160 0.840 357.440 451.360 ;
-      RECT 359.400 0.840 359.680 451.360 ;
-      RECT 361.640 0.840 361.920 451.360 ;
-      RECT 363.880 0.840 364.160 451.360 ;
-      RECT 366.120 0.840 366.400 451.360 ;
-      RECT 368.360 0.840 368.640 451.360 ;
-      RECT 370.600 0.840 370.880 451.360 ;
-      RECT 372.840 0.840 373.120 451.360 ;
-      RECT 375.080 0.840 375.360 451.360 ;
+      RECT 1.000 0.840 1.280 258.160 ;
+      RECT 3.240 0.840 3.520 258.160 ;
+      RECT 5.480 0.840 5.760 258.160 ;
+      RECT 7.720 0.840 8.000 258.160 ;
+      RECT 9.960 0.840 10.240 258.160 ;
+      RECT 12.200 0.840 12.480 258.160 ;
+      RECT 14.440 0.840 14.720 258.160 ;
+      RECT 16.680 0.840 16.960 258.160 ;
+      RECT 18.920 0.840 19.200 258.160 ;
+      RECT 21.160 0.840 21.440 258.160 ;
+      RECT 23.400 0.840 23.680 258.160 ;
+      RECT 25.640 0.840 25.920 258.160 ;
+      RECT 27.880 0.840 28.160 258.160 ;
+      RECT 30.120 0.840 30.400 258.160 ;
+      RECT 32.360 0.840 32.640 258.160 ;
+      RECT 34.600 0.840 34.880 258.160 ;
+      RECT 36.840 0.840 37.120 258.160 ;
+      RECT 39.080 0.840 39.360 258.160 ;
+      RECT 41.320 0.840 41.600 258.160 ;
+      RECT 43.560 0.840 43.840 258.160 ;
+      RECT 45.800 0.840 46.080 258.160 ;
+      RECT 48.040 0.840 48.320 258.160 ;
+      RECT 50.280 0.840 50.560 258.160 ;
+      RECT 52.520 0.840 52.800 258.160 ;
+      RECT 54.760 0.840 55.040 258.160 ;
+      RECT 57.000 0.840 57.280 258.160 ;
+      RECT 59.240 0.840 59.520 258.160 ;
+      RECT 61.480 0.840 61.760 258.160 ;
+      RECT 63.720 0.840 64.000 258.160 ;
+      RECT 65.960 0.840 66.240 258.160 ;
+      RECT 68.200 0.840 68.480 258.160 ;
+      RECT 70.440 0.840 70.720 258.160 ;
+      RECT 72.680 0.840 72.960 258.160 ;
+      RECT 74.920 0.840 75.200 258.160 ;
+      RECT 77.160 0.840 77.440 258.160 ;
+      RECT 79.400 0.840 79.680 258.160 ;
+      RECT 81.640 0.840 81.920 258.160 ;
+      RECT 83.880 0.840 84.160 258.160 ;
+      RECT 86.120 0.840 86.400 258.160 ;
+      RECT 88.360 0.840 88.640 258.160 ;
+      RECT 90.600 0.840 90.880 258.160 ;
+      RECT 92.840 0.840 93.120 258.160 ;
+      RECT 95.080 0.840 95.360 258.160 ;
+      RECT 97.320 0.840 97.600 258.160 ;
+      RECT 99.560 0.840 99.840 258.160 ;
+      RECT 101.800 0.840 102.080 258.160 ;
+      RECT 104.040 0.840 104.320 258.160 ;
+      RECT 106.280 0.840 106.560 258.160 ;
+      RECT 108.520 0.840 108.800 258.160 ;
+      RECT 110.760 0.840 111.040 258.160 ;
+      RECT 113.000 0.840 113.280 258.160 ;
+      RECT 115.240 0.840 115.520 258.160 ;
+      RECT 117.480 0.840 117.760 258.160 ;
+      RECT 119.720 0.840 120.000 258.160 ;
+      RECT 121.960 0.840 122.240 258.160 ;
+      RECT 124.200 0.840 124.480 258.160 ;
+      RECT 126.440 0.840 126.720 258.160 ;
+      RECT 128.680 0.840 128.960 258.160 ;
+      RECT 130.920 0.840 131.200 258.160 ;
+      RECT 133.160 0.840 133.440 258.160 ;
+      RECT 135.400 0.840 135.680 258.160 ;
+      RECT 137.640 0.840 137.920 258.160 ;
+      RECT 139.880 0.840 140.160 258.160 ;
+      RECT 142.120 0.840 142.400 258.160 ;
+      RECT 144.360 0.840 144.640 258.160 ;
+      RECT 146.600 0.840 146.880 258.160 ;
+      RECT 148.840 0.840 149.120 258.160 ;
+      RECT 151.080 0.840 151.360 258.160 ;
+      RECT 153.320 0.840 153.600 258.160 ;
+      RECT 155.560 0.840 155.840 258.160 ;
+      RECT 157.800 0.840 158.080 258.160 ;
+      RECT 160.040 0.840 160.320 258.160 ;
+      RECT 162.280 0.840 162.560 258.160 ;
+      RECT 164.520 0.840 164.800 258.160 ;
+      RECT 166.760 0.840 167.040 258.160 ;
+      RECT 169.000 0.840 169.280 258.160 ;
+      RECT 171.240 0.840 171.520 258.160 ;
+      RECT 173.480 0.840 173.760 258.160 ;
+      RECT 175.720 0.840 176.000 258.160 ;
+      RECT 177.960 0.840 178.240 258.160 ;
+      RECT 180.200 0.840 180.480 258.160 ;
+      RECT 182.440 0.840 182.720 258.160 ;
+      RECT 184.680 0.840 184.960 258.160 ;
+      RECT 186.920 0.840 187.200 258.160 ;
     END
   END VSS
   PIN VDD
@@ -3902,188 +3782,104 @@ MACRO fakeram45_1rw1r_130w512d
     USE POWER ;
     PORT
       LAYER metal4 ;
-      RECT 1.000 0.840 1.280 451.360 ;
-      RECT 3.240 0.840 3.520 451.360 ;
-      RECT 5.480 0.840 5.760 451.360 ;
-      RECT 7.720 0.840 8.000 451.360 ;
-      RECT 9.960 0.840 10.240 451.360 ;
-      RECT 12.200 0.840 12.480 451.360 ;
-      RECT 14.440 0.840 14.720 451.360 ;
-      RECT 16.680 0.840 16.960 451.360 ;
-      RECT 18.920 0.840 19.200 451.360 ;
-      RECT 21.160 0.840 21.440 451.360 ;
-      RECT 23.400 0.840 23.680 451.360 ;
-      RECT 25.640 0.840 25.920 451.360 ;
-      RECT 27.880 0.840 28.160 451.360 ;
-      RECT 30.120 0.840 30.400 451.360 ;
-      RECT 32.360 0.840 32.640 451.360 ;
-      RECT 34.600 0.840 34.880 451.360 ;
-      RECT 36.840 0.840 37.120 451.360 ;
-      RECT 39.080 0.840 39.360 451.360 ;
-      RECT 41.320 0.840 41.600 451.360 ;
-      RECT 43.560 0.840 43.840 451.360 ;
-      RECT 45.800 0.840 46.080 451.360 ;
-      RECT 48.040 0.840 48.320 451.360 ;
-      RECT 50.280 0.840 50.560 451.360 ;
-      RECT 52.520 0.840 52.800 451.360 ;
-      RECT 54.760 0.840 55.040 451.360 ;
-      RECT 57.000 0.840 57.280 451.360 ;
-      RECT 59.240 0.840 59.520 451.360 ;
-      RECT 61.480 0.840 61.760 451.360 ;
-      RECT 63.720 0.840 64.000 451.360 ;
-      RECT 65.960 0.840 66.240 451.360 ;
-      RECT 68.200 0.840 68.480 451.360 ;
-      RECT 70.440 0.840 70.720 451.360 ;
-      RECT 72.680 0.840 72.960 451.360 ;
-      RECT 74.920 0.840 75.200 451.360 ;
-      RECT 77.160 0.840 77.440 451.360 ;
-      RECT 79.400 0.840 79.680 451.360 ;
-      RECT 81.640 0.840 81.920 451.360 ;
-      RECT 83.880 0.840 84.160 451.360 ;
-      RECT 86.120 0.840 86.400 451.360 ;
-      RECT 88.360 0.840 88.640 451.360 ;
-      RECT 90.600 0.840 90.880 451.360 ;
-      RECT 92.840 0.840 93.120 451.360 ;
-      RECT 95.080 0.840 95.360 451.360 ;
-      RECT 97.320 0.840 97.600 451.360 ;
-      RECT 99.560 0.840 99.840 451.360 ;
-      RECT 101.800 0.840 102.080 451.360 ;
-      RECT 104.040 0.840 104.320 451.360 ;
-      RECT 106.280 0.840 106.560 451.360 ;
-      RECT 108.520 0.840 108.800 451.360 ;
-      RECT 110.760 0.840 111.040 451.360 ;
-      RECT 113.000 0.840 113.280 451.360 ;
-      RECT 115.240 0.840 115.520 451.360 ;
-      RECT 117.480 0.840 117.760 451.360 ;
-      RECT 119.720 0.840 120.000 451.360 ;
-      RECT 121.960 0.840 122.240 451.360 ;
-      RECT 124.200 0.840 124.480 451.360 ;
-      RECT 126.440 0.840 126.720 451.360 ;
-      RECT 128.680 0.840 128.960 451.360 ;
-      RECT 130.920 0.840 131.200 451.360 ;
-      RECT 133.160 0.840 133.440 451.360 ;
-      RECT 135.400 0.840 135.680 451.360 ;
-      RECT 137.640 0.840 137.920 451.360 ;
-      RECT 139.880 0.840 140.160 451.360 ;
-      RECT 142.120 0.840 142.400 451.360 ;
-      RECT 144.360 0.840 144.640 451.360 ;
-      RECT 146.600 0.840 146.880 451.360 ;
-      RECT 148.840 0.840 149.120 451.360 ;
-      RECT 151.080 0.840 151.360 451.360 ;
-      RECT 153.320 0.840 153.600 451.360 ;
-      RECT 155.560 0.840 155.840 451.360 ;
-      RECT 157.800 0.840 158.080 451.360 ;
-      RECT 160.040 0.840 160.320 451.360 ;
-      RECT 162.280 0.840 162.560 451.360 ;
-      RECT 164.520 0.840 164.800 451.360 ;
-      RECT 166.760 0.840 167.040 451.360 ;
-      RECT 169.000 0.840 169.280 451.360 ;
-      RECT 171.240 0.840 171.520 451.360 ;
-      RECT 173.480 0.840 173.760 451.360 ;
-      RECT 175.720 0.840 176.000 451.360 ;
-      RECT 177.960 0.840 178.240 451.360 ;
-      RECT 180.200 0.840 180.480 451.360 ;
-      RECT 182.440 0.840 182.720 451.360 ;
-      RECT 184.680 0.840 184.960 451.360 ;
-      RECT 186.920 0.840 187.200 451.360 ;
-      RECT 189.160 0.840 189.440 451.360 ;
-      RECT 191.400 0.840 191.680 451.360 ;
-      RECT 193.640 0.840 193.920 451.360 ;
-      RECT 195.880 0.840 196.160 451.360 ;
-      RECT 198.120 0.840 198.400 451.360 ;
-      RECT 200.360 0.840 200.640 451.360 ;
-      RECT 202.600 0.840 202.880 451.360 ;
-      RECT 204.840 0.840 205.120 451.360 ;
-      RECT 207.080 0.840 207.360 451.360 ;
-      RECT 209.320 0.840 209.600 451.360 ;
-      RECT 211.560 0.840 211.840 451.360 ;
-      RECT 213.800 0.840 214.080 451.360 ;
-      RECT 216.040 0.840 216.320 451.360 ;
-      RECT 218.280 0.840 218.560 451.360 ;
-      RECT 220.520 0.840 220.800 451.360 ;
-      RECT 222.760 0.840 223.040 451.360 ;
-      RECT 225.000 0.840 225.280 451.360 ;
-      RECT 227.240 0.840 227.520 451.360 ;
-      RECT 229.480 0.840 229.760 451.360 ;
-      RECT 231.720 0.840 232.000 451.360 ;
-      RECT 233.960 0.840 234.240 451.360 ;
-      RECT 236.200 0.840 236.480 451.360 ;
-      RECT 238.440 0.840 238.720 451.360 ;
-      RECT 240.680 0.840 240.960 451.360 ;
-      RECT 242.920 0.840 243.200 451.360 ;
-      RECT 245.160 0.840 245.440 451.360 ;
-      RECT 247.400 0.840 247.680 451.360 ;
-      RECT 249.640 0.840 249.920 451.360 ;
-      RECT 251.880 0.840 252.160 451.360 ;
-      RECT 254.120 0.840 254.400 451.360 ;
-      RECT 256.360 0.840 256.640 451.360 ;
-      RECT 258.600 0.840 258.880 451.360 ;
-      RECT 260.840 0.840 261.120 451.360 ;
-      RECT 263.080 0.840 263.360 451.360 ;
-      RECT 265.320 0.840 265.600 451.360 ;
-      RECT 267.560 0.840 267.840 451.360 ;
-      RECT 269.800 0.840 270.080 451.360 ;
-      RECT 272.040 0.840 272.320 451.360 ;
-      RECT 274.280 0.840 274.560 451.360 ;
-      RECT 276.520 0.840 276.800 451.360 ;
-      RECT 278.760 0.840 279.040 451.360 ;
-      RECT 281.000 0.840 281.280 451.360 ;
-      RECT 283.240 0.840 283.520 451.360 ;
-      RECT 285.480 0.840 285.760 451.360 ;
-      RECT 287.720 0.840 288.000 451.360 ;
-      RECT 289.960 0.840 290.240 451.360 ;
-      RECT 292.200 0.840 292.480 451.360 ;
-      RECT 294.440 0.840 294.720 451.360 ;
-      RECT 296.680 0.840 296.960 451.360 ;
-      RECT 298.920 0.840 299.200 451.360 ;
-      RECT 301.160 0.840 301.440 451.360 ;
-      RECT 303.400 0.840 303.680 451.360 ;
-      RECT 305.640 0.840 305.920 451.360 ;
-      RECT 307.880 0.840 308.160 451.360 ;
-      RECT 310.120 0.840 310.400 451.360 ;
-      RECT 312.360 0.840 312.640 451.360 ;
-      RECT 314.600 0.840 314.880 451.360 ;
-      RECT 316.840 0.840 317.120 451.360 ;
-      RECT 319.080 0.840 319.360 451.360 ;
-      RECT 321.320 0.840 321.600 451.360 ;
-      RECT 323.560 0.840 323.840 451.360 ;
-      RECT 325.800 0.840 326.080 451.360 ;
-      RECT 328.040 0.840 328.320 451.360 ;
-      RECT 330.280 0.840 330.560 451.360 ;
-      RECT 332.520 0.840 332.800 451.360 ;
-      RECT 334.760 0.840 335.040 451.360 ;
-      RECT 337.000 0.840 337.280 451.360 ;
-      RECT 339.240 0.840 339.520 451.360 ;
-      RECT 341.480 0.840 341.760 451.360 ;
-      RECT 343.720 0.840 344.000 451.360 ;
-      RECT 345.960 0.840 346.240 451.360 ;
-      RECT 348.200 0.840 348.480 451.360 ;
-      RECT 350.440 0.840 350.720 451.360 ;
-      RECT 352.680 0.840 352.960 451.360 ;
-      RECT 354.920 0.840 355.200 451.360 ;
-      RECT 357.160 0.840 357.440 451.360 ;
-      RECT 359.400 0.840 359.680 451.360 ;
-      RECT 361.640 0.840 361.920 451.360 ;
-      RECT 363.880 0.840 364.160 451.360 ;
-      RECT 366.120 0.840 366.400 451.360 ;
-      RECT 368.360 0.840 368.640 451.360 ;
-      RECT 370.600 0.840 370.880 451.360 ;
-      RECT 372.840 0.840 373.120 451.360 ;
-      RECT 375.080 0.840 375.360 451.360 ;
+      RECT 1.000 0.840 1.280 258.160 ;
+      RECT 3.240 0.840 3.520 258.160 ;
+      RECT 5.480 0.840 5.760 258.160 ;
+      RECT 7.720 0.840 8.000 258.160 ;
+      RECT 9.960 0.840 10.240 258.160 ;
+      RECT 12.200 0.840 12.480 258.160 ;
+      RECT 14.440 0.840 14.720 258.160 ;
+      RECT 16.680 0.840 16.960 258.160 ;
+      RECT 18.920 0.840 19.200 258.160 ;
+      RECT 21.160 0.840 21.440 258.160 ;
+      RECT 23.400 0.840 23.680 258.160 ;
+      RECT 25.640 0.840 25.920 258.160 ;
+      RECT 27.880 0.840 28.160 258.160 ;
+      RECT 30.120 0.840 30.400 258.160 ;
+      RECT 32.360 0.840 32.640 258.160 ;
+      RECT 34.600 0.840 34.880 258.160 ;
+      RECT 36.840 0.840 37.120 258.160 ;
+      RECT 39.080 0.840 39.360 258.160 ;
+      RECT 41.320 0.840 41.600 258.160 ;
+      RECT 43.560 0.840 43.840 258.160 ;
+      RECT 45.800 0.840 46.080 258.160 ;
+      RECT 48.040 0.840 48.320 258.160 ;
+      RECT 50.280 0.840 50.560 258.160 ;
+      RECT 52.520 0.840 52.800 258.160 ;
+      RECT 54.760 0.840 55.040 258.160 ;
+      RECT 57.000 0.840 57.280 258.160 ;
+      RECT 59.240 0.840 59.520 258.160 ;
+      RECT 61.480 0.840 61.760 258.160 ;
+      RECT 63.720 0.840 64.000 258.160 ;
+      RECT 65.960 0.840 66.240 258.160 ;
+      RECT 68.200 0.840 68.480 258.160 ;
+      RECT 70.440 0.840 70.720 258.160 ;
+      RECT 72.680 0.840 72.960 258.160 ;
+      RECT 74.920 0.840 75.200 258.160 ;
+      RECT 77.160 0.840 77.440 258.160 ;
+      RECT 79.400 0.840 79.680 258.160 ;
+      RECT 81.640 0.840 81.920 258.160 ;
+      RECT 83.880 0.840 84.160 258.160 ;
+      RECT 86.120 0.840 86.400 258.160 ;
+      RECT 88.360 0.840 88.640 258.160 ;
+      RECT 90.600 0.840 90.880 258.160 ;
+      RECT 92.840 0.840 93.120 258.160 ;
+      RECT 95.080 0.840 95.360 258.160 ;
+      RECT 97.320 0.840 97.600 258.160 ;
+      RECT 99.560 0.840 99.840 258.160 ;
+      RECT 101.800 0.840 102.080 258.160 ;
+      RECT 104.040 0.840 104.320 258.160 ;
+      RECT 106.280 0.840 106.560 258.160 ;
+      RECT 108.520 0.840 108.800 258.160 ;
+      RECT 110.760 0.840 111.040 258.160 ;
+      RECT 113.000 0.840 113.280 258.160 ;
+      RECT 115.240 0.840 115.520 258.160 ;
+      RECT 117.480 0.840 117.760 258.160 ;
+      RECT 119.720 0.840 120.000 258.160 ;
+      RECT 121.960 0.840 122.240 258.160 ;
+      RECT 124.200 0.840 124.480 258.160 ;
+      RECT 126.440 0.840 126.720 258.160 ;
+      RECT 128.680 0.840 128.960 258.160 ;
+      RECT 130.920 0.840 131.200 258.160 ;
+      RECT 133.160 0.840 133.440 258.160 ;
+      RECT 135.400 0.840 135.680 258.160 ;
+      RECT 137.640 0.840 137.920 258.160 ;
+      RECT 139.880 0.840 140.160 258.160 ;
+      RECT 142.120 0.840 142.400 258.160 ;
+      RECT 144.360 0.840 144.640 258.160 ;
+      RECT 146.600 0.840 146.880 258.160 ;
+      RECT 148.840 0.840 149.120 258.160 ;
+      RECT 151.080 0.840 151.360 258.160 ;
+      RECT 153.320 0.840 153.600 258.160 ;
+      RECT 155.560 0.840 155.840 258.160 ;
+      RECT 157.800 0.840 158.080 258.160 ;
+      RECT 160.040 0.840 160.320 258.160 ;
+      RECT 162.280 0.840 162.560 258.160 ;
+      RECT 164.520 0.840 164.800 258.160 ;
+      RECT 166.760 0.840 167.040 258.160 ;
+      RECT 169.000 0.840 169.280 258.160 ;
+      RECT 171.240 0.840 171.520 258.160 ;
+      RECT 173.480 0.840 173.760 258.160 ;
+      RECT 175.720 0.840 176.000 258.160 ;
+      RECT 177.960 0.840 178.240 258.160 ;
+      RECT 180.200 0.840 180.480 258.160 ;
+      RECT 182.440 0.840 182.720 258.160 ;
+      RECT 184.680 0.840 184.960 258.160 ;
+      RECT 186.920 0.840 187.200 258.160 ;
     END
   END VDD
   OBS
     LAYER metal1 ;
-    RECT 0 0 376.960 452.200 ;
+    RECT 0 0 188.290 259.000 ;
     LAYER metal2 ;
-    RECT 0 0 376.960 452.200 ;
+    RECT 0 0 188.290 259.000 ;
     LAYER metal3 ;
-    RECT 0 0 376.960 452.200 ;
+    RECT 0 0 188.290 259.000 ;
     LAYER metal4 ;
-    RECT 0 0 376.960 452.200 ;
+    RECT 0 0 188.290 259.000 ;
     LAYER OVERLAP ;
-    RECT 0 0 376.960 452.200 ;
+    RECT 0 0 188.290 259.000 ;
   END
-END fakeram45_1rw1r_130w512d
+END fakeram_1rw1r_130w128d_sram
 
 END LIBRARY

--- a/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_130w512d_sram.lef
+++ b/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_130w512d_sram.lef
@@ -1,9 +1,9 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram45_1rw1r_130w128d
-  FOREIGN fakeram45_1rw1r_130w128d 0 0 ;
+MACRO fakeram_1rw1r_130w512d_sram
+  FOREIGN fakeram_1rw1r_130w512d_sram 0 0 ;
   SYMMETRY X Y R90 ;
-  SIZE 188.290 BY 259.000 ;
+  SIZE 376.960 BY 452.200 ;
   CLASS BLOCK ;
   PIN rw0_wd_in[0]
     DIRECTION INPUT ;
@@ -20,7 +20,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 7.105 0.210 7.175 ;
+      RECT 0.000 11.445 0.210 11.515 ;
     END
   END rw0_wd_in[1]
   PIN rw0_wd_in[2]
@@ -29,7 +29,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 13.405 0.210 13.475 ;
+      RECT 0.000 22.085 0.210 22.155 ;
     END
   END rw0_wd_in[2]
   PIN rw0_wd_in[3]
@@ -38,7 +38,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 19.705 0.210 19.775 ;
+      RECT 0.000 32.725 0.210 32.795 ;
     END
   END rw0_wd_in[3]
   PIN rw0_wd_in[4]
@@ -47,7 +47,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 26.005 0.210 26.075 ;
+      RECT 0.000 43.365 0.210 43.435 ;
     END
   END rw0_wd_in[4]
   PIN rw0_wd_in[5]
@@ -56,7 +56,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 32.305 0.210 32.375 ;
+      RECT 0.000 54.005 0.210 54.075 ;
     END
   END rw0_wd_in[5]
   PIN rw0_wd_in[6]
@@ -65,7 +65,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 38.605 0.210 38.675 ;
+      RECT 0.000 64.645 0.210 64.715 ;
     END
   END rw0_wd_in[6]
   PIN rw0_wd_in[7]
@@ -74,7 +74,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 44.905 0.210 44.975 ;
+      RECT 0.000 75.285 0.210 75.355 ;
     END
   END rw0_wd_in[7]
   PIN rw0_wd_in[8]
@@ -83,7 +83,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 51.205 0.210 51.275 ;
+      RECT 0.000 85.925 0.210 85.995 ;
     END
   END rw0_wd_in[8]
   PIN rw0_wd_in[9]
@@ -92,7 +92,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 57.505 0.210 57.575 ;
+      RECT 0.000 96.565 0.210 96.635 ;
     END
   END rw0_wd_in[9]
   PIN rw0_wd_in[10]
@@ -101,7 +101,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 63.805 0.210 63.875 ;
+      RECT 0.000 107.205 0.210 107.275 ;
     END
   END rw0_wd_in[10]
   PIN rw0_wd_in[11]
@@ -110,7 +110,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 70.105 0.210 70.175 ;
+      RECT 0.000 117.845 0.210 117.915 ;
     END
   END rw0_wd_in[11]
   PIN rw0_wd_in[12]
@@ -119,7 +119,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 76.405 0.210 76.475 ;
+      RECT 0.000 128.485 0.210 128.555 ;
     END
   END rw0_wd_in[12]
   PIN rw0_wd_in[13]
@@ -128,7 +128,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 82.705 0.210 82.775 ;
+      RECT 0.000 139.125 0.210 139.195 ;
     END
   END rw0_wd_in[13]
   PIN rw0_wd_in[14]
@@ -137,7 +137,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 89.005 0.210 89.075 ;
+      RECT 0.000 149.765 0.210 149.835 ;
     END
   END rw0_wd_in[14]
   PIN rw0_wd_in[15]
@@ -146,7 +146,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 95.305 0.210 95.375 ;
+      RECT 0.000 160.405 0.210 160.475 ;
     END
   END rw0_wd_in[15]
   PIN rw0_wd_in[16]
@@ -155,7 +155,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 101.605 0.210 101.675 ;
+      RECT 0.000 171.045 0.210 171.115 ;
     END
   END rw0_wd_in[16]
   PIN rw0_wd_in[17]
@@ -164,7 +164,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 107.905 0.210 107.975 ;
+      RECT 0.000 181.685 0.210 181.755 ;
     END
   END rw0_wd_in[17]
   PIN rw0_wd_in[18]
@@ -173,7 +173,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 114.205 0.210 114.275 ;
+      RECT 0.000 192.325 0.210 192.395 ;
     END
   END rw0_wd_in[18]
   PIN rw0_wd_in[19]
@@ -182,7 +182,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 120.505 0.210 120.575 ;
+      RECT 0.000 202.965 0.210 203.035 ;
     END
   END rw0_wd_in[19]
   PIN rw0_wd_in[20]
@@ -191,7 +191,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 126.805 0.210 126.875 ;
+      RECT 0.000 213.605 0.210 213.675 ;
     END
   END rw0_wd_in[20]
   PIN rw0_wd_in[21]
@@ -200,7 +200,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 133.105 0.210 133.175 ;
+      RECT 0.000 224.245 0.210 224.315 ;
     END
   END rw0_wd_in[21]
   PIN rw0_wd_in[22]
@@ -209,7 +209,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 139.405 0.210 139.475 ;
+      RECT 0.000 234.885 0.210 234.955 ;
     END
   END rw0_wd_in[22]
   PIN rw0_wd_in[23]
@@ -218,7 +218,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 145.705 0.210 145.775 ;
+      RECT 0.000 245.525 0.210 245.595 ;
     END
   END rw0_wd_in[23]
   PIN rw0_wd_in[24]
@@ -227,7 +227,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 152.005 0.210 152.075 ;
+      RECT 0.000 256.165 0.210 256.235 ;
     END
   END rw0_wd_in[24]
   PIN rw0_wd_in[25]
@@ -236,7 +236,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 158.305 0.210 158.375 ;
+      RECT 0.000 266.805 0.210 266.875 ;
     END
   END rw0_wd_in[25]
   PIN rw0_wd_in[26]
@@ -245,7 +245,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 164.605 0.210 164.675 ;
+      RECT 0.000 277.445 0.210 277.515 ;
     END
   END rw0_wd_in[26]
   PIN rw0_wd_in[27]
@@ -254,7 +254,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 170.905 0.210 170.975 ;
+      RECT 0.000 288.085 0.210 288.155 ;
     END
   END rw0_wd_in[27]
   PIN rw0_wd_in[28]
@@ -263,7 +263,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 177.205 0.210 177.275 ;
+      RECT 0.000 298.725 0.210 298.795 ;
     END
   END rw0_wd_in[28]
   PIN rw0_wd_in[29]
@@ -272,7 +272,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 183.505 0.210 183.575 ;
+      RECT 0.000 309.365 0.210 309.435 ;
     END
   END rw0_wd_in[29]
   PIN rw0_wd_in[30]
@@ -281,7 +281,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 189.805 0.210 189.875 ;
+      RECT 0.000 320.005 0.210 320.075 ;
     END
   END rw0_wd_in[30]
   PIN rw0_wd_in[31]
@@ -290,7 +290,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 196.105 0.210 196.175 ;
+      RECT 0.000 330.645 0.210 330.715 ;
     END
   END rw0_wd_in[31]
   PIN rw0_wd_in[32]
@@ -299,7 +299,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 202.405 0.210 202.475 ;
+      RECT 0.000 341.285 0.210 341.355 ;
     END
   END rw0_wd_in[32]
   PIN rw0_wd_in[33]
@@ -308,7 +308,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 0.805 188.290 0.875 ;
+      RECT 376.750 0.805 376.960 0.875 ;
     END
   END rw0_wd_in[33]
   PIN rw0_wd_in[34]
@@ -317,7 +317,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 7.105 188.290 7.175 ;
+      RECT 376.750 11.445 376.960 11.515 ;
     END
   END rw0_wd_in[34]
   PIN rw0_wd_in[35]
@@ -326,7 +326,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 13.405 188.290 13.475 ;
+      RECT 376.750 22.085 376.960 22.155 ;
     END
   END rw0_wd_in[35]
   PIN rw0_wd_in[36]
@@ -335,7 +335,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 19.705 188.290 19.775 ;
+      RECT 376.750 32.725 376.960 32.795 ;
     END
   END rw0_wd_in[36]
   PIN rw0_wd_in[37]
@@ -344,7 +344,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 26.005 188.290 26.075 ;
+      RECT 376.750 43.365 376.960 43.435 ;
     END
   END rw0_wd_in[37]
   PIN rw0_wd_in[38]
@@ -353,7 +353,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 32.305 188.290 32.375 ;
+      RECT 376.750 54.005 376.960 54.075 ;
     END
   END rw0_wd_in[38]
   PIN rw0_wd_in[39]
@@ -362,7 +362,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 38.605 188.290 38.675 ;
+      RECT 376.750 64.645 376.960 64.715 ;
     END
   END rw0_wd_in[39]
   PIN rw0_wd_in[40]
@@ -371,7 +371,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 44.905 188.290 44.975 ;
+      RECT 376.750 75.285 376.960 75.355 ;
     END
   END rw0_wd_in[40]
   PIN rw0_wd_in[41]
@@ -380,7 +380,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 51.205 188.290 51.275 ;
+      RECT 376.750 85.925 376.960 85.995 ;
     END
   END rw0_wd_in[41]
   PIN rw0_wd_in[42]
@@ -389,7 +389,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 57.505 188.290 57.575 ;
+      RECT 376.750 96.565 376.960 96.635 ;
     END
   END rw0_wd_in[42]
   PIN rw0_wd_in[43]
@@ -398,7 +398,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 63.805 188.290 63.875 ;
+      RECT 376.750 107.205 376.960 107.275 ;
     END
   END rw0_wd_in[43]
   PIN rw0_wd_in[44]
@@ -407,7 +407,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 70.105 188.290 70.175 ;
+      RECT 376.750 117.845 376.960 117.915 ;
     END
   END rw0_wd_in[44]
   PIN rw0_wd_in[45]
@@ -416,7 +416,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 76.405 188.290 76.475 ;
+      RECT 376.750 128.485 376.960 128.555 ;
     END
   END rw0_wd_in[45]
   PIN rw0_wd_in[46]
@@ -425,7 +425,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 82.705 188.290 82.775 ;
+      RECT 376.750 139.125 376.960 139.195 ;
     END
   END rw0_wd_in[46]
   PIN rw0_wd_in[47]
@@ -434,7 +434,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 89.005 188.290 89.075 ;
+      RECT 376.750 149.765 376.960 149.835 ;
     END
   END rw0_wd_in[47]
   PIN rw0_wd_in[48]
@@ -443,7 +443,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 95.305 188.290 95.375 ;
+      RECT 376.750 160.405 376.960 160.475 ;
     END
   END rw0_wd_in[48]
   PIN rw0_wd_in[49]
@@ -452,7 +452,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 101.605 188.290 101.675 ;
+      RECT 376.750 171.045 376.960 171.115 ;
     END
   END rw0_wd_in[49]
   PIN rw0_wd_in[50]
@@ -461,7 +461,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 107.905 188.290 107.975 ;
+      RECT 376.750 181.685 376.960 181.755 ;
     END
   END rw0_wd_in[50]
   PIN rw0_wd_in[51]
@@ -470,7 +470,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 114.205 188.290 114.275 ;
+      RECT 376.750 192.325 376.960 192.395 ;
     END
   END rw0_wd_in[51]
   PIN rw0_wd_in[52]
@@ -479,7 +479,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 120.505 188.290 120.575 ;
+      RECT 376.750 202.965 376.960 203.035 ;
     END
   END rw0_wd_in[52]
   PIN rw0_wd_in[53]
@@ -488,7 +488,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 126.805 188.290 126.875 ;
+      RECT 376.750 213.605 376.960 213.675 ;
     END
   END rw0_wd_in[53]
   PIN rw0_wd_in[54]
@@ -497,7 +497,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 133.105 188.290 133.175 ;
+      RECT 376.750 224.245 376.960 224.315 ;
     END
   END rw0_wd_in[54]
   PIN rw0_wd_in[55]
@@ -506,7 +506,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 139.405 188.290 139.475 ;
+      RECT 376.750 234.885 376.960 234.955 ;
     END
   END rw0_wd_in[55]
   PIN rw0_wd_in[56]
@@ -515,7 +515,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 145.705 188.290 145.775 ;
+      RECT 376.750 245.525 376.960 245.595 ;
     END
   END rw0_wd_in[56]
   PIN rw0_wd_in[57]
@@ -524,7 +524,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 152.005 188.290 152.075 ;
+      RECT 376.750 256.165 376.960 256.235 ;
     END
   END rw0_wd_in[57]
   PIN rw0_wd_in[58]
@@ -533,7 +533,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 158.305 188.290 158.375 ;
+      RECT 376.750 266.805 376.960 266.875 ;
     END
   END rw0_wd_in[58]
   PIN rw0_wd_in[59]
@@ -542,7 +542,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 164.605 188.290 164.675 ;
+      RECT 376.750 277.445 376.960 277.515 ;
     END
   END rw0_wd_in[59]
   PIN rw0_wd_in[60]
@@ -551,7 +551,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 170.905 188.290 170.975 ;
+      RECT 376.750 288.085 376.960 288.155 ;
     END
   END rw0_wd_in[60]
   PIN rw0_wd_in[61]
@@ -560,7 +560,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 177.205 188.290 177.275 ;
+      RECT 376.750 298.725 376.960 298.795 ;
     END
   END rw0_wd_in[61]
   PIN rw0_wd_in[62]
@@ -569,7 +569,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 183.505 188.290 183.575 ;
+      RECT 376.750 309.365 376.960 309.435 ;
     END
   END rw0_wd_in[62]
   PIN rw0_wd_in[63]
@@ -578,7 +578,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 189.805 188.290 189.875 ;
+      RECT 376.750 320.005 376.960 320.075 ;
     END
   END rw0_wd_in[63]
   PIN rw0_wd_in[64]
@@ -587,7 +587,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 196.105 188.290 196.175 ;
+      RECT 376.750 330.645 376.960 330.715 ;
     END
   END rw0_wd_in[64]
   PIN rw0_wd_in[65]
@@ -605,7 +605,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 2.055 0.000 2.125 0.210 ;
+      RECT 3.005 0.000 3.075 0.210 ;
     END
   END rw0_wd_in[66]
   PIN rw0_wd_in[67]
@@ -614,7 +614,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 3.005 0.000 3.075 0.210 ;
+      RECT 4.905 0.000 4.975 0.210 ;
     END
   END rw0_wd_in[67]
   PIN rw0_wd_in[68]
@@ -623,7 +623,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 3.955 0.000 4.025 0.210 ;
+      RECT 6.805 0.000 6.875 0.210 ;
     END
   END rw0_wd_in[68]
   PIN rw0_wd_in[69]
@@ -632,7 +632,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 4.905 0.000 4.975 0.210 ;
+      RECT 8.705 0.000 8.775 0.210 ;
     END
   END rw0_wd_in[69]
   PIN rw0_wd_in[70]
@@ -641,7 +641,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 5.855 0.000 5.925 0.210 ;
+      RECT 10.605 0.000 10.675 0.210 ;
     END
   END rw0_wd_in[70]
   PIN rw0_wd_in[71]
@@ -650,7 +650,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 6.805 0.000 6.875 0.210 ;
+      RECT 12.505 0.000 12.575 0.210 ;
     END
   END rw0_wd_in[71]
   PIN rw0_wd_in[72]
@@ -659,7 +659,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 7.755 0.000 7.825 0.210 ;
+      RECT 14.405 0.000 14.475 0.210 ;
     END
   END rw0_wd_in[72]
   PIN rw0_wd_in[73]
@@ -668,7 +668,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 8.705 0.000 8.775 0.210 ;
+      RECT 16.305 0.000 16.375 0.210 ;
     END
   END rw0_wd_in[73]
   PIN rw0_wd_in[74]
@@ -677,7 +677,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 9.655 0.000 9.725 0.210 ;
+      RECT 18.205 0.000 18.275 0.210 ;
     END
   END rw0_wd_in[74]
   PIN rw0_wd_in[75]
@@ -686,7 +686,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 10.605 0.000 10.675 0.210 ;
+      RECT 20.105 0.000 20.175 0.210 ;
     END
   END rw0_wd_in[75]
   PIN rw0_wd_in[76]
@@ -695,7 +695,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 11.555 0.000 11.625 0.210 ;
+      RECT 22.005 0.000 22.075 0.210 ;
     END
   END rw0_wd_in[76]
   PIN rw0_wd_in[77]
@@ -704,7 +704,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 12.505 0.000 12.575 0.210 ;
+      RECT 23.905 0.000 23.975 0.210 ;
     END
   END rw0_wd_in[77]
   PIN rw0_wd_in[78]
@@ -713,7 +713,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 13.455 0.000 13.525 0.210 ;
+      RECT 25.805 0.000 25.875 0.210 ;
     END
   END rw0_wd_in[78]
   PIN rw0_wd_in[79]
@@ -722,7 +722,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 14.405 0.000 14.475 0.210 ;
+      RECT 27.705 0.000 27.775 0.210 ;
     END
   END rw0_wd_in[79]
   PIN rw0_wd_in[80]
@@ -731,7 +731,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 15.355 0.000 15.425 0.210 ;
+      RECT 29.605 0.000 29.675 0.210 ;
     END
   END rw0_wd_in[80]
   PIN rw0_wd_in[81]
@@ -740,7 +740,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 16.305 0.000 16.375 0.210 ;
+      RECT 31.505 0.000 31.575 0.210 ;
     END
   END rw0_wd_in[81]
   PIN rw0_wd_in[82]
@@ -749,7 +749,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 17.255 0.000 17.325 0.210 ;
+      RECT 33.405 0.000 33.475 0.210 ;
     END
   END rw0_wd_in[82]
   PIN rw0_wd_in[83]
@@ -758,7 +758,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 18.205 0.000 18.275 0.210 ;
+      RECT 35.305 0.000 35.375 0.210 ;
     END
   END rw0_wd_in[83]
   PIN rw0_wd_in[84]
@@ -767,7 +767,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 19.155 0.000 19.225 0.210 ;
+      RECT 37.205 0.000 37.275 0.210 ;
     END
   END rw0_wd_in[84]
   PIN rw0_wd_in[85]
@@ -776,7 +776,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 20.105 0.000 20.175 0.210 ;
+      RECT 39.105 0.000 39.175 0.210 ;
     END
   END rw0_wd_in[85]
   PIN rw0_wd_in[86]
@@ -785,7 +785,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 21.055 0.000 21.125 0.210 ;
+      RECT 41.005 0.000 41.075 0.210 ;
     END
   END rw0_wd_in[86]
   PIN rw0_wd_in[87]
@@ -794,7 +794,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 22.005 0.000 22.075 0.210 ;
+      RECT 42.905 0.000 42.975 0.210 ;
     END
   END rw0_wd_in[87]
   PIN rw0_wd_in[88]
@@ -803,7 +803,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 22.955 0.000 23.025 0.210 ;
+      RECT 44.805 0.000 44.875 0.210 ;
     END
   END rw0_wd_in[88]
   PIN rw0_wd_in[89]
@@ -812,7 +812,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 23.905 0.000 23.975 0.210 ;
+      RECT 46.705 0.000 46.775 0.210 ;
     END
   END rw0_wd_in[89]
   PIN rw0_wd_in[90]
@@ -821,7 +821,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 24.855 0.000 24.925 0.210 ;
+      RECT 48.605 0.000 48.675 0.210 ;
     END
   END rw0_wd_in[90]
   PIN rw0_wd_in[91]
@@ -830,7 +830,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 25.805 0.000 25.875 0.210 ;
+      RECT 50.505 0.000 50.575 0.210 ;
     END
   END rw0_wd_in[91]
   PIN rw0_wd_in[92]
@@ -839,7 +839,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 26.755 0.000 26.825 0.210 ;
+      RECT 52.405 0.000 52.475 0.210 ;
     END
   END rw0_wd_in[92]
   PIN rw0_wd_in[93]
@@ -848,7 +848,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 27.705 0.000 27.775 0.210 ;
+      RECT 54.305 0.000 54.375 0.210 ;
     END
   END rw0_wd_in[93]
   PIN rw0_wd_in[94]
@@ -857,7 +857,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 28.655 0.000 28.725 0.210 ;
+      RECT 56.205 0.000 56.275 0.210 ;
     END
   END rw0_wd_in[94]
   PIN rw0_wd_in[95]
@@ -866,7 +866,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 29.605 0.000 29.675 0.210 ;
+      RECT 58.105 0.000 58.175 0.210 ;
     END
   END rw0_wd_in[95]
   PIN rw0_wd_in[96]
@@ -875,7 +875,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 30.555 0.000 30.625 0.210 ;
+      RECT 60.005 0.000 60.075 0.210 ;
     END
   END rw0_wd_in[96]
   PIN rw0_wd_in[97]
@@ -884,7 +884,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 31.505 0.000 31.575 0.210 ;
+      RECT 61.905 0.000 61.975 0.210 ;
     END
   END rw0_wd_in[97]
   PIN rw0_wd_in[98]
@@ -893,7 +893,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 32.455 0.000 32.525 0.210 ;
+      RECT 63.805 0.000 63.875 0.210 ;
     END
   END rw0_wd_in[98]
   PIN rw0_wd_in[99]
@@ -902,7 +902,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 33.405 0.000 33.475 0.210 ;
+      RECT 65.705 0.000 65.775 0.210 ;
     END
   END rw0_wd_in[99]
   PIN rw0_wd_in[100]
@@ -911,7 +911,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 34.355 0.000 34.425 0.210 ;
+      RECT 67.605 0.000 67.675 0.210 ;
     END
   END rw0_wd_in[100]
   PIN rw0_wd_in[101]
@@ -920,7 +920,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 35.305 0.000 35.375 0.210 ;
+      RECT 69.505 0.000 69.575 0.210 ;
     END
   END rw0_wd_in[101]
   PIN rw0_wd_in[102]
@@ -929,7 +929,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 36.255 0.000 36.325 0.210 ;
+      RECT 71.405 0.000 71.475 0.210 ;
     END
   END rw0_wd_in[102]
   PIN rw0_wd_in[103]
@@ -938,7 +938,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 37.205 0.000 37.275 0.210 ;
+      RECT 73.305 0.000 73.375 0.210 ;
     END
   END rw0_wd_in[103]
   PIN rw0_wd_in[104]
@@ -947,7 +947,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 38.155 0.000 38.225 0.210 ;
+      RECT 75.205 0.000 75.275 0.210 ;
     END
   END rw0_wd_in[104]
   PIN rw0_wd_in[105]
@@ -956,7 +956,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 39.105 0.000 39.175 0.210 ;
+      RECT 77.105 0.000 77.175 0.210 ;
     END
   END rw0_wd_in[105]
   PIN rw0_wd_in[106]
@@ -965,7 +965,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 40.055 0.000 40.125 0.210 ;
+      RECT 79.005 0.000 79.075 0.210 ;
     END
   END rw0_wd_in[106]
   PIN rw0_wd_in[107]
@@ -974,7 +974,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 41.005 0.000 41.075 0.210 ;
+      RECT 80.905 0.000 80.975 0.210 ;
     END
   END rw0_wd_in[107]
   PIN rw0_wd_in[108]
@@ -983,7 +983,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 41.955 0.000 42.025 0.210 ;
+      RECT 82.805 0.000 82.875 0.210 ;
     END
   END rw0_wd_in[108]
   PIN rw0_wd_in[109]
@@ -992,7 +992,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 42.905 0.000 42.975 0.210 ;
+      RECT 84.705 0.000 84.775 0.210 ;
     END
   END rw0_wd_in[109]
   PIN rw0_wd_in[110]
@@ -1001,7 +1001,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 43.855 0.000 43.925 0.210 ;
+      RECT 86.605 0.000 86.675 0.210 ;
     END
   END rw0_wd_in[110]
   PIN rw0_wd_in[111]
@@ -1010,7 +1010,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 44.805 0.000 44.875 0.210 ;
+      RECT 88.505 0.000 88.575 0.210 ;
     END
   END rw0_wd_in[111]
   PIN rw0_wd_in[112]
@@ -1019,7 +1019,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 45.755 0.000 45.825 0.210 ;
+      RECT 90.405 0.000 90.475 0.210 ;
     END
   END rw0_wd_in[112]
   PIN rw0_wd_in[113]
@@ -1028,7 +1028,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 46.705 0.000 46.775 0.210 ;
+      RECT 92.305 0.000 92.375 0.210 ;
     END
   END rw0_wd_in[113]
   PIN rw0_wd_in[114]
@@ -1037,7 +1037,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 47.655 0.000 47.725 0.210 ;
+      RECT 94.205 0.000 94.275 0.210 ;
     END
   END rw0_wd_in[114]
   PIN rw0_wd_in[115]
@@ -1046,7 +1046,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 48.605 0.000 48.675 0.210 ;
+      RECT 96.105 0.000 96.175 0.210 ;
     END
   END rw0_wd_in[115]
   PIN rw0_wd_in[116]
@@ -1055,7 +1055,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 49.555 0.000 49.625 0.210 ;
+      RECT 98.005 0.000 98.075 0.210 ;
     END
   END rw0_wd_in[116]
   PIN rw0_wd_in[117]
@@ -1064,7 +1064,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 50.505 0.000 50.575 0.210 ;
+      RECT 99.905 0.000 99.975 0.210 ;
     END
   END rw0_wd_in[117]
   PIN rw0_wd_in[118]
@@ -1073,7 +1073,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 51.455 0.000 51.525 0.210 ;
+      RECT 101.805 0.000 101.875 0.210 ;
     END
   END rw0_wd_in[118]
   PIN rw0_wd_in[119]
@@ -1082,7 +1082,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 52.405 0.000 52.475 0.210 ;
+      RECT 103.705 0.000 103.775 0.210 ;
     END
   END rw0_wd_in[119]
   PIN rw0_wd_in[120]
@@ -1091,7 +1091,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 53.355 0.000 53.425 0.210 ;
+      RECT 105.605 0.000 105.675 0.210 ;
     END
   END rw0_wd_in[120]
   PIN rw0_wd_in[121]
@@ -1100,7 +1100,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 54.305 0.000 54.375 0.210 ;
+      RECT 107.505 0.000 107.575 0.210 ;
     END
   END rw0_wd_in[121]
   PIN rw0_wd_in[122]
@@ -1109,7 +1109,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 55.255 0.000 55.325 0.210 ;
+      RECT 109.405 0.000 109.475 0.210 ;
     END
   END rw0_wd_in[122]
   PIN rw0_wd_in[123]
@@ -1118,7 +1118,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 56.205 0.000 56.275 0.210 ;
+      RECT 111.305 0.000 111.375 0.210 ;
     END
   END rw0_wd_in[123]
   PIN rw0_wd_in[124]
@@ -1127,7 +1127,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 57.155 0.000 57.225 0.210 ;
+      RECT 113.205 0.000 113.275 0.210 ;
     END
   END rw0_wd_in[124]
   PIN rw0_wd_in[125]
@@ -1136,7 +1136,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 58.105 0.000 58.175 0.210 ;
+      RECT 115.105 0.000 115.175 0.210 ;
     END
   END rw0_wd_in[125]
   PIN rw0_wd_in[126]
@@ -1145,7 +1145,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 59.055 0.000 59.125 0.210 ;
+      RECT 117.005 0.000 117.075 0.210 ;
     END
   END rw0_wd_in[126]
   PIN rw0_wd_in[127]
@@ -1154,7 +1154,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 60.005 0.000 60.075 0.210 ;
+      RECT 118.905 0.000 118.975 0.210 ;
     END
   END rw0_wd_in[127]
   PIN rw0_wd_in[128]
@@ -1163,7 +1163,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 60.955 0.000 61.025 0.210 ;
+      RECT 120.805 0.000 120.875 0.210 ;
     END
   END rw0_wd_in[128]
   PIN rw0_wd_in[129]
@@ -1172,7 +1172,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 61.905 0.000 61.975 0.210 ;
+      RECT 122.705 0.000 122.775 0.210 ;
     END
   END rw0_wd_in[129]
   PIN rw0_rd_out[0]
@@ -1181,7 +1181,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 62.855 0.000 62.925 0.210 ;
+      RECT 124.605 0.000 124.675 0.210 ;
     END
   END rw0_rd_out[0]
   PIN rw0_rd_out[1]
@@ -1190,7 +1190,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 63.805 0.000 63.875 0.210 ;
+      RECT 126.505 0.000 126.575 0.210 ;
     END
   END rw0_rd_out[1]
   PIN rw0_rd_out[2]
@@ -1199,7 +1199,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 64.755 0.000 64.825 0.210 ;
+      RECT 128.405 0.000 128.475 0.210 ;
     END
   END rw0_rd_out[2]
   PIN rw0_rd_out[3]
@@ -1208,7 +1208,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 65.705 0.000 65.775 0.210 ;
+      RECT 130.305 0.000 130.375 0.210 ;
     END
   END rw0_rd_out[3]
   PIN rw0_rd_out[4]
@@ -1217,7 +1217,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 66.655 0.000 66.725 0.210 ;
+      RECT 132.205 0.000 132.275 0.210 ;
     END
   END rw0_rd_out[4]
   PIN rw0_rd_out[5]
@@ -1226,7 +1226,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 67.605 0.000 67.675 0.210 ;
+      RECT 134.105 0.000 134.175 0.210 ;
     END
   END rw0_rd_out[5]
   PIN rw0_rd_out[6]
@@ -1235,7 +1235,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 68.555 0.000 68.625 0.210 ;
+      RECT 136.005 0.000 136.075 0.210 ;
     END
   END rw0_rd_out[6]
   PIN rw0_rd_out[7]
@@ -1244,7 +1244,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 69.505 0.000 69.575 0.210 ;
+      RECT 137.905 0.000 137.975 0.210 ;
     END
   END rw0_rd_out[7]
   PIN rw0_rd_out[8]
@@ -1253,7 +1253,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 70.455 0.000 70.525 0.210 ;
+      RECT 139.805 0.000 139.875 0.210 ;
     END
   END rw0_rd_out[8]
   PIN rw0_rd_out[9]
@@ -1262,7 +1262,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 71.405 0.000 71.475 0.210 ;
+      RECT 141.705 0.000 141.775 0.210 ;
     END
   END rw0_rd_out[9]
   PIN rw0_rd_out[10]
@@ -1271,7 +1271,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 72.355 0.000 72.425 0.210 ;
+      RECT 143.605 0.000 143.675 0.210 ;
     END
   END rw0_rd_out[10]
   PIN rw0_rd_out[11]
@@ -1280,7 +1280,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 73.305 0.000 73.375 0.210 ;
+      RECT 145.505 0.000 145.575 0.210 ;
     END
   END rw0_rd_out[11]
   PIN rw0_rd_out[12]
@@ -1289,7 +1289,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 74.255 0.000 74.325 0.210 ;
+      RECT 147.405 0.000 147.475 0.210 ;
     END
   END rw0_rd_out[12]
   PIN rw0_rd_out[13]
@@ -1298,7 +1298,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 75.205 0.000 75.275 0.210 ;
+      RECT 149.305 0.000 149.375 0.210 ;
     END
   END rw0_rd_out[13]
   PIN rw0_rd_out[14]
@@ -1307,7 +1307,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 76.155 0.000 76.225 0.210 ;
+      RECT 151.205 0.000 151.275 0.210 ;
     END
   END rw0_rd_out[14]
   PIN rw0_rd_out[15]
@@ -1316,7 +1316,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 77.105 0.000 77.175 0.210 ;
+      RECT 153.105 0.000 153.175 0.210 ;
     END
   END rw0_rd_out[15]
   PIN rw0_rd_out[16]
@@ -1325,7 +1325,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 78.055 0.000 78.125 0.210 ;
+      RECT 155.005 0.000 155.075 0.210 ;
     END
   END rw0_rd_out[16]
   PIN rw0_rd_out[17]
@@ -1334,7 +1334,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 79.005 0.000 79.075 0.210 ;
+      RECT 156.905 0.000 156.975 0.210 ;
     END
   END rw0_rd_out[17]
   PIN rw0_rd_out[18]
@@ -1343,7 +1343,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 79.955 0.000 80.025 0.210 ;
+      RECT 158.805 0.000 158.875 0.210 ;
     END
   END rw0_rd_out[18]
   PIN rw0_rd_out[19]
@@ -1352,7 +1352,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 80.905 0.000 80.975 0.210 ;
+      RECT 160.705 0.000 160.775 0.210 ;
     END
   END rw0_rd_out[19]
   PIN rw0_rd_out[20]
@@ -1361,7 +1361,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 81.855 0.000 81.925 0.210 ;
+      RECT 162.605 0.000 162.675 0.210 ;
     END
   END rw0_rd_out[20]
   PIN rw0_rd_out[21]
@@ -1370,7 +1370,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 82.805 0.000 82.875 0.210 ;
+      RECT 164.505 0.000 164.575 0.210 ;
     END
   END rw0_rd_out[21]
   PIN rw0_rd_out[22]
@@ -1379,7 +1379,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 83.755 0.000 83.825 0.210 ;
+      RECT 166.405 0.000 166.475 0.210 ;
     END
   END rw0_rd_out[22]
   PIN rw0_rd_out[23]
@@ -1388,7 +1388,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 84.705 0.000 84.775 0.210 ;
+      RECT 168.305 0.000 168.375 0.210 ;
     END
   END rw0_rd_out[23]
   PIN rw0_rd_out[24]
@@ -1397,7 +1397,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 85.655 0.000 85.725 0.210 ;
+      RECT 170.205 0.000 170.275 0.210 ;
     END
   END rw0_rd_out[24]
   PIN rw0_rd_out[25]
@@ -1406,7 +1406,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 86.605 0.000 86.675 0.210 ;
+      RECT 172.105 0.000 172.175 0.210 ;
     END
   END rw0_rd_out[25]
   PIN rw0_rd_out[26]
@@ -1415,7 +1415,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 87.555 0.000 87.625 0.210 ;
+      RECT 174.005 0.000 174.075 0.210 ;
     END
   END rw0_rd_out[26]
   PIN rw0_rd_out[27]
@@ -1424,7 +1424,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 88.505 0.000 88.575 0.210 ;
+      RECT 175.905 0.000 175.975 0.210 ;
     END
   END rw0_rd_out[27]
   PIN rw0_rd_out[28]
@@ -1433,7 +1433,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 89.455 0.000 89.525 0.210 ;
+      RECT 177.805 0.000 177.875 0.210 ;
     END
   END rw0_rd_out[28]
   PIN rw0_rd_out[29]
@@ -1442,7 +1442,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 90.405 0.000 90.475 0.210 ;
+      RECT 179.705 0.000 179.775 0.210 ;
     END
   END rw0_rd_out[29]
   PIN rw0_rd_out[30]
@@ -1451,7 +1451,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 91.355 0.000 91.425 0.210 ;
+      RECT 181.605 0.000 181.675 0.210 ;
     END
   END rw0_rd_out[30]
   PIN rw0_rd_out[31]
@@ -1460,7 +1460,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 92.305 0.000 92.375 0.210 ;
+      RECT 183.505 0.000 183.575 0.210 ;
     END
   END rw0_rd_out[31]
   PIN rw0_rd_out[32]
@@ -1469,7 +1469,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 93.255 0.000 93.325 0.210 ;
+      RECT 185.405 0.000 185.475 0.210 ;
     END
   END rw0_rd_out[32]
   PIN rw0_rd_out[33]
@@ -1478,7 +1478,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 94.205 0.000 94.275 0.210 ;
+      RECT 187.305 0.000 187.375 0.210 ;
     END
   END rw0_rd_out[33]
   PIN rw0_rd_out[34]
@@ -1487,7 +1487,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 95.155 0.000 95.225 0.210 ;
+      RECT 189.205 0.000 189.275 0.210 ;
     END
   END rw0_rd_out[34]
   PIN rw0_rd_out[35]
@@ -1496,7 +1496,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 96.105 0.000 96.175 0.210 ;
+      RECT 191.105 0.000 191.175 0.210 ;
     END
   END rw0_rd_out[35]
   PIN rw0_rd_out[36]
@@ -1505,7 +1505,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 97.055 0.000 97.125 0.210 ;
+      RECT 193.005 0.000 193.075 0.210 ;
     END
   END rw0_rd_out[36]
   PIN rw0_rd_out[37]
@@ -1514,7 +1514,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 98.005 0.000 98.075 0.210 ;
+      RECT 194.905 0.000 194.975 0.210 ;
     END
   END rw0_rd_out[37]
   PIN rw0_rd_out[38]
@@ -1523,7 +1523,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 98.955 0.000 99.025 0.210 ;
+      RECT 196.805 0.000 196.875 0.210 ;
     END
   END rw0_rd_out[38]
   PIN rw0_rd_out[39]
@@ -1532,7 +1532,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 99.905 0.000 99.975 0.210 ;
+      RECT 198.705 0.000 198.775 0.210 ;
     END
   END rw0_rd_out[39]
   PIN rw0_rd_out[40]
@@ -1541,7 +1541,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 100.855 0.000 100.925 0.210 ;
+      RECT 200.605 0.000 200.675 0.210 ;
     END
   END rw0_rd_out[40]
   PIN rw0_rd_out[41]
@@ -1550,7 +1550,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 101.805 0.000 101.875 0.210 ;
+      RECT 202.505 0.000 202.575 0.210 ;
     END
   END rw0_rd_out[41]
   PIN rw0_rd_out[42]
@@ -1559,7 +1559,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 102.755 0.000 102.825 0.210 ;
+      RECT 204.405 0.000 204.475 0.210 ;
     END
   END rw0_rd_out[42]
   PIN rw0_rd_out[43]
@@ -1568,7 +1568,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 103.705 0.000 103.775 0.210 ;
+      RECT 206.305 0.000 206.375 0.210 ;
     END
   END rw0_rd_out[43]
   PIN rw0_rd_out[44]
@@ -1577,7 +1577,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 104.655 0.000 104.725 0.210 ;
+      RECT 208.205 0.000 208.275 0.210 ;
     END
   END rw0_rd_out[44]
   PIN rw0_rd_out[45]
@@ -1586,7 +1586,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 105.605 0.000 105.675 0.210 ;
+      RECT 210.105 0.000 210.175 0.210 ;
     END
   END rw0_rd_out[45]
   PIN rw0_rd_out[46]
@@ -1595,7 +1595,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 106.555 0.000 106.625 0.210 ;
+      RECT 212.005 0.000 212.075 0.210 ;
     END
   END rw0_rd_out[46]
   PIN rw0_rd_out[47]
@@ -1604,7 +1604,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 107.505 0.000 107.575 0.210 ;
+      RECT 213.905 0.000 213.975 0.210 ;
     END
   END rw0_rd_out[47]
   PIN rw0_rd_out[48]
@@ -1613,7 +1613,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 108.455 0.000 108.525 0.210 ;
+      RECT 215.805 0.000 215.875 0.210 ;
     END
   END rw0_rd_out[48]
   PIN rw0_rd_out[49]
@@ -1622,7 +1622,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 109.405 0.000 109.475 0.210 ;
+      RECT 217.705 0.000 217.775 0.210 ;
     END
   END rw0_rd_out[49]
   PIN rw0_rd_out[50]
@@ -1631,7 +1631,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 110.355 0.000 110.425 0.210 ;
+      RECT 219.605 0.000 219.675 0.210 ;
     END
   END rw0_rd_out[50]
   PIN rw0_rd_out[51]
@@ -1640,7 +1640,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 111.305 0.000 111.375 0.210 ;
+      RECT 221.505 0.000 221.575 0.210 ;
     END
   END rw0_rd_out[51]
   PIN rw0_rd_out[52]
@@ -1649,7 +1649,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 112.255 0.000 112.325 0.210 ;
+      RECT 223.405 0.000 223.475 0.210 ;
     END
   END rw0_rd_out[52]
   PIN rw0_rd_out[53]
@@ -1658,7 +1658,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 113.205 0.000 113.275 0.210 ;
+      RECT 225.305 0.000 225.375 0.210 ;
     END
   END rw0_rd_out[53]
   PIN rw0_rd_out[54]
@@ -1667,7 +1667,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 114.155 0.000 114.225 0.210 ;
+      RECT 227.205 0.000 227.275 0.210 ;
     END
   END rw0_rd_out[54]
   PIN rw0_rd_out[55]
@@ -1676,7 +1676,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 115.105 0.000 115.175 0.210 ;
+      RECT 229.105 0.000 229.175 0.210 ;
     END
   END rw0_rd_out[55]
   PIN rw0_rd_out[56]
@@ -1685,7 +1685,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 116.055 0.000 116.125 0.210 ;
+      RECT 231.005 0.000 231.075 0.210 ;
     END
   END rw0_rd_out[56]
   PIN rw0_rd_out[57]
@@ -1694,7 +1694,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 117.005 0.000 117.075 0.210 ;
+      RECT 232.905 0.000 232.975 0.210 ;
     END
   END rw0_rd_out[57]
   PIN rw0_rd_out[58]
@@ -1703,7 +1703,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 117.955 0.000 118.025 0.210 ;
+      RECT 234.805 0.000 234.875 0.210 ;
     END
   END rw0_rd_out[58]
   PIN rw0_rd_out[59]
@@ -1712,7 +1712,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 118.905 0.000 118.975 0.210 ;
+      RECT 236.705 0.000 236.775 0.210 ;
     END
   END rw0_rd_out[59]
   PIN rw0_rd_out[60]
@@ -1721,7 +1721,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 119.855 0.000 119.925 0.210 ;
+      RECT 238.605 0.000 238.675 0.210 ;
     END
   END rw0_rd_out[60]
   PIN rw0_rd_out[61]
@@ -1730,7 +1730,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 120.805 0.000 120.875 0.210 ;
+      RECT 240.505 0.000 240.575 0.210 ;
     END
   END rw0_rd_out[61]
   PIN rw0_rd_out[62]
@@ -1739,7 +1739,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 121.755 0.000 121.825 0.210 ;
+      RECT 242.405 0.000 242.475 0.210 ;
     END
   END rw0_rd_out[62]
   PIN rw0_rd_out[63]
@@ -1748,7 +1748,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 122.705 0.000 122.775 0.210 ;
+      RECT 244.305 0.000 244.375 0.210 ;
     END
   END rw0_rd_out[63]
   PIN rw0_rd_out[64]
@@ -1757,7 +1757,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 123.655 0.000 123.725 0.210 ;
+      RECT 246.205 0.000 246.275 0.210 ;
     END
   END rw0_rd_out[64]
   PIN rw0_rd_out[65]
@@ -1766,7 +1766,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 1.105 258.790 1.175 259.000 ;
+      RECT 1.105 451.990 1.175 452.200 ;
     END
   END rw0_rd_out[65]
   PIN rw0_rd_out[66]
@@ -1775,7 +1775,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 2.435 258.790 2.505 259.000 ;
+      RECT 3.765 451.990 3.835 452.200 ;
     END
   END rw0_rd_out[66]
   PIN rw0_rd_out[67]
@@ -1784,7 +1784,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 3.765 258.790 3.835 259.000 ;
+      RECT 6.425 451.990 6.495 452.200 ;
     END
   END rw0_rd_out[67]
   PIN rw0_rd_out[68]
@@ -1793,7 +1793,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 5.095 258.790 5.165 259.000 ;
+      RECT 9.085 451.990 9.155 452.200 ;
     END
   END rw0_rd_out[68]
   PIN rw0_rd_out[69]
@@ -1802,7 +1802,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 6.425 258.790 6.495 259.000 ;
+      RECT 11.745 451.990 11.815 452.200 ;
     END
   END rw0_rd_out[69]
   PIN rw0_rd_out[70]
@@ -1811,7 +1811,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 7.755 258.790 7.825 259.000 ;
+      RECT 14.405 451.990 14.475 452.200 ;
     END
   END rw0_rd_out[70]
   PIN rw0_rd_out[71]
@@ -1820,7 +1820,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 9.085 258.790 9.155 259.000 ;
+      RECT 17.065 451.990 17.135 452.200 ;
     END
   END rw0_rd_out[71]
   PIN rw0_rd_out[72]
@@ -1829,7 +1829,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 10.415 258.790 10.485 259.000 ;
+      RECT 19.725 451.990 19.795 452.200 ;
     END
   END rw0_rd_out[72]
   PIN rw0_rd_out[73]
@@ -1838,7 +1838,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 11.745 258.790 11.815 259.000 ;
+      RECT 22.385 451.990 22.455 452.200 ;
     END
   END rw0_rd_out[73]
   PIN rw0_rd_out[74]
@@ -1847,7 +1847,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 13.075 258.790 13.145 259.000 ;
+      RECT 25.045 451.990 25.115 452.200 ;
     END
   END rw0_rd_out[74]
   PIN rw0_rd_out[75]
@@ -1856,7 +1856,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 14.405 258.790 14.475 259.000 ;
+      RECT 27.705 451.990 27.775 452.200 ;
     END
   END rw0_rd_out[75]
   PIN rw0_rd_out[76]
@@ -1865,7 +1865,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 15.735 258.790 15.805 259.000 ;
+      RECT 30.365 451.990 30.435 452.200 ;
     END
   END rw0_rd_out[76]
   PIN rw0_rd_out[77]
@@ -1874,7 +1874,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 17.065 258.790 17.135 259.000 ;
+      RECT 33.025 451.990 33.095 452.200 ;
     END
   END rw0_rd_out[77]
   PIN rw0_rd_out[78]
@@ -1883,7 +1883,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 18.395 258.790 18.465 259.000 ;
+      RECT 35.685 451.990 35.755 452.200 ;
     END
   END rw0_rd_out[78]
   PIN rw0_rd_out[79]
@@ -1892,7 +1892,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 19.725 258.790 19.795 259.000 ;
+      RECT 38.345 451.990 38.415 452.200 ;
     END
   END rw0_rd_out[79]
   PIN rw0_rd_out[80]
@@ -1901,7 +1901,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 21.055 258.790 21.125 259.000 ;
+      RECT 41.005 451.990 41.075 452.200 ;
     END
   END rw0_rd_out[80]
   PIN rw0_rd_out[81]
@@ -1910,7 +1910,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 22.385 258.790 22.455 259.000 ;
+      RECT 43.665 451.990 43.735 452.200 ;
     END
   END rw0_rd_out[81]
   PIN rw0_rd_out[82]
@@ -1919,7 +1919,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 23.715 258.790 23.785 259.000 ;
+      RECT 46.325 451.990 46.395 452.200 ;
     END
   END rw0_rd_out[82]
   PIN rw0_rd_out[83]
@@ -1928,7 +1928,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 25.045 258.790 25.115 259.000 ;
+      RECT 48.985 451.990 49.055 452.200 ;
     END
   END rw0_rd_out[83]
   PIN rw0_rd_out[84]
@@ -1937,7 +1937,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 26.375 258.790 26.445 259.000 ;
+      RECT 51.645 451.990 51.715 452.200 ;
     END
   END rw0_rd_out[84]
   PIN rw0_rd_out[85]
@@ -1946,7 +1946,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 27.705 258.790 27.775 259.000 ;
+      RECT 54.305 451.990 54.375 452.200 ;
     END
   END rw0_rd_out[85]
   PIN rw0_rd_out[86]
@@ -1955,7 +1955,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 29.035 258.790 29.105 259.000 ;
+      RECT 56.965 451.990 57.035 452.200 ;
     END
   END rw0_rd_out[86]
   PIN rw0_rd_out[87]
@@ -1964,7 +1964,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 30.365 258.790 30.435 259.000 ;
+      RECT 59.625 451.990 59.695 452.200 ;
     END
   END rw0_rd_out[87]
   PIN rw0_rd_out[88]
@@ -1973,7 +1973,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 31.695 258.790 31.765 259.000 ;
+      RECT 62.285 451.990 62.355 452.200 ;
     END
   END rw0_rd_out[88]
   PIN rw0_rd_out[89]
@@ -1982,7 +1982,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 33.025 258.790 33.095 259.000 ;
+      RECT 64.945 451.990 65.015 452.200 ;
     END
   END rw0_rd_out[89]
   PIN rw0_rd_out[90]
@@ -1991,7 +1991,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 34.355 258.790 34.425 259.000 ;
+      RECT 67.605 451.990 67.675 452.200 ;
     END
   END rw0_rd_out[90]
   PIN rw0_rd_out[91]
@@ -2000,7 +2000,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 35.685 258.790 35.755 259.000 ;
+      RECT 70.265 451.990 70.335 452.200 ;
     END
   END rw0_rd_out[91]
   PIN rw0_rd_out[92]
@@ -2009,7 +2009,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 37.015 258.790 37.085 259.000 ;
+      RECT 72.925 451.990 72.995 452.200 ;
     END
   END rw0_rd_out[92]
   PIN rw0_rd_out[93]
@@ -2018,7 +2018,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 38.345 258.790 38.415 259.000 ;
+      RECT 75.585 451.990 75.655 452.200 ;
     END
   END rw0_rd_out[93]
   PIN rw0_rd_out[94]
@@ -2027,7 +2027,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 39.675 258.790 39.745 259.000 ;
+      RECT 78.245 451.990 78.315 452.200 ;
     END
   END rw0_rd_out[94]
   PIN rw0_rd_out[95]
@@ -2036,7 +2036,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 41.005 258.790 41.075 259.000 ;
+      RECT 80.905 451.990 80.975 452.200 ;
     END
   END rw0_rd_out[95]
   PIN rw0_rd_out[96]
@@ -2045,7 +2045,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 42.335 258.790 42.405 259.000 ;
+      RECT 83.565 451.990 83.635 452.200 ;
     END
   END rw0_rd_out[96]
   PIN rw0_rd_out[97]
@@ -2054,7 +2054,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 43.665 258.790 43.735 259.000 ;
+      RECT 86.225 451.990 86.295 452.200 ;
     END
   END rw0_rd_out[97]
   PIN rw0_rd_out[98]
@@ -2063,7 +2063,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 44.995 258.790 45.065 259.000 ;
+      RECT 88.885 451.990 88.955 452.200 ;
     END
   END rw0_rd_out[98]
   PIN rw0_rd_out[99]
@@ -2072,7 +2072,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 46.325 258.790 46.395 259.000 ;
+      RECT 91.545 451.990 91.615 452.200 ;
     END
   END rw0_rd_out[99]
   PIN rw0_rd_out[100]
@@ -2081,7 +2081,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 47.655 258.790 47.725 259.000 ;
+      RECT 94.205 451.990 94.275 452.200 ;
     END
   END rw0_rd_out[100]
   PIN rw0_rd_out[101]
@@ -2090,7 +2090,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 48.985 258.790 49.055 259.000 ;
+      RECT 96.865 451.990 96.935 452.200 ;
     END
   END rw0_rd_out[101]
   PIN rw0_rd_out[102]
@@ -2099,7 +2099,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 50.315 258.790 50.385 259.000 ;
+      RECT 99.525 451.990 99.595 452.200 ;
     END
   END rw0_rd_out[102]
   PIN rw0_rd_out[103]
@@ -2108,7 +2108,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 51.645 258.790 51.715 259.000 ;
+      RECT 102.185 451.990 102.255 452.200 ;
     END
   END rw0_rd_out[103]
   PIN rw0_rd_out[104]
@@ -2117,7 +2117,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 52.975 258.790 53.045 259.000 ;
+      RECT 104.845 451.990 104.915 452.200 ;
     END
   END rw0_rd_out[104]
   PIN rw0_rd_out[105]
@@ -2126,7 +2126,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 54.305 258.790 54.375 259.000 ;
+      RECT 107.505 451.990 107.575 452.200 ;
     END
   END rw0_rd_out[105]
   PIN rw0_rd_out[106]
@@ -2135,7 +2135,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 55.635 258.790 55.705 259.000 ;
+      RECT 110.165 451.990 110.235 452.200 ;
     END
   END rw0_rd_out[106]
   PIN rw0_rd_out[107]
@@ -2144,7 +2144,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 56.965 258.790 57.035 259.000 ;
+      RECT 112.825 451.990 112.895 452.200 ;
     END
   END rw0_rd_out[107]
   PIN rw0_rd_out[108]
@@ -2153,7 +2153,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 58.295 258.790 58.365 259.000 ;
+      RECT 115.485 451.990 115.555 452.200 ;
     END
   END rw0_rd_out[108]
   PIN rw0_rd_out[109]
@@ -2162,7 +2162,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 59.625 258.790 59.695 259.000 ;
+      RECT 118.145 451.990 118.215 452.200 ;
     END
   END rw0_rd_out[109]
   PIN rw0_rd_out[110]
@@ -2171,7 +2171,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 60.955 258.790 61.025 259.000 ;
+      RECT 120.805 451.990 120.875 452.200 ;
     END
   END rw0_rd_out[110]
   PIN rw0_rd_out[111]
@@ -2180,7 +2180,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 62.285 258.790 62.355 259.000 ;
+      RECT 123.465 451.990 123.535 452.200 ;
     END
   END rw0_rd_out[111]
   PIN rw0_rd_out[112]
@@ -2189,7 +2189,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 63.615 258.790 63.685 259.000 ;
+      RECT 126.125 451.990 126.195 452.200 ;
     END
   END rw0_rd_out[112]
   PIN rw0_rd_out[113]
@@ -2198,7 +2198,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 64.945 258.790 65.015 259.000 ;
+      RECT 128.785 451.990 128.855 452.200 ;
     END
   END rw0_rd_out[113]
   PIN rw0_rd_out[114]
@@ -2207,7 +2207,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 66.275 258.790 66.345 259.000 ;
+      RECT 131.445 451.990 131.515 452.200 ;
     END
   END rw0_rd_out[114]
   PIN rw0_rd_out[115]
@@ -2216,7 +2216,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 67.605 258.790 67.675 259.000 ;
+      RECT 134.105 451.990 134.175 452.200 ;
     END
   END rw0_rd_out[115]
   PIN rw0_rd_out[116]
@@ -2225,7 +2225,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 68.935 258.790 69.005 259.000 ;
+      RECT 136.765 451.990 136.835 452.200 ;
     END
   END rw0_rd_out[116]
   PIN rw0_rd_out[117]
@@ -2234,7 +2234,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 70.265 258.790 70.335 259.000 ;
+      RECT 139.425 451.990 139.495 452.200 ;
     END
   END rw0_rd_out[117]
   PIN rw0_rd_out[118]
@@ -2243,7 +2243,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 71.595 258.790 71.665 259.000 ;
+      RECT 142.085 451.990 142.155 452.200 ;
     END
   END rw0_rd_out[118]
   PIN rw0_rd_out[119]
@@ -2252,7 +2252,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 72.925 258.790 72.995 259.000 ;
+      RECT 144.745 451.990 144.815 452.200 ;
     END
   END rw0_rd_out[119]
   PIN rw0_rd_out[120]
@@ -2261,7 +2261,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 74.255 258.790 74.325 259.000 ;
+      RECT 147.405 451.990 147.475 452.200 ;
     END
   END rw0_rd_out[120]
   PIN rw0_rd_out[121]
@@ -2270,7 +2270,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 75.585 258.790 75.655 259.000 ;
+      RECT 150.065 451.990 150.135 452.200 ;
     END
   END rw0_rd_out[121]
   PIN rw0_rd_out[122]
@@ -2279,7 +2279,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 76.915 258.790 76.985 259.000 ;
+      RECT 152.725 451.990 152.795 452.200 ;
     END
   END rw0_rd_out[122]
   PIN rw0_rd_out[123]
@@ -2288,7 +2288,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 78.245 258.790 78.315 259.000 ;
+      RECT 155.385 451.990 155.455 452.200 ;
     END
   END rw0_rd_out[123]
   PIN rw0_rd_out[124]
@@ -2297,7 +2297,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 79.575 258.790 79.645 259.000 ;
+      RECT 158.045 451.990 158.115 452.200 ;
     END
   END rw0_rd_out[124]
   PIN rw0_rd_out[125]
@@ -2306,7 +2306,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 80.905 258.790 80.975 259.000 ;
+      RECT 160.705 451.990 160.775 452.200 ;
     END
   END rw0_rd_out[125]
   PIN rw0_rd_out[126]
@@ -2315,7 +2315,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 82.235 258.790 82.305 259.000 ;
+      RECT 163.365 451.990 163.435 452.200 ;
     END
   END rw0_rd_out[126]
   PIN rw0_rd_out[127]
@@ -2324,7 +2324,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 83.565 258.790 83.635 259.000 ;
+      RECT 166.025 451.990 166.095 452.200 ;
     END
   END rw0_rd_out[127]
   PIN rw0_rd_out[128]
@@ -2333,7 +2333,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 84.895 258.790 84.965 259.000 ;
+      RECT 168.685 451.990 168.755 452.200 ;
     END
   END rw0_rd_out[128]
   PIN rw0_rd_out[129]
@@ -2342,7 +2342,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 86.225 258.790 86.295 259.000 ;
+      RECT 171.345 451.990 171.415 452.200 ;
     END
   END rw0_rd_out[129]
   PIN r0_rd_out[0]
@@ -2351,7 +2351,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 124.605 0.000 124.675 0.210 ;
+      RECT 248.105 0.000 248.175 0.210 ;
     END
   END r0_rd_out[0]
   PIN r0_rd_out[1]
@@ -2360,7 +2360,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 125.555 0.000 125.625 0.210 ;
+      RECT 250.005 0.000 250.075 0.210 ;
     END
   END r0_rd_out[1]
   PIN r0_rd_out[2]
@@ -2369,7 +2369,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 126.505 0.000 126.575 0.210 ;
+      RECT 251.905 0.000 251.975 0.210 ;
     END
   END r0_rd_out[2]
   PIN r0_rd_out[3]
@@ -2378,7 +2378,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 127.455 0.000 127.525 0.210 ;
+      RECT 253.805 0.000 253.875 0.210 ;
     END
   END r0_rd_out[3]
   PIN r0_rd_out[4]
@@ -2387,7 +2387,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 128.405 0.000 128.475 0.210 ;
+      RECT 255.705 0.000 255.775 0.210 ;
     END
   END r0_rd_out[4]
   PIN r0_rd_out[5]
@@ -2396,7 +2396,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 129.355 0.000 129.425 0.210 ;
+      RECT 257.605 0.000 257.675 0.210 ;
     END
   END r0_rd_out[5]
   PIN r0_rd_out[6]
@@ -2405,7 +2405,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 130.305 0.000 130.375 0.210 ;
+      RECT 259.505 0.000 259.575 0.210 ;
     END
   END r0_rd_out[6]
   PIN r0_rd_out[7]
@@ -2414,7 +2414,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 131.255 0.000 131.325 0.210 ;
+      RECT 261.405 0.000 261.475 0.210 ;
     END
   END r0_rd_out[7]
   PIN r0_rd_out[8]
@@ -2423,7 +2423,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 132.205 0.000 132.275 0.210 ;
+      RECT 263.305 0.000 263.375 0.210 ;
     END
   END r0_rd_out[8]
   PIN r0_rd_out[9]
@@ -2432,7 +2432,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 133.155 0.000 133.225 0.210 ;
+      RECT 265.205 0.000 265.275 0.210 ;
     END
   END r0_rd_out[9]
   PIN r0_rd_out[10]
@@ -2441,7 +2441,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 134.105 0.000 134.175 0.210 ;
+      RECT 267.105 0.000 267.175 0.210 ;
     END
   END r0_rd_out[10]
   PIN r0_rd_out[11]
@@ -2450,7 +2450,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 135.055 0.000 135.125 0.210 ;
+      RECT 269.005 0.000 269.075 0.210 ;
     END
   END r0_rd_out[11]
   PIN r0_rd_out[12]
@@ -2459,7 +2459,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 136.005 0.000 136.075 0.210 ;
+      RECT 270.905 0.000 270.975 0.210 ;
     END
   END r0_rd_out[12]
   PIN r0_rd_out[13]
@@ -2468,7 +2468,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 136.955 0.000 137.025 0.210 ;
+      RECT 272.805 0.000 272.875 0.210 ;
     END
   END r0_rd_out[13]
   PIN r0_rd_out[14]
@@ -2477,7 +2477,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 137.905 0.000 137.975 0.210 ;
+      RECT 274.705 0.000 274.775 0.210 ;
     END
   END r0_rd_out[14]
   PIN r0_rd_out[15]
@@ -2486,7 +2486,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 138.855 0.000 138.925 0.210 ;
+      RECT 276.605 0.000 276.675 0.210 ;
     END
   END r0_rd_out[15]
   PIN r0_rd_out[16]
@@ -2495,7 +2495,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 139.805 0.000 139.875 0.210 ;
+      RECT 278.505 0.000 278.575 0.210 ;
     END
   END r0_rd_out[16]
   PIN r0_rd_out[17]
@@ -2504,7 +2504,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 140.755 0.000 140.825 0.210 ;
+      RECT 280.405 0.000 280.475 0.210 ;
     END
   END r0_rd_out[17]
   PIN r0_rd_out[18]
@@ -2513,7 +2513,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 141.705 0.000 141.775 0.210 ;
+      RECT 282.305 0.000 282.375 0.210 ;
     END
   END r0_rd_out[18]
   PIN r0_rd_out[19]
@@ -2522,7 +2522,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 142.655 0.000 142.725 0.210 ;
+      RECT 284.205 0.000 284.275 0.210 ;
     END
   END r0_rd_out[19]
   PIN r0_rd_out[20]
@@ -2531,7 +2531,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 143.605 0.000 143.675 0.210 ;
+      RECT 286.105 0.000 286.175 0.210 ;
     END
   END r0_rd_out[20]
   PIN r0_rd_out[21]
@@ -2540,7 +2540,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 144.555 0.000 144.625 0.210 ;
+      RECT 288.005 0.000 288.075 0.210 ;
     END
   END r0_rd_out[21]
   PIN r0_rd_out[22]
@@ -2549,7 +2549,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 145.505 0.000 145.575 0.210 ;
+      RECT 289.905 0.000 289.975 0.210 ;
     END
   END r0_rd_out[22]
   PIN r0_rd_out[23]
@@ -2558,7 +2558,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 146.455 0.000 146.525 0.210 ;
+      RECT 291.805 0.000 291.875 0.210 ;
     END
   END r0_rd_out[23]
   PIN r0_rd_out[24]
@@ -2567,7 +2567,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 147.405 0.000 147.475 0.210 ;
+      RECT 293.705 0.000 293.775 0.210 ;
     END
   END r0_rd_out[24]
   PIN r0_rd_out[25]
@@ -2576,7 +2576,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 148.355 0.000 148.425 0.210 ;
+      RECT 295.605 0.000 295.675 0.210 ;
     END
   END r0_rd_out[25]
   PIN r0_rd_out[26]
@@ -2585,7 +2585,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 149.305 0.000 149.375 0.210 ;
+      RECT 297.505 0.000 297.575 0.210 ;
     END
   END r0_rd_out[26]
   PIN r0_rd_out[27]
@@ -2594,7 +2594,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 150.255 0.000 150.325 0.210 ;
+      RECT 299.405 0.000 299.475 0.210 ;
     END
   END r0_rd_out[27]
   PIN r0_rd_out[28]
@@ -2603,7 +2603,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 151.205 0.000 151.275 0.210 ;
+      RECT 301.305 0.000 301.375 0.210 ;
     END
   END r0_rd_out[28]
   PIN r0_rd_out[29]
@@ -2612,7 +2612,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 152.155 0.000 152.225 0.210 ;
+      RECT 303.205 0.000 303.275 0.210 ;
     END
   END r0_rd_out[29]
   PIN r0_rd_out[30]
@@ -2621,7 +2621,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 153.105 0.000 153.175 0.210 ;
+      RECT 305.105 0.000 305.175 0.210 ;
     END
   END r0_rd_out[30]
   PIN r0_rd_out[31]
@@ -2630,7 +2630,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 154.055 0.000 154.125 0.210 ;
+      RECT 307.005 0.000 307.075 0.210 ;
     END
   END r0_rd_out[31]
   PIN r0_rd_out[32]
@@ -2639,7 +2639,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 155.005 0.000 155.075 0.210 ;
+      RECT 308.905 0.000 308.975 0.210 ;
     END
   END r0_rd_out[32]
   PIN r0_rd_out[33]
@@ -2648,7 +2648,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 155.955 0.000 156.025 0.210 ;
+      RECT 310.805 0.000 310.875 0.210 ;
     END
   END r0_rd_out[33]
   PIN r0_rd_out[34]
@@ -2657,7 +2657,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 156.905 0.000 156.975 0.210 ;
+      RECT 312.705 0.000 312.775 0.210 ;
     END
   END r0_rd_out[34]
   PIN r0_rd_out[35]
@@ -2666,7 +2666,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 157.855 0.000 157.925 0.210 ;
+      RECT 314.605 0.000 314.675 0.210 ;
     END
   END r0_rd_out[35]
   PIN r0_rd_out[36]
@@ -2675,7 +2675,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 158.805 0.000 158.875 0.210 ;
+      RECT 316.505 0.000 316.575 0.210 ;
     END
   END r0_rd_out[36]
   PIN r0_rd_out[37]
@@ -2684,7 +2684,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 159.755 0.000 159.825 0.210 ;
+      RECT 318.405 0.000 318.475 0.210 ;
     END
   END r0_rd_out[37]
   PIN r0_rd_out[38]
@@ -2693,7 +2693,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 160.705 0.000 160.775 0.210 ;
+      RECT 320.305 0.000 320.375 0.210 ;
     END
   END r0_rd_out[38]
   PIN r0_rd_out[39]
@@ -2702,7 +2702,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 161.655 0.000 161.725 0.210 ;
+      RECT 322.205 0.000 322.275 0.210 ;
     END
   END r0_rd_out[39]
   PIN r0_rd_out[40]
@@ -2711,7 +2711,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 162.605 0.000 162.675 0.210 ;
+      RECT 324.105 0.000 324.175 0.210 ;
     END
   END r0_rd_out[40]
   PIN r0_rd_out[41]
@@ -2720,7 +2720,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 163.555 0.000 163.625 0.210 ;
+      RECT 326.005 0.000 326.075 0.210 ;
     END
   END r0_rd_out[41]
   PIN r0_rd_out[42]
@@ -2729,7 +2729,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 164.505 0.000 164.575 0.210 ;
+      RECT 327.905 0.000 327.975 0.210 ;
     END
   END r0_rd_out[42]
   PIN r0_rd_out[43]
@@ -2738,7 +2738,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 165.455 0.000 165.525 0.210 ;
+      RECT 329.805 0.000 329.875 0.210 ;
     END
   END r0_rd_out[43]
   PIN r0_rd_out[44]
@@ -2747,7 +2747,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 166.405 0.000 166.475 0.210 ;
+      RECT 331.705 0.000 331.775 0.210 ;
     END
   END r0_rd_out[44]
   PIN r0_rd_out[45]
@@ -2756,7 +2756,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 167.355 0.000 167.425 0.210 ;
+      RECT 333.605 0.000 333.675 0.210 ;
     END
   END r0_rd_out[45]
   PIN r0_rd_out[46]
@@ -2765,7 +2765,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 168.305 0.000 168.375 0.210 ;
+      RECT 335.505 0.000 335.575 0.210 ;
     END
   END r0_rd_out[46]
   PIN r0_rd_out[47]
@@ -2774,7 +2774,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 169.255 0.000 169.325 0.210 ;
+      RECT 337.405 0.000 337.475 0.210 ;
     END
   END r0_rd_out[47]
   PIN r0_rd_out[48]
@@ -2783,7 +2783,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 170.205 0.000 170.275 0.210 ;
+      RECT 339.305 0.000 339.375 0.210 ;
     END
   END r0_rd_out[48]
   PIN r0_rd_out[49]
@@ -2792,7 +2792,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 171.155 0.000 171.225 0.210 ;
+      RECT 341.205 0.000 341.275 0.210 ;
     END
   END r0_rd_out[49]
   PIN r0_rd_out[50]
@@ -2801,7 +2801,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 172.105 0.000 172.175 0.210 ;
+      RECT 343.105 0.000 343.175 0.210 ;
     END
   END r0_rd_out[50]
   PIN r0_rd_out[51]
@@ -2810,7 +2810,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 173.055 0.000 173.125 0.210 ;
+      RECT 345.005 0.000 345.075 0.210 ;
     END
   END r0_rd_out[51]
   PIN r0_rd_out[52]
@@ -2819,7 +2819,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 174.005 0.000 174.075 0.210 ;
+      RECT 346.905 0.000 346.975 0.210 ;
     END
   END r0_rd_out[52]
   PIN r0_rd_out[53]
@@ -2828,7 +2828,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 174.955 0.000 175.025 0.210 ;
+      RECT 348.805 0.000 348.875 0.210 ;
     END
   END r0_rd_out[53]
   PIN r0_rd_out[54]
@@ -2837,7 +2837,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 175.905 0.000 175.975 0.210 ;
+      RECT 350.705 0.000 350.775 0.210 ;
     END
   END r0_rd_out[54]
   PIN r0_rd_out[55]
@@ -2846,7 +2846,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 176.855 0.000 176.925 0.210 ;
+      RECT 352.605 0.000 352.675 0.210 ;
     END
   END r0_rd_out[55]
   PIN r0_rd_out[56]
@@ -2855,7 +2855,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 177.805 0.000 177.875 0.210 ;
+      RECT 354.505 0.000 354.575 0.210 ;
     END
   END r0_rd_out[56]
   PIN r0_rd_out[57]
@@ -2864,7 +2864,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 178.755 0.000 178.825 0.210 ;
+      RECT 356.405 0.000 356.475 0.210 ;
     END
   END r0_rd_out[57]
   PIN r0_rd_out[58]
@@ -2873,7 +2873,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 179.705 0.000 179.775 0.210 ;
+      RECT 358.305 0.000 358.375 0.210 ;
     END
   END r0_rd_out[58]
   PIN r0_rd_out[59]
@@ -2882,7 +2882,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 180.655 0.000 180.725 0.210 ;
+      RECT 360.205 0.000 360.275 0.210 ;
     END
   END r0_rd_out[59]
   PIN r0_rd_out[60]
@@ -2891,7 +2891,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 181.605 0.000 181.675 0.210 ;
+      RECT 362.105 0.000 362.175 0.210 ;
     END
   END r0_rd_out[60]
   PIN r0_rd_out[61]
@@ -2900,7 +2900,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 182.555 0.000 182.625 0.210 ;
+      RECT 364.005 0.000 364.075 0.210 ;
     END
   END r0_rd_out[61]
   PIN r0_rd_out[62]
@@ -2909,7 +2909,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 183.505 0.000 183.575 0.210 ;
+      RECT 365.905 0.000 365.975 0.210 ;
     END
   END r0_rd_out[62]
   PIN r0_rd_out[63]
@@ -2918,7 +2918,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 184.455 0.000 184.525 0.210 ;
+      RECT 367.805 0.000 367.875 0.210 ;
     END
   END r0_rd_out[63]
   PIN r0_rd_out[64]
@@ -2927,7 +2927,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 185.405 0.000 185.475 0.210 ;
+      RECT 369.705 0.000 369.775 0.210 ;
     END
   END r0_rd_out[64]
   PIN r0_rd_out[65]
@@ -2936,7 +2936,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 87.555 258.790 87.625 259.000 ;
+      RECT 174.005 451.990 174.075 452.200 ;
     END
   END r0_rd_out[65]
   PIN r0_rd_out[66]
@@ -2945,7 +2945,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 88.885 258.790 88.955 259.000 ;
+      RECT 176.665 451.990 176.735 452.200 ;
     END
   END r0_rd_out[66]
   PIN r0_rd_out[67]
@@ -2954,7 +2954,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 90.215 258.790 90.285 259.000 ;
+      RECT 179.325 451.990 179.395 452.200 ;
     END
   END r0_rd_out[67]
   PIN r0_rd_out[68]
@@ -2963,7 +2963,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 91.545 258.790 91.615 259.000 ;
+      RECT 181.985 451.990 182.055 452.200 ;
     END
   END r0_rd_out[68]
   PIN r0_rd_out[69]
@@ -2972,7 +2972,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 92.875 258.790 92.945 259.000 ;
+      RECT 184.645 451.990 184.715 452.200 ;
     END
   END r0_rd_out[69]
   PIN r0_rd_out[70]
@@ -2981,7 +2981,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 94.205 258.790 94.275 259.000 ;
+      RECT 187.305 451.990 187.375 452.200 ;
     END
   END r0_rd_out[70]
   PIN r0_rd_out[71]
@@ -2990,7 +2990,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 95.535 258.790 95.605 259.000 ;
+      RECT 189.965 451.990 190.035 452.200 ;
     END
   END r0_rd_out[71]
   PIN r0_rd_out[72]
@@ -2999,7 +2999,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 96.865 258.790 96.935 259.000 ;
+      RECT 192.625 451.990 192.695 452.200 ;
     END
   END r0_rd_out[72]
   PIN r0_rd_out[73]
@@ -3008,7 +3008,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 98.195 258.790 98.265 259.000 ;
+      RECT 195.285 451.990 195.355 452.200 ;
     END
   END r0_rd_out[73]
   PIN r0_rd_out[74]
@@ -3017,7 +3017,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 99.525 258.790 99.595 259.000 ;
+      RECT 197.945 451.990 198.015 452.200 ;
     END
   END r0_rd_out[74]
   PIN r0_rd_out[75]
@@ -3026,7 +3026,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 100.855 258.790 100.925 259.000 ;
+      RECT 200.605 451.990 200.675 452.200 ;
     END
   END r0_rd_out[75]
   PIN r0_rd_out[76]
@@ -3035,7 +3035,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 102.185 258.790 102.255 259.000 ;
+      RECT 203.265 451.990 203.335 452.200 ;
     END
   END r0_rd_out[76]
   PIN r0_rd_out[77]
@@ -3044,7 +3044,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 103.515 258.790 103.585 259.000 ;
+      RECT 205.925 451.990 205.995 452.200 ;
     END
   END r0_rd_out[77]
   PIN r0_rd_out[78]
@@ -3053,7 +3053,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 104.845 258.790 104.915 259.000 ;
+      RECT 208.585 451.990 208.655 452.200 ;
     END
   END r0_rd_out[78]
   PIN r0_rd_out[79]
@@ -3062,7 +3062,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 106.175 258.790 106.245 259.000 ;
+      RECT 211.245 451.990 211.315 452.200 ;
     END
   END r0_rd_out[79]
   PIN r0_rd_out[80]
@@ -3071,7 +3071,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 107.505 258.790 107.575 259.000 ;
+      RECT 213.905 451.990 213.975 452.200 ;
     END
   END r0_rd_out[80]
   PIN r0_rd_out[81]
@@ -3080,7 +3080,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 108.835 258.790 108.905 259.000 ;
+      RECT 216.565 451.990 216.635 452.200 ;
     END
   END r0_rd_out[81]
   PIN r0_rd_out[82]
@@ -3089,7 +3089,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 110.165 258.790 110.235 259.000 ;
+      RECT 219.225 451.990 219.295 452.200 ;
     END
   END r0_rd_out[82]
   PIN r0_rd_out[83]
@@ -3098,7 +3098,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 111.495 258.790 111.565 259.000 ;
+      RECT 221.885 451.990 221.955 452.200 ;
     END
   END r0_rd_out[83]
   PIN r0_rd_out[84]
@@ -3107,7 +3107,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 112.825 258.790 112.895 259.000 ;
+      RECT 224.545 451.990 224.615 452.200 ;
     END
   END r0_rd_out[84]
   PIN r0_rd_out[85]
@@ -3116,7 +3116,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 114.155 258.790 114.225 259.000 ;
+      RECT 227.205 451.990 227.275 452.200 ;
     END
   END r0_rd_out[85]
   PIN r0_rd_out[86]
@@ -3125,7 +3125,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 115.485 258.790 115.555 259.000 ;
+      RECT 229.865 451.990 229.935 452.200 ;
     END
   END r0_rd_out[86]
   PIN r0_rd_out[87]
@@ -3134,7 +3134,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 116.815 258.790 116.885 259.000 ;
+      RECT 232.525 451.990 232.595 452.200 ;
     END
   END r0_rd_out[87]
   PIN r0_rd_out[88]
@@ -3143,7 +3143,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 118.145 258.790 118.215 259.000 ;
+      RECT 235.185 451.990 235.255 452.200 ;
     END
   END r0_rd_out[88]
   PIN r0_rd_out[89]
@@ -3152,7 +3152,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 119.475 258.790 119.545 259.000 ;
+      RECT 237.845 451.990 237.915 452.200 ;
     END
   END r0_rd_out[89]
   PIN r0_rd_out[90]
@@ -3161,7 +3161,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 120.805 258.790 120.875 259.000 ;
+      RECT 240.505 451.990 240.575 452.200 ;
     END
   END r0_rd_out[90]
   PIN r0_rd_out[91]
@@ -3170,7 +3170,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 122.135 258.790 122.205 259.000 ;
+      RECT 243.165 451.990 243.235 452.200 ;
     END
   END r0_rd_out[91]
   PIN r0_rd_out[92]
@@ -3179,7 +3179,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 123.465 258.790 123.535 259.000 ;
+      RECT 245.825 451.990 245.895 452.200 ;
     END
   END r0_rd_out[92]
   PIN r0_rd_out[93]
@@ -3188,7 +3188,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 124.795 258.790 124.865 259.000 ;
+      RECT 248.485 451.990 248.555 452.200 ;
     END
   END r0_rd_out[93]
   PIN r0_rd_out[94]
@@ -3197,7 +3197,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 126.125 258.790 126.195 259.000 ;
+      RECT 251.145 451.990 251.215 452.200 ;
     END
   END r0_rd_out[94]
   PIN r0_rd_out[95]
@@ -3206,7 +3206,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 127.455 258.790 127.525 259.000 ;
+      RECT 253.805 451.990 253.875 452.200 ;
     END
   END r0_rd_out[95]
   PIN r0_rd_out[96]
@@ -3215,7 +3215,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 128.785 258.790 128.855 259.000 ;
+      RECT 256.465 451.990 256.535 452.200 ;
     END
   END r0_rd_out[96]
   PIN r0_rd_out[97]
@@ -3224,7 +3224,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 130.115 258.790 130.185 259.000 ;
+      RECT 259.125 451.990 259.195 452.200 ;
     END
   END r0_rd_out[97]
   PIN r0_rd_out[98]
@@ -3233,7 +3233,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 131.445 258.790 131.515 259.000 ;
+      RECT 261.785 451.990 261.855 452.200 ;
     END
   END r0_rd_out[98]
   PIN r0_rd_out[99]
@@ -3242,7 +3242,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 132.775 258.790 132.845 259.000 ;
+      RECT 264.445 451.990 264.515 452.200 ;
     END
   END r0_rd_out[99]
   PIN r0_rd_out[100]
@@ -3251,7 +3251,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 134.105 258.790 134.175 259.000 ;
+      RECT 267.105 451.990 267.175 452.200 ;
     END
   END r0_rd_out[100]
   PIN r0_rd_out[101]
@@ -3260,7 +3260,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 135.435 258.790 135.505 259.000 ;
+      RECT 269.765 451.990 269.835 452.200 ;
     END
   END r0_rd_out[101]
   PIN r0_rd_out[102]
@@ -3269,7 +3269,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 136.765 258.790 136.835 259.000 ;
+      RECT 272.425 451.990 272.495 452.200 ;
     END
   END r0_rd_out[102]
   PIN r0_rd_out[103]
@@ -3278,7 +3278,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 138.095 258.790 138.165 259.000 ;
+      RECT 275.085 451.990 275.155 452.200 ;
     END
   END r0_rd_out[103]
   PIN r0_rd_out[104]
@@ -3287,7 +3287,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 139.425 258.790 139.495 259.000 ;
+      RECT 277.745 451.990 277.815 452.200 ;
     END
   END r0_rd_out[104]
   PIN r0_rd_out[105]
@@ -3296,7 +3296,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 140.755 258.790 140.825 259.000 ;
+      RECT 280.405 451.990 280.475 452.200 ;
     END
   END r0_rd_out[105]
   PIN r0_rd_out[106]
@@ -3305,7 +3305,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 142.085 258.790 142.155 259.000 ;
+      RECT 283.065 451.990 283.135 452.200 ;
     END
   END r0_rd_out[106]
   PIN r0_rd_out[107]
@@ -3314,7 +3314,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 143.415 258.790 143.485 259.000 ;
+      RECT 285.725 451.990 285.795 452.200 ;
     END
   END r0_rd_out[107]
   PIN r0_rd_out[108]
@@ -3323,7 +3323,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 144.745 258.790 144.815 259.000 ;
+      RECT 288.385 451.990 288.455 452.200 ;
     END
   END r0_rd_out[108]
   PIN r0_rd_out[109]
@@ -3332,7 +3332,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 146.075 258.790 146.145 259.000 ;
+      RECT 291.045 451.990 291.115 452.200 ;
     END
   END r0_rd_out[109]
   PIN r0_rd_out[110]
@@ -3341,7 +3341,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 147.405 258.790 147.475 259.000 ;
+      RECT 293.705 451.990 293.775 452.200 ;
     END
   END r0_rd_out[110]
   PIN r0_rd_out[111]
@@ -3350,7 +3350,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 148.735 258.790 148.805 259.000 ;
+      RECT 296.365 451.990 296.435 452.200 ;
     END
   END r0_rd_out[111]
   PIN r0_rd_out[112]
@@ -3359,7 +3359,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 150.065 258.790 150.135 259.000 ;
+      RECT 299.025 451.990 299.095 452.200 ;
     END
   END r0_rd_out[112]
   PIN r0_rd_out[113]
@@ -3368,7 +3368,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 151.395 258.790 151.465 259.000 ;
+      RECT 301.685 451.990 301.755 452.200 ;
     END
   END r0_rd_out[113]
   PIN r0_rd_out[114]
@@ -3377,7 +3377,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 152.725 258.790 152.795 259.000 ;
+      RECT 304.345 451.990 304.415 452.200 ;
     END
   END r0_rd_out[114]
   PIN r0_rd_out[115]
@@ -3386,7 +3386,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 154.055 258.790 154.125 259.000 ;
+      RECT 307.005 451.990 307.075 452.200 ;
     END
   END r0_rd_out[115]
   PIN r0_rd_out[116]
@@ -3395,7 +3395,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 155.385 258.790 155.455 259.000 ;
+      RECT 309.665 451.990 309.735 452.200 ;
     END
   END r0_rd_out[116]
   PIN r0_rd_out[117]
@@ -3404,7 +3404,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 156.715 258.790 156.785 259.000 ;
+      RECT 312.325 451.990 312.395 452.200 ;
     END
   END r0_rd_out[117]
   PIN r0_rd_out[118]
@@ -3413,7 +3413,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 158.045 258.790 158.115 259.000 ;
+      RECT 314.985 451.990 315.055 452.200 ;
     END
   END r0_rd_out[118]
   PIN r0_rd_out[119]
@@ -3422,7 +3422,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 159.375 258.790 159.445 259.000 ;
+      RECT 317.645 451.990 317.715 452.200 ;
     END
   END r0_rd_out[119]
   PIN r0_rd_out[120]
@@ -3431,7 +3431,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 160.705 258.790 160.775 259.000 ;
+      RECT 320.305 451.990 320.375 452.200 ;
     END
   END r0_rd_out[120]
   PIN r0_rd_out[121]
@@ -3440,7 +3440,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 162.035 258.790 162.105 259.000 ;
+      RECT 322.965 451.990 323.035 452.200 ;
     END
   END r0_rd_out[121]
   PIN r0_rd_out[122]
@@ -3449,7 +3449,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 163.365 258.790 163.435 259.000 ;
+      RECT 325.625 451.990 325.695 452.200 ;
     END
   END r0_rd_out[122]
   PIN r0_rd_out[123]
@@ -3458,7 +3458,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 164.695 258.790 164.765 259.000 ;
+      RECT 328.285 451.990 328.355 452.200 ;
     END
   END r0_rd_out[123]
   PIN r0_rd_out[124]
@@ -3467,7 +3467,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 166.025 258.790 166.095 259.000 ;
+      RECT 330.945 451.990 331.015 452.200 ;
     END
   END r0_rd_out[124]
   PIN r0_rd_out[125]
@@ -3476,7 +3476,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 167.355 258.790 167.425 259.000 ;
+      RECT 333.605 451.990 333.675 452.200 ;
     END
   END r0_rd_out[125]
   PIN r0_rd_out[126]
@@ -3485,7 +3485,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 168.685 258.790 168.755 259.000 ;
+      RECT 336.265 451.990 336.335 452.200 ;
     END
   END r0_rd_out[126]
   PIN r0_rd_out[127]
@@ -3494,7 +3494,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 170.015 258.790 170.085 259.000 ;
+      RECT 338.925 451.990 338.995 452.200 ;
     END
   END r0_rd_out[127]
   PIN r0_rd_out[128]
@@ -3503,7 +3503,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 171.345 258.790 171.415 259.000 ;
+      RECT 341.585 451.990 341.655 452.200 ;
     END
   END r0_rd_out[128]
   PIN r0_rd_out[129]
@@ -3512,7 +3512,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 172.675 258.790 172.745 259.000 ;
+      RECT 344.245 451.990 344.315 452.200 ;
     END
   END r0_rd_out[129]
   PIN rw0_addr_in[0]
@@ -3521,7 +3521,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 208.705 0.210 208.775 ;
+      RECT 0.000 351.925 0.210 351.995 ;
     END
   END rw0_addr_in[0]
   PIN rw0_addr_in[1]
@@ -3530,7 +3530,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 215.005 0.210 215.075 ;
+      RECT 0.000 362.565 0.210 362.635 ;
     END
   END rw0_addr_in[1]
   PIN rw0_addr_in[2]
@@ -3539,7 +3539,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 221.305 0.210 221.375 ;
+      RECT 0.000 373.205 0.210 373.275 ;
     END
   END rw0_addr_in[2]
   PIN rw0_addr_in[3]
@@ -3548,7 +3548,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 227.605 0.210 227.675 ;
+      RECT 0.000 383.845 0.210 383.915 ;
     END
   END rw0_addr_in[3]
   PIN rw0_addr_in[4]
@@ -3557,7 +3557,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 202.405 188.290 202.475 ;
+      RECT 0.000 394.485 0.210 394.555 ;
     END
   END rw0_addr_in[4]
   PIN rw0_addr_in[5]
@@ -3566,7 +3566,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 208.705 188.290 208.775 ;
+      RECT 376.750 341.285 376.960 341.355 ;
     END
   END rw0_addr_in[5]
   PIN rw0_addr_in[6]
@@ -3575,16 +3575,34 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 215.005 188.290 215.075 ;
+      RECT 376.750 351.925 376.960 351.995 ;
     END
   END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 376.750 362.565 376.960 362.635 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 376.750 373.205 376.960 373.275 ;
+    END
+  END rw0_addr_in[8]
   PIN r0_addr_in[0]
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 233.905 0.210 233.975 ;
+      RECT 0.000 405.125 0.210 405.195 ;
     END
   END r0_addr_in[0]
   PIN r0_addr_in[1]
@@ -3593,7 +3611,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 240.205 0.210 240.275 ;
+      RECT 0.000 415.765 0.210 415.835 ;
     END
   END r0_addr_in[1]
   PIN r0_addr_in[2]
@@ -3602,7 +3620,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 246.505 0.210 246.575 ;
+      RECT 0.000 426.405 0.210 426.475 ;
     END
   END r0_addr_in[2]
   PIN r0_addr_in[3]
@@ -3611,7 +3629,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 0.000 252.805 0.210 252.875 ;
+      RECT 0.000 437.045 0.210 437.115 ;
     END
   END r0_addr_in[3]
   PIN r0_addr_in[4]
@@ -3620,7 +3638,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 221.305 188.290 221.375 ;
+      RECT 0.000 447.685 0.210 447.755 ;
     END
   END r0_addr_in[4]
   PIN r0_addr_in[5]
@@ -3629,7 +3647,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 227.605 188.290 227.675 ;
+      RECT 376.750 383.845 376.960 383.915 ;
     END
   END r0_addr_in[5]
   PIN r0_addr_in[6]
@@ -3638,16 +3656,34 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal3 ;
-      RECT 188.080 233.905 188.290 233.975 ;
+      RECT 376.750 394.485 376.960 394.555 ;
     END
   END r0_addr_in[6]
+  PIN r0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 376.750 405.125 376.960 405.195 ;
+    END
+  END r0_addr_in[7]
+  PIN r0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 376.750 415.765 376.960 415.835 ;
+    END
+  END r0_addr_in[8]
   PIN rw0_we_in
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 174.005 258.790 174.075 259.000 ;
+      RECT 346.905 451.990 346.975 452.200 ;
     END
   END rw0_we_in
   PIN rw0_ce_in
@@ -3656,7 +3692,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 175.335 258.790 175.405 259.000 ;
+      RECT 349.565 451.990 349.635 452.200 ;
     END
   END rw0_ce_in
   PIN rw0_clk
@@ -3665,7 +3701,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 176.665 258.790 176.735 259.000 ;
+      RECT 352.225 451.990 352.295 452.200 ;
     END
   END rw0_clk
   PIN r0_ce_in
@@ -3674,7 +3710,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 177.995 258.790 178.065 259.000 ;
+      RECT 354.885 451.990 354.955 452.200 ;
     END
   END r0_ce_in
   PIN r0_clk
@@ -3683,7 +3719,7 @@ MACRO fakeram45_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER metal2 ;
-      RECT 179.325 258.790 179.395 259.000 ;
+      RECT 357.545 451.990 357.615 452.200 ;
     END
   END r0_clk
   PIN VSS
@@ -3691,90 +3727,174 @@ MACRO fakeram45_1rw1r_130w128d
     USE GROUND ;
     PORT
       LAYER metal4 ;
-      RECT 1.000 0.840 1.280 258.160 ;
-      RECT 3.240 0.840 3.520 258.160 ;
-      RECT 5.480 0.840 5.760 258.160 ;
-      RECT 7.720 0.840 8.000 258.160 ;
-      RECT 9.960 0.840 10.240 258.160 ;
-      RECT 12.200 0.840 12.480 258.160 ;
-      RECT 14.440 0.840 14.720 258.160 ;
-      RECT 16.680 0.840 16.960 258.160 ;
-      RECT 18.920 0.840 19.200 258.160 ;
-      RECT 21.160 0.840 21.440 258.160 ;
-      RECT 23.400 0.840 23.680 258.160 ;
-      RECT 25.640 0.840 25.920 258.160 ;
-      RECT 27.880 0.840 28.160 258.160 ;
-      RECT 30.120 0.840 30.400 258.160 ;
-      RECT 32.360 0.840 32.640 258.160 ;
-      RECT 34.600 0.840 34.880 258.160 ;
-      RECT 36.840 0.840 37.120 258.160 ;
-      RECT 39.080 0.840 39.360 258.160 ;
-      RECT 41.320 0.840 41.600 258.160 ;
-      RECT 43.560 0.840 43.840 258.160 ;
-      RECT 45.800 0.840 46.080 258.160 ;
-      RECT 48.040 0.840 48.320 258.160 ;
-      RECT 50.280 0.840 50.560 258.160 ;
-      RECT 52.520 0.840 52.800 258.160 ;
-      RECT 54.760 0.840 55.040 258.160 ;
-      RECT 57.000 0.840 57.280 258.160 ;
-      RECT 59.240 0.840 59.520 258.160 ;
-      RECT 61.480 0.840 61.760 258.160 ;
-      RECT 63.720 0.840 64.000 258.160 ;
-      RECT 65.960 0.840 66.240 258.160 ;
-      RECT 68.200 0.840 68.480 258.160 ;
-      RECT 70.440 0.840 70.720 258.160 ;
-      RECT 72.680 0.840 72.960 258.160 ;
-      RECT 74.920 0.840 75.200 258.160 ;
-      RECT 77.160 0.840 77.440 258.160 ;
-      RECT 79.400 0.840 79.680 258.160 ;
-      RECT 81.640 0.840 81.920 258.160 ;
-      RECT 83.880 0.840 84.160 258.160 ;
-      RECT 86.120 0.840 86.400 258.160 ;
-      RECT 88.360 0.840 88.640 258.160 ;
-      RECT 90.600 0.840 90.880 258.160 ;
-      RECT 92.840 0.840 93.120 258.160 ;
-      RECT 95.080 0.840 95.360 258.160 ;
-      RECT 97.320 0.840 97.600 258.160 ;
-      RECT 99.560 0.840 99.840 258.160 ;
-      RECT 101.800 0.840 102.080 258.160 ;
-      RECT 104.040 0.840 104.320 258.160 ;
-      RECT 106.280 0.840 106.560 258.160 ;
-      RECT 108.520 0.840 108.800 258.160 ;
-      RECT 110.760 0.840 111.040 258.160 ;
-      RECT 113.000 0.840 113.280 258.160 ;
-      RECT 115.240 0.840 115.520 258.160 ;
-      RECT 117.480 0.840 117.760 258.160 ;
-      RECT 119.720 0.840 120.000 258.160 ;
-      RECT 121.960 0.840 122.240 258.160 ;
-      RECT 124.200 0.840 124.480 258.160 ;
-      RECT 126.440 0.840 126.720 258.160 ;
-      RECT 128.680 0.840 128.960 258.160 ;
-      RECT 130.920 0.840 131.200 258.160 ;
-      RECT 133.160 0.840 133.440 258.160 ;
-      RECT 135.400 0.840 135.680 258.160 ;
-      RECT 137.640 0.840 137.920 258.160 ;
-      RECT 139.880 0.840 140.160 258.160 ;
-      RECT 142.120 0.840 142.400 258.160 ;
-      RECT 144.360 0.840 144.640 258.160 ;
-      RECT 146.600 0.840 146.880 258.160 ;
-      RECT 148.840 0.840 149.120 258.160 ;
-      RECT 151.080 0.840 151.360 258.160 ;
-      RECT 153.320 0.840 153.600 258.160 ;
-      RECT 155.560 0.840 155.840 258.160 ;
-      RECT 157.800 0.840 158.080 258.160 ;
-      RECT 160.040 0.840 160.320 258.160 ;
-      RECT 162.280 0.840 162.560 258.160 ;
-      RECT 164.520 0.840 164.800 258.160 ;
-      RECT 166.760 0.840 167.040 258.160 ;
-      RECT 169.000 0.840 169.280 258.160 ;
-      RECT 171.240 0.840 171.520 258.160 ;
-      RECT 173.480 0.840 173.760 258.160 ;
-      RECT 175.720 0.840 176.000 258.160 ;
-      RECT 177.960 0.840 178.240 258.160 ;
-      RECT 180.200 0.840 180.480 258.160 ;
-      RECT 182.440 0.840 182.720 258.160 ;
-      RECT 184.680 0.840 184.960 258.160 ;
-      RECT 186.920 0.840 187.200 258.160 ;
+      RECT 1.000 0.840 1.280 451.360 ;
+      RECT 3.240 0.840 3.520 451.360 ;
+      RECT 5.480 0.840 5.760 451.360 ;
+      RECT 7.720 0.840 8.000 451.360 ;
+      RECT 9.960 0.840 10.240 451.360 ;
+      RECT 12.200 0.840 12.480 451.360 ;
+      RECT 14.440 0.840 14.720 451.360 ;
+      RECT 16.680 0.840 16.960 451.360 ;
+      RECT 18.920 0.840 19.200 451.360 ;
+      RECT 21.160 0.840 21.440 451.360 ;
+      RECT 23.400 0.840 23.680 451.360 ;
+      RECT 25.640 0.840 25.920 451.360 ;
+      RECT 27.880 0.840 28.160 451.360 ;
+      RECT 30.120 0.840 30.400 451.360 ;
+      RECT 32.360 0.840 32.640 451.360 ;
+      RECT 34.600 0.840 34.880 451.360 ;
+      RECT 36.840 0.840 37.120 451.360 ;
+      RECT 39.080 0.840 39.360 451.360 ;
+      RECT 41.320 0.840 41.600 451.360 ;
+      RECT 43.560 0.840 43.840 451.360 ;
+      RECT 45.800 0.840 46.080 451.360 ;
+      RECT 48.040 0.840 48.320 451.360 ;
+      RECT 50.280 0.840 50.560 451.360 ;
+      RECT 52.520 0.840 52.800 451.360 ;
+      RECT 54.760 0.840 55.040 451.360 ;
+      RECT 57.000 0.840 57.280 451.360 ;
+      RECT 59.240 0.840 59.520 451.360 ;
+      RECT 61.480 0.840 61.760 451.360 ;
+      RECT 63.720 0.840 64.000 451.360 ;
+      RECT 65.960 0.840 66.240 451.360 ;
+      RECT 68.200 0.840 68.480 451.360 ;
+      RECT 70.440 0.840 70.720 451.360 ;
+      RECT 72.680 0.840 72.960 451.360 ;
+      RECT 74.920 0.840 75.200 451.360 ;
+      RECT 77.160 0.840 77.440 451.360 ;
+      RECT 79.400 0.840 79.680 451.360 ;
+      RECT 81.640 0.840 81.920 451.360 ;
+      RECT 83.880 0.840 84.160 451.360 ;
+      RECT 86.120 0.840 86.400 451.360 ;
+      RECT 88.360 0.840 88.640 451.360 ;
+      RECT 90.600 0.840 90.880 451.360 ;
+      RECT 92.840 0.840 93.120 451.360 ;
+      RECT 95.080 0.840 95.360 451.360 ;
+      RECT 97.320 0.840 97.600 451.360 ;
+      RECT 99.560 0.840 99.840 451.360 ;
+      RECT 101.800 0.840 102.080 451.360 ;
+      RECT 104.040 0.840 104.320 451.360 ;
+      RECT 106.280 0.840 106.560 451.360 ;
+      RECT 108.520 0.840 108.800 451.360 ;
+      RECT 110.760 0.840 111.040 451.360 ;
+      RECT 113.000 0.840 113.280 451.360 ;
+      RECT 115.240 0.840 115.520 451.360 ;
+      RECT 117.480 0.840 117.760 451.360 ;
+      RECT 119.720 0.840 120.000 451.360 ;
+      RECT 121.960 0.840 122.240 451.360 ;
+      RECT 124.200 0.840 124.480 451.360 ;
+      RECT 126.440 0.840 126.720 451.360 ;
+      RECT 128.680 0.840 128.960 451.360 ;
+      RECT 130.920 0.840 131.200 451.360 ;
+      RECT 133.160 0.840 133.440 451.360 ;
+      RECT 135.400 0.840 135.680 451.360 ;
+      RECT 137.640 0.840 137.920 451.360 ;
+      RECT 139.880 0.840 140.160 451.360 ;
+      RECT 142.120 0.840 142.400 451.360 ;
+      RECT 144.360 0.840 144.640 451.360 ;
+      RECT 146.600 0.840 146.880 451.360 ;
+      RECT 148.840 0.840 149.120 451.360 ;
+      RECT 151.080 0.840 151.360 451.360 ;
+      RECT 153.320 0.840 153.600 451.360 ;
+      RECT 155.560 0.840 155.840 451.360 ;
+      RECT 157.800 0.840 158.080 451.360 ;
+      RECT 160.040 0.840 160.320 451.360 ;
+      RECT 162.280 0.840 162.560 451.360 ;
+      RECT 164.520 0.840 164.800 451.360 ;
+      RECT 166.760 0.840 167.040 451.360 ;
+      RECT 169.000 0.840 169.280 451.360 ;
+      RECT 171.240 0.840 171.520 451.360 ;
+      RECT 173.480 0.840 173.760 451.360 ;
+      RECT 175.720 0.840 176.000 451.360 ;
+      RECT 177.960 0.840 178.240 451.360 ;
+      RECT 180.200 0.840 180.480 451.360 ;
+      RECT 182.440 0.840 182.720 451.360 ;
+      RECT 184.680 0.840 184.960 451.360 ;
+      RECT 186.920 0.840 187.200 451.360 ;
+      RECT 189.160 0.840 189.440 451.360 ;
+      RECT 191.400 0.840 191.680 451.360 ;
+      RECT 193.640 0.840 193.920 451.360 ;
+      RECT 195.880 0.840 196.160 451.360 ;
+      RECT 198.120 0.840 198.400 451.360 ;
+      RECT 200.360 0.840 200.640 451.360 ;
+      RECT 202.600 0.840 202.880 451.360 ;
+      RECT 204.840 0.840 205.120 451.360 ;
+      RECT 207.080 0.840 207.360 451.360 ;
+      RECT 209.320 0.840 209.600 451.360 ;
+      RECT 211.560 0.840 211.840 451.360 ;
+      RECT 213.800 0.840 214.080 451.360 ;
+      RECT 216.040 0.840 216.320 451.360 ;
+      RECT 218.280 0.840 218.560 451.360 ;
+      RECT 220.520 0.840 220.800 451.360 ;
+      RECT 222.760 0.840 223.040 451.360 ;
+      RECT 225.000 0.840 225.280 451.360 ;
+      RECT 227.240 0.840 227.520 451.360 ;
+      RECT 229.480 0.840 229.760 451.360 ;
+      RECT 231.720 0.840 232.000 451.360 ;
+      RECT 233.960 0.840 234.240 451.360 ;
+      RECT 236.200 0.840 236.480 451.360 ;
+      RECT 238.440 0.840 238.720 451.360 ;
+      RECT 240.680 0.840 240.960 451.360 ;
+      RECT 242.920 0.840 243.200 451.360 ;
+      RECT 245.160 0.840 245.440 451.360 ;
+      RECT 247.400 0.840 247.680 451.360 ;
+      RECT 249.640 0.840 249.920 451.360 ;
+      RECT 251.880 0.840 252.160 451.360 ;
+      RECT 254.120 0.840 254.400 451.360 ;
+      RECT 256.360 0.840 256.640 451.360 ;
+      RECT 258.600 0.840 258.880 451.360 ;
+      RECT 260.840 0.840 261.120 451.360 ;
+      RECT 263.080 0.840 263.360 451.360 ;
+      RECT 265.320 0.840 265.600 451.360 ;
+      RECT 267.560 0.840 267.840 451.360 ;
+      RECT 269.800 0.840 270.080 451.360 ;
+      RECT 272.040 0.840 272.320 451.360 ;
+      RECT 274.280 0.840 274.560 451.360 ;
+      RECT 276.520 0.840 276.800 451.360 ;
+      RECT 278.760 0.840 279.040 451.360 ;
+      RECT 281.000 0.840 281.280 451.360 ;
+      RECT 283.240 0.840 283.520 451.360 ;
+      RECT 285.480 0.840 285.760 451.360 ;
+      RECT 287.720 0.840 288.000 451.360 ;
+      RECT 289.960 0.840 290.240 451.360 ;
+      RECT 292.200 0.840 292.480 451.360 ;
+      RECT 294.440 0.840 294.720 451.360 ;
+      RECT 296.680 0.840 296.960 451.360 ;
+      RECT 298.920 0.840 299.200 451.360 ;
+      RECT 301.160 0.840 301.440 451.360 ;
+      RECT 303.400 0.840 303.680 451.360 ;
+      RECT 305.640 0.840 305.920 451.360 ;
+      RECT 307.880 0.840 308.160 451.360 ;
+      RECT 310.120 0.840 310.400 451.360 ;
+      RECT 312.360 0.840 312.640 451.360 ;
+      RECT 314.600 0.840 314.880 451.360 ;
+      RECT 316.840 0.840 317.120 451.360 ;
+      RECT 319.080 0.840 319.360 451.360 ;
+      RECT 321.320 0.840 321.600 451.360 ;
+      RECT 323.560 0.840 323.840 451.360 ;
+      RECT 325.800 0.840 326.080 451.360 ;
+      RECT 328.040 0.840 328.320 451.360 ;
+      RECT 330.280 0.840 330.560 451.360 ;
+      RECT 332.520 0.840 332.800 451.360 ;
+      RECT 334.760 0.840 335.040 451.360 ;
+      RECT 337.000 0.840 337.280 451.360 ;
+      RECT 339.240 0.840 339.520 451.360 ;
+      RECT 341.480 0.840 341.760 451.360 ;
+      RECT 343.720 0.840 344.000 451.360 ;
+      RECT 345.960 0.840 346.240 451.360 ;
+      RECT 348.200 0.840 348.480 451.360 ;
+      RECT 350.440 0.840 350.720 451.360 ;
+      RECT 352.680 0.840 352.960 451.360 ;
+      RECT 354.920 0.840 355.200 451.360 ;
+      RECT 357.160 0.840 357.440 451.360 ;
+      RECT 359.400 0.840 359.680 451.360 ;
+      RECT 361.640 0.840 361.920 451.360 ;
+      RECT 363.880 0.840 364.160 451.360 ;
+      RECT 366.120 0.840 366.400 451.360 ;
+      RECT 368.360 0.840 368.640 451.360 ;
+      RECT 370.600 0.840 370.880 451.360 ;
+      RECT 372.840 0.840 373.120 451.360 ;
+      RECT 375.080 0.840 375.360 451.360 ;
     END
   END VSS
   PIN VDD
@@ -3782,104 +3902,188 @@ MACRO fakeram45_1rw1r_130w128d
     USE POWER ;
     PORT
       LAYER metal4 ;
-      RECT 1.000 0.840 1.280 258.160 ;
-      RECT 3.240 0.840 3.520 258.160 ;
-      RECT 5.480 0.840 5.760 258.160 ;
-      RECT 7.720 0.840 8.000 258.160 ;
-      RECT 9.960 0.840 10.240 258.160 ;
-      RECT 12.200 0.840 12.480 258.160 ;
-      RECT 14.440 0.840 14.720 258.160 ;
-      RECT 16.680 0.840 16.960 258.160 ;
-      RECT 18.920 0.840 19.200 258.160 ;
-      RECT 21.160 0.840 21.440 258.160 ;
-      RECT 23.400 0.840 23.680 258.160 ;
-      RECT 25.640 0.840 25.920 258.160 ;
-      RECT 27.880 0.840 28.160 258.160 ;
-      RECT 30.120 0.840 30.400 258.160 ;
-      RECT 32.360 0.840 32.640 258.160 ;
-      RECT 34.600 0.840 34.880 258.160 ;
-      RECT 36.840 0.840 37.120 258.160 ;
-      RECT 39.080 0.840 39.360 258.160 ;
-      RECT 41.320 0.840 41.600 258.160 ;
-      RECT 43.560 0.840 43.840 258.160 ;
-      RECT 45.800 0.840 46.080 258.160 ;
-      RECT 48.040 0.840 48.320 258.160 ;
-      RECT 50.280 0.840 50.560 258.160 ;
-      RECT 52.520 0.840 52.800 258.160 ;
-      RECT 54.760 0.840 55.040 258.160 ;
-      RECT 57.000 0.840 57.280 258.160 ;
-      RECT 59.240 0.840 59.520 258.160 ;
-      RECT 61.480 0.840 61.760 258.160 ;
-      RECT 63.720 0.840 64.000 258.160 ;
-      RECT 65.960 0.840 66.240 258.160 ;
-      RECT 68.200 0.840 68.480 258.160 ;
-      RECT 70.440 0.840 70.720 258.160 ;
-      RECT 72.680 0.840 72.960 258.160 ;
-      RECT 74.920 0.840 75.200 258.160 ;
-      RECT 77.160 0.840 77.440 258.160 ;
-      RECT 79.400 0.840 79.680 258.160 ;
-      RECT 81.640 0.840 81.920 258.160 ;
-      RECT 83.880 0.840 84.160 258.160 ;
-      RECT 86.120 0.840 86.400 258.160 ;
-      RECT 88.360 0.840 88.640 258.160 ;
-      RECT 90.600 0.840 90.880 258.160 ;
-      RECT 92.840 0.840 93.120 258.160 ;
-      RECT 95.080 0.840 95.360 258.160 ;
-      RECT 97.320 0.840 97.600 258.160 ;
-      RECT 99.560 0.840 99.840 258.160 ;
-      RECT 101.800 0.840 102.080 258.160 ;
-      RECT 104.040 0.840 104.320 258.160 ;
-      RECT 106.280 0.840 106.560 258.160 ;
-      RECT 108.520 0.840 108.800 258.160 ;
-      RECT 110.760 0.840 111.040 258.160 ;
-      RECT 113.000 0.840 113.280 258.160 ;
-      RECT 115.240 0.840 115.520 258.160 ;
-      RECT 117.480 0.840 117.760 258.160 ;
-      RECT 119.720 0.840 120.000 258.160 ;
-      RECT 121.960 0.840 122.240 258.160 ;
-      RECT 124.200 0.840 124.480 258.160 ;
-      RECT 126.440 0.840 126.720 258.160 ;
-      RECT 128.680 0.840 128.960 258.160 ;
-      RECT 130.920 0.840 131.200 258.160 ;
-      RECT 133.160 0.840 133.440 258.160 ;
-      RECT 135.400 0.840 135.680 258.160 ;
-      RECT 137.640 0.840 137.920 258.160 ;
-      RECT 139.880 0.840 140.160 258.160 ;
-      RECT 142.120 0.840 142.400 258.160 ;
-      RECT 144.360 0.840 144.640 258.160 ;
-      RECT 146.600 0.840 146.880 258.160 ;
-      RECT 148.840 0.840 149.120 258.160 ;
-      RECT 151.080 0.840 151.360 258.160 ;
-      RECT 153.320 0.840 153.600 258.160 ;
-      RECT 155.560 0.840 155.840 258.160 ;
-      RECT 157.800 0.840 158.080 258.160 ;
-      RECT 160.040 0.840 160.320 258.160 ;
-      RECT 162.280 0.840 162.560 258.160 ;
-      RECT 164.520 0.840 164.800 258.160 ;
-      RECT 166.760 0.840 167.040 258.160 ;
-      RECT 169.000 0.840 169.280 258.160 ;
-      RECT 171.240 0.840 171.520 258.160 ;
-      RECT 173.480 0.840 173.760 258.160 ;
-      RECT 175.720 0.840 176.000 258.160 ;
-      RECT 177.960 0.840 178.240 258.160 ;
-      RECT 180.200 0.840 180.480 258.160 ;
-      RECT 182.440 0.840 182.720 258.160 ;
-      RECT 184.680 0.840 184.960 258.160 ;
-      RECT 186.920 0.840 187.200 258.160 ;
+      RECT 1.000 0.840 1.280 451.360 ;
+      RECT 3.240 0.840 3.520 451.360 ;
+      RECT 5.480 0.840 5.760 451.360 ;
+      RECT 7.720 0.840 8.000 451.360 ;
+      RECT 9.960 0.840 10.240 451.360 ;
+      RECT 12.200 0.840 12.480 451.360 ;
+      RECT 14.440 0.840 14.720 451.360 ;
+      RECT 16.680 0.840 16.960 451.360 ;
+      RECT 18.920 0.840 19.200 451.360 ;
+      RECT 21.160 0.840 21.440 451.360 ;
+      RECT 23.400 0.840 23.680 451.360 ;
+      RECT 25.640 0.840 25.920 451.360 ;
+      RECT 27.880 0.840 28.160 451.360 ;
+      RECT 30.120 0.840 30.400 451.360 ;
+      RECT 32.360 0.840 32.640 451.360 ;
+      RECT 34.600 0.840 34.880 451.360 ;
+      RECT 36.840 0.840 37.120 451.360 ;
+      RECT 39.080 0.840 39.360 451.360 ;
+      RECT 41.320 0.840 41.600 451.360 ;
+      RECT 43.560 0.840 43.840 451.360 ;
+      RECT 45.800 0.840 46.080 451.360 ;
+      RECT 48.040 0.840 48.320 451.360 ;
+      RECT 50.280 0.840 50.560 451.360 ;
+      RECT 52.520 0.840 52.800 451.360 ;
+      RECT 54.760 0.840 55.040 451.360 ;
+      RECT 57.000 0.840 57.280 451.360 ;
+      RECT 59.240 0.840 59.520 451.360 ;
+      RECT 61.480 0.840 61.760 451.360 ;
+      RECT 63.720 0.840 64.000 451.360 ;
+      RECT 65.960 0.840 66.240 451.360 ;
+      RECT 68.200 0.840 68.480 451.360 ;
+      RECT 70.440 0.840 70.720 451.360 ;
+      RECT 72.680 0.840 72.960 451.360 ;
+      RECT 74.920 0.840 75.200 451.360 ;
+      RECT 77.160 0.840 77.440 451.360 ;
+      RECT 79.400 0.840 79.680 451.360 ;
+      RECT 81.640 0.840 81.920 451.360 ;
+      RECT 83.880 0.840 84.160 451.360 ;
+      RECT 86.120 0.840 86.400 451.360 ;
+      RECT 88.360 0.840 88.640 451.360 ;
+      RECT 90.600 0.840 90.880 451.360 ;
+      RECT 92.840 0.840 93.120 451.360 ;
+      RECT 95.080 0.840 95.360 451.360 ;
+      RECT 97.320 0.840 97.600 451.360 ;
+      RECT 99.560 0.840 99.840 451.360 ;
+      RECT 101.800 0.840 102.080 451.360 ;
+      RECT 104.040 0.840 104.320 451.360 ;
+      RECT 106.280 0.840 106.560 451.360 ;
+      RECT 108.520 0.840 108.800 451.360 ;
+      RECT 110.760 0.840 111.040 451.360 ;
+      RECT 113.000 0.840 113.280 451.360 ;
+      RECT 115.240 0.840 115.520 451.360 ;
+      RECT 117.480 0.840 117.760 451.360 ;
+      RECT 119.720 0.840 120.000 451.360 ;
+      RECT 121.960 0.840 122.240 451.360 ;
+      RECT 124.200 0.840 124.480 451.360 ;
+      RECT 126.440 0.840 126.720 451.360 ;
+      RECT 128.680 0.840 128.960 451.360 ;
+      RECT 130.920 0.840 131.200 451.360 ;
+      RECT 133.160 0.840 133.440 451.360 ;
+      RECT 135.400 0.840 135.680 451.360 ;
+      RECT 137.640 0.840 137.920 451.360 ;
+      RECT 139.880 0.840 140.160 451.360 ;
+      RECT 142.120 0.840 142.400 451.360 ;
+      RECT 144.360 0.840 144.640 451.360 ;
+      RECT 146.600 0.840 146.880 451.360 ;
+      RECT 148.840 0.840 149.120 451.360 ;
+      RECT 151.080 0.840 151.360 451.360 ;
+      RECT 153.320 0.840 153.600 451.360 ;
+      RECT 155.560 0.840 155.840 451.360 ;
+      RECT 157.800 0.840 158.080 451.360 ;
+      RECT 160.040 0.840 160.320 451.360 ;
+      RECT 162.280 0.840 162.560 451.360 ;
+      RECT 164.520 0.840 164.800 451.360 ;
+      RECT 166.760 0.840 167.040 451.360 ;
+      RECT 169.000 0.840 169.280 451.360 ;
+      RECT 171.240 0.840 171.520 451.360 ;
+      RECT 173.480 0.840 173.760 451.360 ;
+      RECT 175.720 0.840 176.000 451.360 ;
+      RECT 177.960 0.840 178.240 451.360 ;
+      RECT 180.200 0.840 180.480 451.360 ;
+      RECT 182.440 0.840 182.720 451.360 ;
+      RECT 184.680 0.840 184.960 451.360 ;
+      RECT 186.920 0.840 187.200 451.360 ;
+      RECT 189.160 0.840 189.440 451.360 ;
+      RECT 191.400 0.840 191.680 451.360 ;
+      RECT 193.640 0.840 193.920 451.360 ;
+      RECT 195.880 0.840 196.160 451.360 ;
+      RECT 198.120 0.840 198.400 451.360 ;
+      RECT 200.360 0.840 200.640 451.360 ;
+      RECT 202.600 0.840 202.880 451.360 ;
+      RECT 204.840 0.840 205.120 451.360 ;
+      RECT 207.080 0.840 207.360 451.360 ;
+      RECT 209.320 0.840 209.600 451.360 ;
+      RECT 211.560 0.840 211.840 451.360 ;
+      RECT 213.800 0.840 214.080 451.360 ;
+      RECT 216.040 0.840 216.320 451.360 ;
+      RECT 218.280 0.840 218.560 451.360 ;
+      RECT 220.520 0.840 220.800 451.360 ;
+      RECT 222.760 0.840 223.040 451.360 ;
+      RECT 225.000 0.840 225.280 451.360 ;
+      RECT 227.240 0.840 227.520 451.360 ;
+      RECT 229.480 0.840 229.760 451.360 ;
+      RECT 231.720 0.840 232.000 451.360 ;
+      RECT 233.960 0.840 234.240 451.360 ;
+      RECT 236.200 0.840 236.480 451.360 ;
+      RECT 238.440 0.840 238.720 451.360 ;
+      RECT 240.680 0.840 240.960 451.360 ;
+      RECT 242.920 0.840 243.200 451.360 ;
+      RECT 245.160 0.840 245.440 451.360 ;
+      RECT 247.400 0.840 247.680 451.360 ;
+      RECT 249.640 0.840 249.920 451.360 ;
+      RECT 251.880 0.840 252.160 451.360 ;
+      RECT 254.120 0.840 254.400 451.360 ;
+      RECT 256.360 0.840 256.640 451.360 ;
+      RECT 258.600 0.840 258.880 451.360 ;
+      RECT 260.840 0.840 261.120 451.360 ;
+      RECT 263.080 0.840 263.360 451.360 ;
+      RECT 265.320 0.840 265.600 451.360 ;
+      RECT 267.560 0.840 267.840 451.360 ;
+      RECT 269.800 0.840 270.080 451.360 ;
+      RECT 272.040 0.840 272.320 451.360 ;
+      RECT 274.280 0.840 274.560 451.360 ;
+      RECT 276.520 0.840 276.800 451.360 ;
+      RECT 278.760 0.840 279.040 451.360 ;
+      RECT 281.000 0.840 281.280 451.360 ;
+      RECT 283.240 0.840 283.520 451.360 ;
+      RECT 285.480 0.840 285.760 451.360 ;
+      RECT 287.720 0.840 288.000 451.360 ;
+      RECT 289.960 0.840 290.240 451.360 ;
+      RECT 292.200 0.840 292.480 451.360 ;
+      RECT 294.440 0.840 294.720 451.360 ;
+      RECT 296.680 0.840 296.960 451.360 ;
+      RECT 298.920 0.840 299.200 451.360 ;
+      RECT 301.160 0.840 301.440 451.360 ;
+      RECT 303.400 0.840 303.680 451.360 ;
+      RECT 305.640 0.840 305.920 451.360 ;
+      RECT 307.880 0.840 308.160 451.360 ;
+      RECT 310.120 0.840 310.400 451.360 ;
+      RECT 312.360 0.840 312.640 451.360 ;
+      RECT 314.600 0.840 314.880 451.360 ;
+      RECT 316.840 0.840 317.120 451.360 ;
+      RECT 319.080 0.840 319.360 451.360 ;
+      RECT 321.320 0.840 321.600 451.360 ;
+      RECT 323.560 0.840 323.840 451.360 ;
+      RECT 325.800 0.840 326.080 451.360 ;
+      RECT 328.040 0.840 328.320 451.360 ;
+      RECT 330.280 0.840 330.560 451.360 ;
+      RECT 332.520 0.840 332.800 451.360 ;
+      RECT 334.760 0.840 335.040 451.360 ;
+      RECT 337.000 0.840 337.280 451.360 ;
+      RECT 339.240 0.840 339.520 451.360 ;
+      RECT 341.480 0.840 341.760 451.360 ;
+      RECT 343.720 0.840 344.000 451.360 ;
+      RECT 345.960 0.840 346.240 451.360 ;
+      RECT 348.200 0.840 348.480 451.360 ;
+      RECT 350.440 0.840 350.720 451.360 ;
+      RECT 352.680 0.840 352.960 451.360 ;
+      RECT 354.920 0.840 355.200 451.360 ;
+      RECT 357.160 0.840 357.440 451.360 ;
+      RECT 359.400 0.840 359.680 451.360 ;
+      RECT 361.640 0.840 361.920 451.360 ;
+      RECT 363.880 0.840 364.160 451.360 ;
+      RECT 366.120 0.840 366.400 451.360 ;
+      RECT 368.360 0.840 368.640 451.360 ;
+      RECT 370.600 0.840 370.880 451.360 ;
+      RECT 372.840 0.840 373.120 451.360 ;
+      RECT 375.080 0.840 375.360 451.360 ;
     END
   END VDD
   OBS
     LAYER metal1 ;
-    RECT 0 0 188.290 259.000 ;
+    RECT 0 0 376.960 452.200 ;
     LAYER metal2 ;
-    RECT 0 0 188.290 259.000 ;
+    RECT 0 0 376.960 452.200 ;
     LAYER metal3 ;
-    RECT 0 0 188.290 259.000 ;
+    RECT 0 0 376.960 452.200 ;
     LAYER metal4 ;
-    RECT 0 0 188.290 259.000 ;
+    RECT 0 0 376.960 452.200 ;
     LAYER OVERLAP ;
-    RECT 0 0 188.290 259.000 ;
+    RECT 0 0 376.960 452.200 ;
   END
-END fakeram45_1rw1r_130w128d
+END fakeram_1rw1r_130w512d_sram
 
 END LIBRARY

--- a/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_230w128d_sram.lef
+++ b/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_230w128d_sram.lef
@@ -1,7 +1,7 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram45_1rw1r_230w128d
-  FOREIGN fakeram45_1rw1r_230w128d 0 0 ;
+MACRO fakeram_1rw1r_230w128d_sram
+  FOREIGN fakeram_1rw1r_230w128d_sram 0 0 ;
   SYMMETRY X Y R90 ;
   SIZE 231.040 BY 340.200 ;
   CLASS BLOCK ;
@@ -6618,6 +6618,6 @@ MACRO fakeram45_1rw1r_230w128d
     LAYER OVERLAP ;
     RECT 0 0 231.040 340.200 ;
   END
-END fakeram45_1rw1r_230w128d
+END fakeram_1rw1r_230w128d_sram
 
 END LIBRARY

--- a/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_92w256d_sram.lef
+++ b/designs/nangate45/litepci/sram/lef/fakeram_1rw1r_92w256d_sram.lef
@@ -1,7 +1,7 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram45_1rw1r_92w256d
-  FOREIGN fakeram45_1rw1r_92w256d 0 0 ;
+MACRO fakeram_1rw1r_92w256d_sram
+  FOREIGN fakeram_1rw1r_92w256d_sram 0 0 ;
   SYMMETRY X Y R90 ;
   SIZE 170.050 BY 308.000 ;
   CLASS BLOCK ;
@@ -2856,6 +2856,6 @@ MACRO fakeram45_1rw1r_92w256d
     LAYER OVERLAP ;
     RECT 0 0 170.050 308.000 ;
   END
-END fakeram45_1rw1r_92w256d
+END fakeram_1rw1r_92w256d_sram
 
 END LIBRARY

--- a/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_130w1024d_sram.lib
+++ b/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_130w1024d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram45_1rw1r_230w128d) {
+library(fakeram_1rw1r_130w1024d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:51Z";
+    date : "2026-05-19 17:28:16Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,68 +46,68 @@ library(fakeram45_1rw1r_230w128d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram45_1rw1r_230w128d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_230w128d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_230w128d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_130w1024d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_230w128d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram45_1rw1r_230w128d_DATA) {
+    type (fakeram_1rw1r_130w1024d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 230;
-        bit_from : 229;
+        bit_width : 130;
+        bit_from : 129;
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram45_1rw1r_230w128d_ADDRESS) {
+    type (fakeram_1rw1r_130w1024d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 7;
-        bit_from : 6;
+        bit_width : 10;
+        bit_from : 9;
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram45_1rw1r_230w128d) {
-    area : 78599.808;
+cell(fakeram_1rw1r_130w1024d_sram) {
+    area : 344901.984;
     interface_timing : true;
     memory() {
         type : ram;
-        address_width : 7;
-        word_width : 230;
+        address_width : 10;
+        word_width : 130;
     }
     pin(r0_clk)   {
         direction : input;
         capacitance : 0.025;
         clock : true;
-        min_period           : 0.325 ;
+        min_period           : 0.468 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("19.631, 19.631")
+                values ("45.940, 45.940")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("19.631, 19.631")
+                values ("45.940, 45.940")
             }
         }
     }
@@ -116,21 +116,21 @@ cell(fakeram45_1rw1r_230w128d) {
         direction : input;
         capacitance : 0.025;
         clock : true;
-        min_period           : 0.325 ;
+        min_period           : 0.468 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("19.631, 19.631")
+                values ("45.940, 45.940")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("19.631, 19.631")
+                values ("45.940, 45.940")
             }
         }
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram45_1rw1r_230w128d_DATA;
+        bus_type : fakeram_1rw1r_130w1024d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,34 +140,34 @@ cell(fakeram45_1rw1r_230w128d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_230w128d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.359, 0.359", \
-                  "0.359, 0.359" \
+                  "0.636, 0.636", \
+                  "0.636, 0.636" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_230w128d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.359, 0.359", \
-                  "0.359, 0.359" \
+                  "0.636, 0.636", \
+                  "0.636, 0.636" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_230w128d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_230w128d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram45_1rw1r_230w128d_DATA;
+        bus_type : fakeram_1rw1r_130w1024d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,27 +177,27 @@ cell(fakeram45_1rw1r_230w128d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_230w128d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.359, 0.359", \
-                  "0.359, 0.359" \
+                  "0.636, 0.636", \
+                  "0.636, 0.636" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_230w128d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.359, 0.359", \
-                  "0.359, 0.359" \
+                  "0.636, 0.636", \
+                  "0.636, 0.636" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_230w128d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_230w128d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
@@ -209,7 +209,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -247,13 +247,13 @@ cell(fakeram45_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
         }
     }
@@ -263,7 +263,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -301,13 +301,13 @@ cell(fakeram45_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
         }
     }
@@ -317,7 +317,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram45_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram45_1rw1r_230w128d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w1024d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram45_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram45_1rw1r_230w128d_DATA;
+        bus_type : fakeram_1rw1r_130w1024d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram45_1rw1r_230w128d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram45_1rw1r_230w128d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w1024d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram45_1rw1r_230w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram45_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -536,17 +536,17 @@ cell(fakeram45_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
-            fall_power(fakeram45_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.196, 0.196")
+                values ("0.459, 0.459")
             }
         }
     }
-    cell_leakage_power : 1804.210;
+    cell_leakage_power : 5703.950;
 }
 
 }

--- a/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_130w128d_sram.lib
+++ b/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_130w128d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram45_1rw1r_130w512d) {
+library(fakeram_1rw1r_130w128d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:48Z";
+    date : "2026-05-19 17:28:14Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,32 +46,32 @@ library(fakeram45_1rw1r_130w512d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram45_1rw1r_130w512d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_130w512d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_130w512d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_130w128d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_130w512d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram45_1rw1r_130w512d_DATA) {
+    type (fakeram_1rw1r_130w128d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
         bit_width : 130;
@@ -79,35 +79,35 @@ library(fakeram45_1rw1r_130w512d) {
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram45_1rw1r_130w512d_ADDRESS) {
+    type (fakeram_1rw1r_130w128d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 9;
-        bit_from : 8;
+        bit_width : 7;
+        bit_from : 6;
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram45_1rw1r_130w512d) {
-    area : 170461.312;
+cell(fakeram_1rw1r_130w128d_sram) {
+    area : 48767.110;
     interface_timing : true;
     memory() {
         type : ram;
-        address_width : 9;
+        address_width : 7;
         word_width : 130;
     }
     pin(r0_clk)   {
         direction : input;
         capacitance : 0.025;
         clock : true;
-        min_period           : 0.357 ;
+        min_period           : 0.278 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("32.803, 32.803")
+                values ("9.446, 9.446")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("32.803, 32.803")
+                values ("9.446, 9.446")
             }
         }
     }
@@ -116,21 +116,21 @@ cell(fakeram45_1rw1r_130w512d) {
         direction : input;
         capacitance : 0.025;
         clock : true;
-        min_period           : 0.357 ;
+        min_period           : 0.278 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("32.803, 32.803")
+                values ("9.446, 9.446")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("32.803, 32.803")
+                values ("9.446, 9.446")
             }
         }
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram45_1rw1r_130w512d_DATA;
+        bus_type : fakeram_1rw1r_130w128d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,34 +140,34 @@ cell(fakeram45_1rw1r_130w512d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_130w512d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.501, 0.501", \
-                  "0.501, 0.501" \
+                  "0.336, 0.336", \
+                  "0.336, 0.336" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_130w512d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.501, 0.501", \
-                  "0.501, 0.501" \
+                  "0.336, 0.336", \
+                  "0.336, 0.336" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_130w512d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_130w512d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram45_1rw1r_130w512d_DATA;
+        bus_type : fakeram_1rw1r_130w128d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,27 +177,27 @@ cell(fakeram45_1rw1r_130w512d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_130w512d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.501, 0.501", \
-                  "0.501, 0.501" \
+                  "0.336, 0.336", \
+                  "0.336, 0.336" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_130w512d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.501, 0.501", \
-                  "0.501, 0.501" \
+                  "0.336, 0.336", \
+                  "0.336, 0.336" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_130w512d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_130w512d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
@@ -209,7 +209,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -247,13 +247,13 @@ cell(fakeram45_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
         }
     }
@@ -263,7 +263,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -301,13 +301,13 @@ cell(fakeram45_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
         }
     }
@@ -317,7 +317,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram45_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram45_1rw1r_130w512d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w128d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram45_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram45_1rw1r_130w512d_DATA;
+        bus_type : fakeram_1rw1r_130w128d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram45_1rw1r_130w512d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram45_1rw1r_130w512d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w128d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram45_1rw1r_130w512d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram45_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -536,17 +536,17 @@ cell(fakeram45_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
-            fall_power(fakeram45_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.328, 0.328")
+                values ("0.094, 0.094")
             }
         }
     }
-    cell_leakage_power : 3363.500;
+    cell_leakage_power : 1105.440;
 }
 
 }

--- a/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_130w512d_sram.lib
+++ b/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_130w512d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram45_1rw1r_130w128d) {
+library(fakeram_1rw1r_130w512d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:47Z";
+    date : "2026-05-19 17:28:15Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,32 +46,32 @@ library(fakeram45_1rw1r_130w128d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram45_1rw1r_130w128d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_130w128d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_130w128d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_130w512d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_130w128d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram45_1rw1r_130w128d_DATA) {
+    type (fakeram_1rw1r_130w512d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
         bit_width : 130;
@@ -79,35 +79,35 @@ library(fakeram45_1rw1r_130w128d) {
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram45_1rw1r_130w128d_ADDRESS) {
+    type (fakeram_1rw1r_130w512d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 7;
-        bit_from : 6;
+        bit_width : 9;
+        bit_from : 8;
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram45_1rw1r_130w128d) {
-    area : 48767.110;
+cell(fakeram_1rw1r_130w512d_sram) {
+    area : 170461.312;
     interface_timing : true;
     memory() {
         type : ram;
-        address_width : 7;
+        address_width : 9;
         word_width : 130;
     }
     pin(r0_clk)   {
         direction : input;
         capacitance : 0.025;
         clock : true;
-        min_period           : 0.278 ;
+        min_period           : 0.357 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("9.446, 9.446")
+                values ("32.803, 32.803")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("9.446, 9.446")
+                values ("32.803, 32.803")
             }
         }
     }
@@ -116,21 +116,21 @@ cell(fakeram45_1rw1r_130w128d) {
         direction : input;
         capacitance : 0.025;
         clock : true;
-        min_period           : 0.278 ;
+        min_period           : 0.357 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("9.446, 9.446")
+                values ("32.803, 32.803")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("9.446, 9.446")
+                values ("32.803, 32.803")
             }
         }
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram45_1rw1r_130w128d_DATA;
+        bus_type : fakeram_1rw1r_130w512d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,34 +140,34 @@ cell(fakeram45_1rw1r_130w128d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_130w128d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.336, 0.336", \
-                  "0.336, 0.336" \
+                  "0.501, 0.501", \
+                  "0.501, 0.501" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_130w128d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.336, 0.336", \
-                  "0.336, 0.336" \
+                  "0.501, 0.501", \
+                  "0.501, 0.501" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_130w128d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_130w128d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram45_1rw1r_130w128d_DATA;
+        bus_type : fakeram_1rw1r_130w512d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,27 +177,27 @@ cell(fakeram45_1rw1r_130w128d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_130w128d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.336, 0.336", \
-                  "0.336, 0.336" \
+                  "0.501, 0.501", \
+                  "0.501, 0.501" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_130w128d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.336, 0.336", \
-                  "0.336, 0.336" \
+                  "0.501, 0.501", \
+                  "0.501, 0.501" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_130w128d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_130w128d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
@@ -209,7 +209,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -247,13 +247,13 @@ cell(fakeram45_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
         }
     }
@@ -263,7 +263,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -301,13 +301,13 @@ cell(fakeram45_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
         }
     }
@@ -317,7 +317,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram45_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram45_1rw1r_130w128d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w512d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram45_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram45_1rw1r_130w128d_DATA;
+        bus_type : fakeram_1rw1r_130w512d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram45_1rw1r_130w128d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram45_1rw1r_130w128d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w512d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram45_1rw1r_130w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram45_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -536,17 +536,17 @@ cell(fakeram45_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
-            fall_power(fakeram45_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.094, 0.094")
+                values ("0.328, 0.328")
             }
         }
     }
-    cell_leakage_power : 1105.440;
+    cell_leakage_power : 3363.500;
 }
 
 }

--- a/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_230w128d_sram.lib
+++ b/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_230w128d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram45_1rw1r_130w1024d) {
+library(fakeram_1rw1r_230w128d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:50Z";
+    date : "2026-05-19 17:28:17Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,68 +46,68 @@ library(fakeram45_1rw1r_130w1024d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram45_1rw1r_130w1024d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_130w1024d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_130w1024d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_230w128d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_130w1024d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram45_1rw1r_130w1024d_DATA) {
+    type (fakeram_1rw1r_230w128d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 130;
-        bit_from : 129;
+        bit_width : 230;
+        bit_from : 229;
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram45_1rw1r_130w1024d_ADDRESS) {
+    type (fakeram_1rw1r_230w128d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 10;
-        bit_from : 9;
+        bit_width : 7;
+        bit_from : 6;
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram45_1rw1r_130w1024d) {
-    area : 344901.984;
+cell(fakeram_1rw1r_230w128d_sram) {
+    area : 78599.808;
     interface_timing : true;
     memory() {
         type : ram;
-        address_width : 10;
-        word_width : 130;
+        address_width : 7;
+        word_width : 230;
     }
     pin(r0_clk)   {
         direction : input;
         capacitance : 0.025;
         clock : true;
-        min_period           : 0.468 ;
+        min_period           : 0.325 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("45.940, 45.940")
+                values ("19.631, 19.631")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("45.940, 45.940")
+                values ("19.631, 19.631")
             }
         }
     }
@@ -116,21 +116,21 @@ cell(fakeram45_1rw1r_130w1024d) {
         direction : input;
         capacitance : 0.025;
         clock : true;
-        min_period           : 0.468 ;
+        min_period           : 0.325 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("45.940, 45.940")
+                values ("19.631, 19.631")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
-                values ("45.940, 45.940")
+                values ("19.631, 19.631")
             }
         }
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram45_1rw1r_130w1024d_DATA;
+        bus_type : fakeram_1rw1r_230w128d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,34 +140,34 @@ cell(fakeram45_1rw1r_130w1024d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_130w1024d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.636, 0.636", \
-                  "0.636, 0.636" \
+                  "0.359, 0.359", \
+                  "0.359, 0.359" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_130w1024d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.636, 0.636", \
-                  "0.636, 0.636" \
+                  "0.359, 0.359", \
+                  "0.359, 0.359" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_130w1024d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_130w1024d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram45_1rw1r_130w1024d_DATA;
+        bus_type : fakeram_1rw1r_230w128d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,27 +177,27 @@ cell(fakeram45_1rw1r_130w1024d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_130w1024d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.636, 0.636", \
-                  "0.636, 0.636" \
+                  "0.359, 0.359", \
+                  "0.359, 0.359" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_130w1024d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
-                  "0.636, 0.636", \
-                  "0.636, 0.636" \
+                  "0.359, 0.359", \
+                  "0.359, 0.359" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_130w1024d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_130w1024d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
@@ -209,7 +209,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -247,13 +247,13 @@ cell(fakeram45_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
         }
     }
@@ -263,7 +263,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -301,13 +301,13 @@ cell(fakeram45_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
         }
     }
@@ -317,7 +317,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram45_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram45_1rw1r_130w1024d_ADDRESS;
+        bus_type : fakeram_1rw1r_230w128d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram45_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram45_1rw1r_130w1024d_DATA;
+        bus_type : fakeram_1rw1r_230w128d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram45_1rw1r_130w1024d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram45_1rw1r_130w1024d_ADDRESS;
+        bus_type : fakeram_1rw1r_230w128d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram45_1rw1r_130w1024d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram45_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -536,17 +536,17 @@ cell(fakeram45_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
-            fall_power(fakeram45_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
-                values ("0.459, 0.459")
+                values ("0.196, 0.196")
             }
         }
     }
-    cell_leakage_power : 5703.950;
+    cell_leakage_power : 1804.210;
 }
 
 }

--- a/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_92w256d_sram.lib
+++ b/designs/nangate45/litepci/sram/lib/fakeram_1rw1r_92w256d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram45_1rw1r_92w256d) {
+library(fakeram_1rw1r_92w256d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:47Z";
+    date : "2026-05-19 17:28:13Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,32 +46,32 @@ library(fakeram45_1rw1r_92w256d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram45_1rw1r_92w256d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_92w256d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram45_1rw1r_92w256d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_92w256d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_92w256d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram45_1rw1r_92w256d_DATA) {
+    type (fakeram_1rw1r_92w256d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
         bit_width : 92;
@@ -79,7 +79,7 @@ library(fakeram45_1rw1r_92w256d) {
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram45_1rw1r_92w256d_ADDRESS) {
+    type (fakeram_1rw1r_92w256d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
         bit_width : 8;
@@ -87,7 +87,7 @@ library(fakeram45_1rw1r_92w256d) {
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram45_1rw1r_92w256d) {
+cell(fakeram_1rw1r_92w256d_sram) {
     area : 52375.400;
     interface_timing : true;
     memory() {
@@ -101,11 +101,11 @@ cell(fakeram45_1rw1r_92w256d) {
         clock : true;
         min_period           : 0.313 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
                 values ("8.307, 8.307")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
                 values ("8.307, 8.307")
             }
@@ -118,11 +118,11 @@ cell(fakeram45_1rw1r_92w256d) {
         clock : true;
         min_period           : 0.313 ;
         internal_power(){
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
                 values ("8.307, 8.307")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
                 index_1 ("0.009, 0.227");
                 values ("8.307, 8.307")
             }
@@ -130,7 +130,7 @@ cell(fakeram45_1rw1r_92w256d) {
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram45_1rw1r_92w256d_DATA;
+        bus_type : fakeram_1rw1r_92w256d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,7 +140,7 @@ cell(fakeram45_1rw1r_92w256d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_92w256d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -148,7 +148,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.378, 0.378" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_92w256d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -156,18 +156,18 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.378, 0.378" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_92w256d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_92w256d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram45_1rw1r_92w256d_DATA;
+        bus_type : fakeram_1rw1r_92w256d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,7 +177,7 @@ cell(fakeram45_1rw1r_92w256d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram45_1rw1r_92w256d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -185,7 +185,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.378, 0.378" \
                 )
             }
-            cell_fall(fakeram45_1rw1r_92w256d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -193,11 +193,11 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.378, 0.378" \
                 )
             }
-            rise_transition(fakeram45_1rw1r_92w256d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
-            fall_transition(fakeram45_1rw1r_92w256d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.009, 0.227")
             }
@@ -209,7 +209,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -247,11 +247,11 @@ cell(fakeram45_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
@@ -263,7 +263,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -301,11 +301,11 @@ cell(fakeram45_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
@@ -317,7 +317,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram45_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram45_1rw1r_92w256d_ADDRESS;
+        bus_type : fakeram_1rw1r_92w256d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram45_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram45_1rw1r_92w256d_DATA;
+        bus_type : fakeram_1rw1r_92w256d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram45_1rw1r_92w256d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram45_1rw1r_92w256d_ADDRESS;
+        bus_type : fakeram_1rw1r_92w256d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram45_1rw1r_92w256d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram45_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram45_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.009, 0.227");
                 index_2 ("0.009, 0.227");
                 values ( \
@@ -536,11 +536,11 @@ cell(fakeram45_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }
-            fall_power(fakeram45_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.009, 0.227");
                 values ("0.083, 0.083")
             }

--- a/designs/src/litepci/dev/generated/fakeram_nangate45.cfg
+++ b/designs/src/litepci/dev/generated/fakeram_nangate45.cfg
@@ -11,10 +11,10 @@
   "flipPins": true,
 
   "srams": [
-    { "name": "fakeram45_1rw1r_92w256d",  "width":  92, "depth":  256, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
-    { "name": "fakeram45_1rw1r_130w128d", "width": 130, "depth":  128, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
-    { "name": "fakeram45_1rw1r_130w512d", "width": 130, "depth":  512, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
-    { "name": "fakeram45_1rw1r_130w1024d","width": 130, "depth": 1024, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
-    { "name": "fakeram45_1rw1r_230w128d", "width": 230, "depth":  128, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} }
+    { "name": "fakeram_1rw1r_92w256d_sram",  "width":  92, "depth":  256, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
+    { "name": "fakeram_1rw1r_130w128d_sram", "width": 130, "depth":  128, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
+    { "name": "fakeram_1rw1r_130w512d_sram", "width": 130, "depth":  512, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
+    { "name": "fakeram_1rw1r_130w1024d_sram","width": 130, "depth": 1024, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
+    { "name": "fakeram_1rw1r_230w128d_sram", "width": 230, "depth":  128, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} }
   ]
 }


### PR DESCRIPTION
## Summary

Renames the nangate45/litepci FakeRAM macros to the unified `fakeram_1rw1r_<W>w<D>d_sram` naming convention used by `designs/src/litepci/litepcie_core.v`. This fixes nangate45/litepci, which has been failing on main with 'Module \`fakeram_1rw1r_230w128d_sram\` not part of the design'.

## Changes

11 files: 5 LEF + 5 LIB renames in `designs/nangate45/litepci/sram/{lef,lib}/` plus the corresponding `designs/src/litepci/dev/generated/fakeram_nangate45.cfg` rename of the `name:` fields. Content is unchanged — the LEFs/LIBs are regenerated under the new names via `tools/regenerate_sram.sh litepci nangate45` (post-bsg_fakeram wd_in fix, so they're electrically valid).

| Old name | New name |
|---|---|
| `fakeram45_1rw1r_92w256d` | `fakeram_1rw1r_92w256d_sram` |
| `fakeram45_1rw1r_130w128d` | `fakeram_1rw1r_130w128d_sram` |
| `fakeram45_1rw1r_130w512d` | `fakeram_1rw1r_130w512d_sram` |
| `fakeram45_1rw1r_130w1024d` | `fakeram_1rw1r_130w1024d_sram` |
| `fakeram45_1rw1r_230w128d` | `fakeram_1rw1r_230w128d_sram` |

## Validation

Built end-to-end on NRP k8s: **nangate45/litepci closed in 35 m** on the precursor branch (`litepci-multiplat-fix-v2` / `c75ea180`, which carried both n45+sky changes together).

## Scope

Deliberately **nangate45-only**. The sister sky130hd portion of `c75ea180` was excluded because sky130hd/litepci fails independently with real GRT congestion (`Net rst fanout 3211` + 'Global routing failed' on both attempts, 4h each) — a separate design-physical issue beyond the macro-naming fix. Sky/litepci stays in its existing main state (already broken per project memory).