### PR TITLE
sky130hd/litepci: route-fix via spread lever (util 30 / density 0.40 / halo 100) — now closes

### DIFF
--- a/designs/sky130hd/litepci/BUILD.bazel
+++ b/designs/sky130hd/litepci/BUILD.bazel
@@ -43,9 +43,9 @@ hightide_design(
         # Round-2 PPA tune: 45%→55% util (GRT peak at 45% was 19% on met2 —
         # plenty of room).  pcie_us LEF settled at 1000×1000 µm (885 µm pin
         # column + margin).
-        "CORE_UTILIZATION": "40",
-        "PLACE_DENSITY": "0.55",
-        "MACRO_PLACE_HALO": "60 60",
+        "CORE_UTILIZATION": "30",
+        "PLACE_DENSITY": "0.40",
+        "MACRO_PLACE_HALO": "100 100",
         "GDS_ALLOW_EMPTY": "fakeram.*|pcie_us",
         # See asap7 BUILD.bazel — flow does not yet patch litepcie's
         # inferred memories to explicit fakeram instances.

--- a/designs/sky130hd/litepci/BUILD.bazel
+++ b/designs/sky130hd/litepci/BUILD.bazel
@@ -43,9 +43,9 @@ hightide_design(
         # Round-2 PPA tune: 45%→55% util (GRT peak at 45% was 19% on met2 —
         # plenty of room).  pcie_us LEF settled at 1000×1000 µm (885 µm pin
         # column + margin).
-        "CORE_UTILIZATION": "55",
-        "PLACE_DENSITY": "0.65",
-        "MACRO_PLACE_HALO": "20 20",
+        "CORE_UTILIZATION": "40",
+        "PLACE_DENSITY": "0.55",
+        "MACRO_PLACE_HALO": "60 60",
         "GDS_ALLOW_EMPTY": "fakeram.*|pcie_us",
         # See asap7 BUILD.bazel — flow does not yet patch litepcie's
         # inferred memories to explicit fakeram instances.

--- a/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_130w1024d_sram.lef
+++ b/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_130w1024d_sram.lef
@@ -1,9 +1,9 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram130_1rw1r_130w512d
-  FOREIGN fakeram130_1rw1r_130w512d 0 0 ;
+MACRO fakeram_1rw1r_130w1024d_sram
+  FOREIGN fakeram_1rw1r_130w1024d_sram 0 0 ;
   SYMMETRY X Y R90 ;
-  SIZE 1182.660 BY 1895.840 ;
+  SIZE 2364.860 BY 1895.840 ;
   CLASS BLOCK ;
   PIN rw0_wd_in[0]
     DIRECTION INPUT ;
@@ -20,7 +20,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 48.810 0.900 49.110 ;
+      RECT 0.000 47.450 0.900 47.750 ;
     END
   END rw0_wd_in[1]
   PIN rw0_wd_in[2]
@@ -29,7 +29,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 93.690 0.900 93.990 ;
+      RECT 0.000 90.970 0.900 91.270 ;
     END
   END rw0_wd_in[2]
   PIN rw0_wd_in[3]
@@ -38,7 +38,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 138.570 0.900 138.870 ;
+      RECT 0.000 134.490 0.900 134.790 ;
     END
   END rw0_wd_in[3]
   PIN rw0_wd_in[4]
@@ -47,7 +47,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 183.450 0.900 183.750 ;
+      RECT 0.000 178.010 0.900 178.310 ;
     END
   END rw0_wd_in[4]
   PIN rw0_wd_in[5]
@@ -56,7 +56,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 228.330 0.900 228.630 ;
+      RECT 0.000 221.530 0.900 221.830 ;
     END
   END rw0_wd_in[5]
   PIN rw0_wd_in[6]
@@ -65,7 +65,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 273.210 0.900 273.510 ;
+      RECT 0.000 265.050 0.900 265.350 ;
     END
   END rw0_wd_in[6]
   PIN rw0_wd_in[7]
@@ -74,7 +74,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 318.090 0.900 318.390 ;
+      RECT 0.000 308.570 0.900 308.870 ;
     END
   END rw0_wd_in[7]
   PIN rw0_wd_in[8]
@@ -83,7 +83,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 362.970 0.900 363.270 ;
+      RECT 0.000 352.090 0.900 352.390 ;
     END
   END rw0_wd_in[8]
   PIN rw0_wd_in[9]
@@ -92,7 +92,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 407.850 0.900 408.150 ;
+      RECT 0.000 395.610 0.900 395.910 ;
     END
   END rw0_wd_in[9]
   PIN rw0_wd_in[10]
@@ -101,7 +101,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 452.730 0.900 453.030 ;
+      RECT 0.000 439.130 0.900 439.430 ;
     END
   END rw0_wd_in[10]
   PIN rw0_wd_in[11]
@@ -110,7 +110,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 497.610 0.900 497.910 ;
+      RECT 0.000 482.650 0.900 482.950 ;
     END
   END rw0_wd_in[11]
   PIN rw0_wd_in[12]
@@ -119,7 +119,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 542.490 0.900 542.790 ;
+      RECT 0.000 526.170 0.900 526.470 ;
     END
   END rw0_wd_in[12]
   PIN rw0_wd_in[13]
@@ -128,7 +128,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 587.370 0.900 587.670 ;
+      RECT 0.000 569.690 0.900 569.990 ;
     END
   END rw0_wd_in[13]
   PIN rw0_wd_in[14]
@@ -137,7 +137,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 632.250 0.900 632.550 ;
+      RECT 0.000 613.210 0.900 613.510 ;
     END
   END rw0_wd_in[14]
   PIN rw0_wd_in[15]
@@ -146,7 +146,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 677.130 0.900 677.430 ;
+      RECT 0.000 656.730 0.900 657.030 ;
     END
   END rw0_wd_in[15]
   PIN rw0_wd_in[16]
@@ -155,7 +155,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 722.010 0.900 722.310 ;
+      RECT 0.000 700.250 0.900 700.550 ;
     END
   END rw0_wd_in[16]
   PIN rw0_wd_in[17]
@@ -164,7 +164,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 766.890 0.900 767.190 ;
+      RECT 0.000 743.770 0.900 744.070 ;
     END
   END rw0_wd_in[17]
   PIN rw0_wd_in[18]
@@ -173,7 +173,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 811.770 0.900 812.070 ;
+      RECT 0.000 787.290 0.900 787.590 ;
     END
   END rw0_wd_in[18]
   PIN rw0_wd_in[19]
@@ -182,7 +182,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 856.650 0.900 856.950 ;
+      RECT 0.000 830.810 0.900 831.110 ;
     END
   END rw0_wd_in[19]
   PIN rw0_wd_in[20]
@@ -191,7 +191,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 901.530 0.900 901.830 ;
+      RECT 0.000 874.330 0.900 874.630 ;
     END
   END rw0_wd_in[20]
   PIN rw0_wd_in[21]
@@ -200,7 +200,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 946.410 0.900 946.710 ;
+      RECT 0.000 917.850 0.900 918.150 ;
     END
   END rw0_wd_in[21]
   PIN rw0_wd_in[22]
@@ -209,7 +209,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 991.290 0.900 991.590 ;
+      RECT 0.000 961.370 0.900 961.670 ;
     END
   END rw0_wd_in[22]
   PIN rw0_wd_in[23]
@@ -218,7 +218,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1036.170 0.900 1036.470 ;
+      RECT 0.000 1004.890 0.900 1005.190 ;
     END
   END rw0_wd_in[23]
   PIN rw0_wd_in[24]
@@ -227,7 +227,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1081.050 0.900 1081.350 ;
+      RECT 0.000 1048.410 0.900 1048.710 ;
     END
   END rw0_wd_in[24]
   PIN rw0_wd_in[25]
@@ -236,7 +236,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1125.930 0.900 1126.230 ;
+      RECT 0.000 1091.930 0.900 1092.230 ;
     END
   END rw0_wd_in[25]
   PIN rw0_wd_in[26]
@@ -245,7 +245,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1170.810 0.900 1171.110 ;
+      RECT 0.000 1135.450 0.900 1135.750 ;
     END
   END rw0_wd_in[26]
   PIN rw0_wd_in[27]
@@ -254,7 +254,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1215.690 0.900 1215.990 ;
+      RECT 0.000 1178.970 0.900 1179.270 ;
     END
   END rw0_wd_in[27]
   PIN rw0_wd_in[28]
@@ -263,7 +263,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1260.570 0.900 1260.870 ;
+      RECT 0.000 1222.490 0.900 1222.790 ;
     END
   END rw0_wd_in[28]
   PIN rw0_wd_in[29]
@@ -272,7 +272,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1305.450 0.900 1305.750 ;
+      RECT 0.000 1266.010 0.900 1266.310 ;
     END
   END rw0_wd_in[29]
   PIN rw0_wd_in[30]
@@ -281,7 +281,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1350.330 0.900 1350.630 ;
+      RECT 0.000 1309.530 0.900 1309.830 ;
     END
   END rw0_wd_in[30]
   PIN rw0_wd_in[31]
@@ -290,7 +290,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1395.210 0.900 1395.510 ;
+      RECT 0.000 1353.050 0.900 1353.350 ;
     END
   END rw0_wd_in[31]
   PIN rw0_wd_in[32]
@@ -299,7 +299,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1440.090 0.900 1440.390 ;
+      RECT 0.000 1396.570 0.900 1396.870 ;
     END
   END rw0_wd_in[32]
   PIN rw0_wd_in[33]
@@ -308,7 +308,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 3.930 1182.660 4.230 ;
+      RECT 2363.960 3.930 2364.860 4.230 ;
     END
   END rw0_wd_in[33]
   PIN rw0_wd_in[34]
@@ -317,7 +317,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 48.810 1182.660 49.110 ;
+      RECT 2363.960 47.450 2364.860 47.750 ;
     END
   END rw0_wd_in[34]
   PIN rw0_wd_in[35]
@@ -326,7 +326,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 93.690 1182.660 93.990 ;
+      RECT 2363.960 90.970 2364.860 91.270 ;
     END
   END rw0_wd_in[35]
   PIN rw0_wd_in[36]
@@ -335,7 +335,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 138.570 1182.660 138.870 ;
+      RECT 2363.960 134.490 2364.860 134.790 ;
     END
   END rw0_wd_in[36]
   PIN rw0_wd_in[37]
@@ -344,7 +344,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 183.450 1182.660 183.750 ;
+      RECT 2363.960 178.010 2364.860 178.310 ;
     END
   END rw0_wd_in[37]
   PIN rw0_wd_in[38]
@@ -353,7 +353,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 228.330 1182.660 228.630 ;
+      RECT 2363.960 221.530 2364.860 221.830 ;
     END
   END rw0_wd_in[38]
   PIN rw0_wd_in[39]
@@ -362,7 +362,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 273.210 1182.660 273.510 ;
+      RECT 2363.960 265.050 2364.860 265.350 ;
     END
   END rw0_wd_in[39]
   PIN rw0_wd_in[40]
@@ -371,7 +371,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 318.090 1182.660 318.390 ;
+      RECT 2363.960 308.570 2364.860 308.870 ;
     END
   END rw0_wd_in[40]
   PIN rw0_wd_in[41]
@@ -380,7 +380,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 362.970 1182.660 363.270 ;
+      RECT 2363.960 352.090 2364.860 352.390 ;
     END
   END rw0_wd_in[41]
   PIN rw0_wd_in[42]
@@ -389,7 +389,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 407.850 1182.660 408.150 ;
+      RECT 2363.960 395.610 2364.860 395.910 ;
     END
   END rw0_wd_in[42]
   PIN rw0_wd_in[43]
@@ -398,7 +398,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 452.730 1182.660 453.030 ;
+      RECT 2363.960 439.130 2364.860 439.430 ;
     END
   END rw0_wd_in[43]
   PIN rw0_wd_in[44]
@@ -407,7 +407,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 497.610 1182.660 497.910 ;
+      RECT 2363.960 482.650 2364.860 482.950 ;
     END
   END rw0_wd_in[44]
   PIN rw0_wd_in[45]
@@ -416,7 +416,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 542.490 1182.660 542.790 ;
+      RECT 2363.960 526.170 2364.860 526.470 ;
     END
   END rw0_wd_in[45]
   PIN rw0_wd_in[46]
@@ -425,7 +425,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 587.370 1182.660 587.670 ;
+      RECT 2363.960 569.690 2364.860 569.990 ;
     END
   END rw0_wd_in[46]
   PIN rw0_wd_in[47]
@@ -434,7 +434,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 632.250 1182.660 632.550 ;
+      RECT 2363.960 613.210 2364.860 613.510 ;
     END
   END rw0_wd_in[47]
   PIN rw0_wd_in[48]
@@ -443,7 +443,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 677.130 1182.660 677.430 ;
+      RECT 2363.960 656.730 2364.860 657.030 ;
     END
   END rw0_wd_in[48]
   PIN rw0_wd_in[49]
@@ -452,7 +452,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 722.010 1182.660 722.310 ;
+      RECT 2363.960 700.250 2364.860 700.550 ;
     END
   END rw0_wd_in[49]
   PIN rw0_wd_in[50]
@@ -461,7 +461,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 766.890 1182.660 767.190 ;
+      RECT 2363.960 743.770 2364.860 744.070 ;
     END
   END rw0_wd_in[50]
   PIN rw0_wd_in[51]
@@ -470,7 +470,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 811.770 1182.660 812.070 ;
+      RECT 2363.960 787.290 2364.860 787.590 ;
     END
   END rw0_wd_in[51]
   PIN rw0_wd_in[52]
@@ -479,7 +479,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 856.650 1182.660 856.950 ;
+      RECT 2363.960 830.810 2364.860 831.110 ;
     END
   END rw0_wd_in[52]
   PIN rw0_wd_in[53]
@@ -488,7 +488,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 901.530 1182.660 901.830 ;
+      RECT 2363.960 874.330 2364.860 874.630 ;
     END
   END rw0_wd_in[53]
   PIN rw0_wd_in[54]
@@ -497,7 +497,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 946.410 1182.660 946.710 ;
+      RECT 2363.960 917.850 2364.860 918.150 ;
     END
   END rw0_wd_in[54]
   PIN rw0_wd_in[55]
@@ -506,7 +506,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 991.290 1182.660 991.590 ;
+      RECT 2363.960 961.370 2364.860 961.670 ;
     END
   END rw0_wd_in[55]
   PIN rw0_wd_in[56]
@@ -515,7 +515,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1036.170 1182.660 1036.470 ;
+      RECT 2363.960 1004.890 2364.860 1005.190 ;
     END
   END rw0_wd_in[56]
   PIN rw0_wd_in[57]
@@ -524,7 +524,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1081.050 1182.660 1081.350 ;
+      RECT 2363.960 1048.410 2364.860 1048.710 ;
     END
   END rw0_wd_in[57]
   PIN rw0_wd_in[58]
@@ -533,7 +533,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1125.930 1182.660 1126.230 ;
+      RECT 2363.960 1091.930 2364.860 1092.230 ;
     END
   END rw0_wd_in[58]
   PIN rw0_wd_in[59]
@@ -542,7 +542,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1170.810 1182.660 1171.110 ;
+      RECT 2363.960 1135.450 2364.860 1135.750 ;
     END
   END rw0_wd_in[59]
   PIN rw0_wd_in[60]
@@ -551,7 +551,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1215.690 1182.660 1215.990 ;
+      RECT 2363.960 1178.970 2364.860 1179.270 ;
     END
   END rw0_wd_in[60]
   PIN rw0_wd_in[61]
@@ -560,7 +560,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1260.570 1182.660 1260.870 ;
+      RECT 2363.960 1222.490 2364.860 1222.790 ;
     END
   END rw0_wd_in[61]
   PIN rw0_wd_in[62]
@@ -569,7 +569,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1305.450 1182.660 1305.750 ;
+      RECT 2363.960 1266.010 2364.860 1266.310 ;
     END
   END rw0_wd_in[62]
   PIN rw0_wd_in[63]
@@ -578,7 +578,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1350.330 1182.660 1350.630 ;
+      RECT 2363.960 1309.530 2364.860 1309.830 ;
     END
   END rw0_wd_in[63]
   PIN rw0_wd_in[64]
@@ -587,7 +587,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1395.210 1182.660 1395.510 ;
+      RECT 2363.960 1353.050 2364.860 1353.350 ;
     END
   END rw0_wd_in[64]
   PIN rw0_wd_in[65]
@@ -605,7 +605,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 8.670 0.000 8.810 0.420 ;
+      RECT 14.650 0.000 14.790 0.420 ;
     END
   END rw0_wd_in[66]
   PIN rw0_wd_in[67]
@@ -614,7 +614,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 14.650 0.000 14.790 0.420 ;
+      RECT 26.610 0.000 26.750 0.420 ;
     END
   END rw0_wd_in[67]
   PIN rw0_wd_in[68]
@@ -623,7 +623,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 20.630 0.000 20.770 0.420 ;
+      RECT 38.570 0.000 38.710 0.420 ;
     END
   END rw0_wd_in[68]
   PIN rw0_wd_in[69]
@@ -632,7 +632,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 26.610 0.000 26.750 0.420 ;
+      RECT 50.530 0.000 50.670 0.420 ;
     END
   END rw0_wd_in[69]
   PIN rw0_wd_in[70]
@@ -641,7 +641,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 32.590 0.000 32.730 0.420 ;
+      RECT 62.490 0.000 62.630 0.420 ;
     END
   END rw0_wd_in[70]
   PIN rw0_wd_in[71]
@@ -650,7 +650,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 38.570 0.000 38.710 0.420 ;
+      RECT 74.450 0.000 74.590 0.420 ;
     END
   END rw0_wd_in[71]
   PIN rw0_wd_in[72]
@@ -659,7 +659,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 44.550 0.000 44.690 0.420 ;
+      RECT 86.410 0.000 86.550 0.420 ;
     END
   END rw0_wd_in[72]
   PIN rw0_wd_in[73]
@@ -668,7 +668,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 50.530 0.000 50.670 0.420 ;
+      RECT 98.370 0.000 98.510 0.420 ;
     END
   END rw0_wd_in[73]
   PIN rw0_wd_in[74]
@@ -677,7 +677,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 56.510 0.000 56.650 0.420 ;
+      RECT 110.330 0.000 110.470 0.420 ;
     END
   END rw0_wd_in[74]
   PIN rw0_wd_in[75]
@@ -686,7 +686,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 62.490 0.000 62.630 0.420 ;
+      RECT 122.290 0.000 122.430 0.420 ;
     END
   END rw0_wd_in[75]
   PIN rw0_wd_in[76]
@@ -695,7 +695,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 68.470 0.000 68.610 0.420 ;
+      RECT 134.250 0.000 134.390 0.420 ;
     END
   END rw0_wd_in[76]
   PIN rw0_wd_in[77]
@@ -704,7 +704,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 74.450 0.000 74.590 0.420 ;
+      RECT 146.210 0.000 146.350 0.420 ;
     END
   END rw0_wd_in[77]
   PIN rw0_wd_in[78]
@@ -713,7 +713,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 80.430 0.000 80.570 0.420 ;
+      RECT 158.170 0.000 158.310 0.420 ;
     END
   END rw0_wd_in[78]
   PIN rw0_wd_in[79]
@@ -722,7 +722,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 86.410 0.000 86.550 0.420 ;
+      RECT 170.130 0.000 170.270 0.420 ;
     END
   END rw0_wd_in[79]
   PIN rw0_wd_in[80]
@@ -731,7 +731,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 92.390 0.000 92.530 0.420 ;
+      RECT 182.090 0.000 182.230 0.420 ;
     END
   END rw0_wd_in[80]
   PIN rw0_wd_in[81]
@@ -740,7 +740,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 98.370 0.000 98.510 0.420 ;
+      RECT 194.050 0.000 194.190 0.420 ;
     END
   END rw0_wd_in[81]
   PIN rw0_wd_in[82]
@@ -749,7 +749,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 104.350 0.000 104.490 0.420 ;
+      RECT 206.010 0.000 206.150 0.420 ;
     END
   END rw0_wd_in[82]
   PIN rw0_wd_in[83]
@@ -758,7 +758,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 110.330 0.000 110.470 0.420 ;
+      RECT 217.970 0.000 218.110 0.420 ;
     END
   END rw0_wd_in[83]
   PIN rw0_wd_in[84]
@@ -767,7 +767,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 116.310 0.000 116.450 0.420 ;
+      RECT 229.930 0.000 230.070 0.420 ;
     END
   END rw0_wd_in[84]
   PIN rw0_wd_in[85]
@@ -776,7 +776,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 122.290 0.000 122.430 0.420 ;
+      RECT 241.890 0.000 242.030 0.420 ;
     END
   END rw0_wd_in[85]
   PIN rw0_wd_in[86]
@@ -785,7 +785,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 128.270 0.000 128.410 0.420 ;
+      RECT 253.850 0.000 253.990 0.420 ;
     END
   END rw0_wd_in[86]
   PIN rw0_wd_in[87]
@@ -794,7 +794,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 134.250 0.000 134.390 0.420 ;
+      RECT 265.810 0.000 265.950 0.420 ;
     END
   END rw0_wd_in[87]
   PIN rw0_wd_in[88]
@@ -803,7 +803,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 140.230 0.000 140.370 0.420 ;
+      RECT 277.770 0.000 277.910 0.420 ;
     END
   END rw0_wd_in[88]
   PIN rw0_wd_in[89]
@@ -812,7 +812,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 146.210 0.000 146.350 0.420 ;
+      RECT 289.730 0.000 289.870 0.420 ;
     END
   END rw0_wd_in[89]
   PIN rw0_wd_in[90]
@@ -821,7 +821,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 152.190 0.000 152.330 0.420 ;
+      RECT 301.690 0.000 301.830 0.420 ;
     END
   END rw0_wd_in[90]
   PIN rw0_wd_in[91]
@@ -830,7 +830,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 158.170 0.000 158.310 0.420 ;
+      RECT 313.650 0.000 313.790 0.420 ;
     END
   END rw0_wd_in[91]
   PIN rw0_wd_in[92]
@@ -839,7 +839,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 164.150 0.000 164.290 0.420 ;
+      RECT 325.610 0.000 325.750 0.420 ;
     END
   END rw0_wd_in[92]
   PIN rw0_wd_in[93]
@@ -848,7 +848,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 170.130 0.000 170.270 0.420 ;
+      RECT 337.570 0.000 337.710 0.420 ;
     END
   END rw0_wd_in[93]
   PIN rw0_wd_in[94]
@@ -857,7 +857,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 176.110 0.000 176.250 0.420 ;
+      RECT 349.530 0.000 349.670 0.420 ;
     END
   END rw0_wd_in[94]
   PIN rw0_wd_in[95]
@@ -866,7 +866,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 182.090 0.000 182.230 0.420 ;
+      RECT 361.490 0.000 361.630 0.420 ;
     END
   END rw0_wd_in[95]
   PIN rw0_wd_in[96]
@@ -875,7 +875,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 188.070 0.000 188.210 0.420 ;
+      RECT 373.450 0.000 373.590 0.420 ;
     END
   END rw0_wd_in[96]
   PIN rw0_wd_in[97]
@@ -884,7 +884,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 194.050 0.000 194.190 0.420 ;
+      RECT 385.410 0.000 385.550 0.420 ;
     END
   END rw0_wd_in[97]
   PIN rw0_wd_in[98]
@@ -893,7 +893,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 200.030 0.000 200.170 0.420 ;
+      RECT 397.370 0.000 397.510 0.420 ;
     END
   END rw0_wd_in[98]
   PIN rw0_wd_in[99]
@@ -902,7 +902,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 206.010 0.000 206.150 0.420 ;
+      RECT 409.330 0.000 409.470 0.420 ;
     END
   END rw0_wd_in[99]
   PIN rw0_wd_in[100]
@@ -911,7 +911,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 211.990 0.000 212.130 0.420 ;
+      RECT 421.290 0.000 421.430 0.420 ;
     END
   END rw0_wd_in[100]
   PIN rw0_wd_in[101]
@@ -920,7 +920,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 217.970 0.000 218.110 0.420 ;
+      RECT 433.250 0.000 433.390 0.420 ;
     END
   END rw0_wd_in[101]
   PIN rw0_wd_in[102]
@@ -929,7 +929,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 223.950 0.000 224.090 0.420 ;
+      RECT 445.210 0.000 445.350 0.420 ;
     END
   END rw0_wd_in[102]
   PIN rw0_wd_in[103]
@@ -938,7 +938,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 229.930 0.000 230.070 0.420 ;
+      RECT 457.170 0.000 457.310 0.420 ;
     END
   END rw0_wd_in[103]
   PIN rw0_wd_in[104]
@@ -947,7 +947,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 235.910 0.000 236.050 0.420 ;
+      RECT 469.130 0.000 469.270 0.420 ;
     END
   END rw0_wd_in[104]
   PIN rw0_wd_in[105]
@@ -956,7 +956,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 241.890 0.000 242.030 0.420 ;
+      RECT 481.090 0.000 481.230 0.420 ;
     END
   END rw0_wd_in[105]
   PIN rw0_wd_in[106]
@@ -965,7 +965,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 247.870 0.000 248.010 0.420 ;
+      RECT 493.050 0.000 493.190 0.420 ;
     END
   END rw0_wd_in[106]
   PIN rw0_wd_in[107]
@@ -974,7 +974,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 253.850 0.000 253.990 0.420 ;
+      RECT 505.010 0.000 505.150 0.420 ;
     END
   END rw0_wd_in[107]
   PIN rw0_wd_in[108]
@@ -983,7 +983,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 259.830 0.000 259.970 0.420 ;
+      RECT 516.970 0.000 517.110 0.420 ;
     END
   END rw0_wd_in[108]
   PIN rw0_wd_in[109]
@@ -992,7 +992,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 265.810 0.000 265.950 0.420 ;
+      RECT 528.930 0.000 529.070 0.420 ;
     END
   END rw0_wd_in[109]
   PIN rw0_wd_in[110]
@@ -1001,7 +1001,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 271.790 0.000 271.930 0.420 ;
+      RECT 540.890 0.000 541.030 0.420 ;
     END
   END rw0_wd_in[110]
   PIN rw0_wd_in[111]
@@ -1010,7 +1010,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 277.770 0.000 277.910 0.420 ;
+      RECT 552.850 0.000 552.990 0.420 ;
     END
   END rw0_wd_in[111]
   PIN rw0_wd_in[112]
@@ -1019,7 +1019,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 283.750 0.000 283.890 0.420 ;
+      RECT 564.810 0.000 564.950 0.420 ;
     END
   END rw0_wd_in[112]
   PIN rw0_wd_in[113]
@@ -1028,7 +1028,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 289.730 0.000 289.870 0.420 ;
+      RECT 576.770 0.000 576.910 0.420 ;
     END
   END rw0_wd_in[113]
   PIN rw0_wd_in[114]
@@ -1037,7 +1037,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 295.710 0.000 295.850 0.420 ;
+      RECT 588.730 0.000 588.870 0.420 ;
     END
   END rw0_wd_in[114]
   PIN rw0_wd_in[115]
@@ -1046,7 +1046,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 301.690 0.000 301.830 0.420 ;
+      RECT 600.690 0.000 600.830 0.420 ;
     END
   END rw0_wd_in[115]
   PIN rw0_wd_in[116]
@@ -1055,7 +1055,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 307.670 0.000 307.810 0.420 ;
+      RECT 612.650 0.000 612.790 0.420 ;
     END
   END rw0_wd_in[116]
   PIN rw0_wd_in[117]
@@ -1064,7 +1064,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 313.650 0.000 313.790 0.420 ;
+      RECT 624.610 0.000 624.750 0.420 ;
     END
   END rw0_wd_in[117]
   PIN rw0_wd_in[118]
@@ -1073,7 +1073,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 319.630 0.000 319.770 0.420 ;
+      RECT 636.570 0.000 636.710 0.420 ;
     END
   END rw0_wd_in[118]
   PIN rw0_wd_in[119]
@@ -1082,7 +1082,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 325.610 0.000 325.750 0.420 ;
+      RECT 648.530 0.000 648.670 0.420 ;
     END
   END rw0_wd_in[119]
   PIN rw0_wd_in[120]
@@ -1091,7 +1091,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 331.590 0.000 331.730 0.420 ;
+      RECT 660.490 0.000 660.630 0.420 ;
     END
   END rw0_wd_in[120]
   PIN rw0_wd_in[121]
@@ -1100,7 +1100,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 337.570 0.000 337.710 0.420 ;
+      RECT 672.450 0.000 672.590 0.420 ;
     END
   END rw0_wd_in[121]
   PIN rw0_wd_in[122]
@@ -1109,7 +1109,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 343.550 0.000 343.690 0.420 ;
+      RECT 684.410 0.000 684.550 0.420 ;
     END
   END rw0_wd_in[122]
   PIN rw0_wd_in[123]
@@ -1118,7 +1118,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 349.530 0.000 349.670 0.420 ;
+      RECT 696.370 0.000 696.510 0.420 ;
     END
   END rw0_wd_in[123]
   PIN rw0_wd_in[124]
@@ -1127,7 +1127,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 355.510 0.000 355.650 0.420 ;
+      RECT 708.330 0.000 708.470 0.420 ;
     END
   END rw0_wd_in[124]
   PIN rw0_wd_in[125]
@@ -1136,7 +1136,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 361.490 0.000 361.630 0.420 ;
+      RECT 720.290 0.000 720.430 0.420 ;
     END
   END rw0_wd_in[125]
   PIN rw0_wd_in[126]
@@ -1145,7 +1145,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 367.470 0.000 367.610 0.420 ;
+      RECT 732.250 0.000 732.390 0.420 ;
     END
   END rw0_wd_in[126]
   PIN rw0_wd_in[127]
@@ -1154,7 +1154,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 373.450 0.000 373.590 0.420 ;
+      RECT 744.210 0.000 744.350 0.420 ;
     END
   END rw0_wd_in[127]
   PIN rw0_wd_in[128]
@@ -1163,7 +1163,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 379.430 0.000 379.570 0.420 ;
+      RECT 756.170 0.000 756.310 0.420 ;
     END
   END rw0_wd_in[128]
   PIN rw0_wd_in[129]
@@ -1172,7 +1172,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 385.410 0.000 385.550 0.420 ;
+      RECT 768.130 0.000 768.270 0.420 ;
     END
   END rw0_wd_in[129]
   PIN rw0_rd_out[0]
@@ -1181,7 +1181,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 391.390 0.000 391.530 0.420 ;
+      RECT 780.090 0.000 780.230 0.420 ;
     END
   END rw0_rd_out[0]
   PIN rw0_rd_out[1]
@@ -1190,7 +1190,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 397.370 0.000 397.510 0.420 ;
+      RECT 792.050 0.000 792.190 0.420 ;
     END
   END rw0_rd_out[1]
   PIN rw0_rd_out[2]
@@ -1199,7 +1199,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 403.350 0.000 403.490 0.420 ;
+      RECT 804.010 0.000 804.150 0.420 ;
     END
   END rw0_rd_out[2]
   PIN rw0_rd_out[3]
@@ -1208,7 +1208,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 409.330 0.000 409.470 0.420 ;
+      RECT 815.970 0.000 816.110 0.420 ;
     END
   END rw0_rd_out[3]
   PIN rw0_rd_out[4]
@@ -1217,7 +1217,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 415.310 0.000 415.450 0.420 ;
+      RECT 827.930 0.000 828.070 0.420 ;
     END
   END rw0_rd_out[4]
   PIN rw0_rd_out[5]
@@ -1226,7 +1226,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 421.290 0.000 421.430 0.420 ;
+      RECT 839.890 0.000 840.030 0.420 ;
     END
   END rw0_rd_out[5]
   PIN rw0_rd_out[6]
@@ -1235,7 +1235,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 427.270 0.000 427.410 0.420 ;
+      RECT 851.850 0.000 851.990 0.420 ;
     END
   END rw0_rd_out[6]
   PIN rw0_rd_out[7]
@@ -1244,7 +1244,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 433.250 0.000 433.390 0.420 ;
+      RECT 863.810 0.000 863.950 0.420 ;
     END
   END rw0_rd_out[7]
   PIN rw0_rd_out[8]
@@ -1253,7 +1253,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 439.230 0.000 439.370 0.420 ;
+      RECT 875.770 0.000 875.910 0.420 ;
     END
   END rw0_rd_out[8]
   PIN rw0_rd_out[9]
@@ -1262,7 +1262,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 445.210 0.000 445.350 0.420 ;
+      RECT 887.730 0.000 887.870 0.420 ;
     END
   END rw0_rd_out[9]
   PIN rw0_rd_out[10]
@@ -1271,7 +1271,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 451.190 0.000 451.330 0.420 ;
+      RECT 899.690 0.000 899.830 0.420 ;
     END
   END rw0_rd_out[10]
   PIN rw0_rd_out[11]
@@ -1280,7 +1280,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 457.170 0.000 457.310 0.420 ;
+      RECT 911.650 0.000 911.790 0.420 ;
     END
   END rw0_rd_out[11]
   PIN rw0_rd_out[12]
@@ -1289,7 +1289,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 463.150 0.000 463.290 0.420 ;
+      RECT 923.610 0.000 923.750 0.420 ;
     END
   END rw0_rd_out[12]
   PIN rw0_rd_out[13]
@@ -1298,7 +1298,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 469.130 0.000 469.270 0.420 ;
+      RECT 935.570 0.000 935.710 0.420 ;
     END
   END rw0_rd_out[13]
   PIN rw0_rd_out[14]
@@ -1307,7 +1307,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 475.110 0.000 475.250 0.420 ;
+      RECT 947.530 0.000 947.670 0.420 ;
     END
   END rw0_rd_out[14]
   PIN rw0_rd_out[15]
@@ -1316,7 +1316,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 481.090 0.000 481.230 0.420 ;
+      RECT 959.490 0.000 959.630 0.420 ;
     END
   END rw0_rd_out[15]
   PIN rw0_rd_out[16]
@@ -1325,7 +1325,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 487.070 0.000 487.210 0.420 ;
+      RECT 971.450 0.000 971.590 0.420 ;
     END
   END rw0_rd_out[16]
   PIN rw0_rd_out[17]
@@ -1334,7 +1334,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 493.050 0.000 493.190 0.420 ;
+      RECT 983.410 0.000 983.550 0.420 ;
     END
   END rw0_rd_out[17]
   PIN rw0_rd_out[18]
@@ -1343,7 +1343,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 499.030 0.000 499.170 0.420 ;
+      RECT 995.370 0.000 995.510 0.420 ;
     END
   END rw0_rd_out[18]
   PIN rw0_rd_out[19]
@@ -1352,7 +1352,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 505.010 0.000 505.150 0.420 ;
+      RECT 1007.330 0.000 1007.470 0.420 ;
     END
   END rw0_rd_out[19]
   PIN rw0_rd_out[20]
@@ -1361,7 +1361,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 510.990 0.000 511.130 0.420 ;
+      RECT 1019.290 0.000 1019.430 0.420 ;
     END
   END rw0_rd_out[20]
   PIN rw0_rd_out[21]
@@ -1370,7 +1370,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 516.970 0.000 517.110 0.420 ;
+      RECT 1031.250 0.000 1031.390 0.420 ;
     END
   END rw0_rd_out[21]
   PIN rw0_rd_out[22]
@@ -1379,7 +1379,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 522.950 0.000 523.090 0.420 ;
+      RECT 1043.210 0.000 1043.350 0.420 ;
     END
   END rw0_rd_out[22]
   PIN rw0_rd_out[23]
@@ -1388,7 +1388,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 528.930 0.000 529.070 0.420 ;
+      RECT 1055.170 0.000 1055.310 0.420 ;
     END
   END rw0_rd_out[23]
   PIN rw0_rd_out[24]
@@ -1397,7 +1397,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 534.910 0.000 535.050 0.420 ;
+      RECT 1067.130 0.000 1067.270 0.420 ;
     END
   END rw0_rd_out[24]
   PIN rw0_rd_out[25]
@@ -1406,7 +1406,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 540.890 0.000 541.030 0.420 ;
+      RECT 1079.090 0.000 1079.230 0.420 ;
     END
   END rw0_rd_out[25]
   PIN rw0_rd_out[26]
@@ -1415,7 +1415,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 546.870 0.000 547.010 0.420 ;
+      RECT 1091.050 0.000 1091.190 0.420 ;
     END
   END rw0_rd_out[26]
   PIN rw0_rd_out[27]
@@ -1424,7 +1424,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 552.850 0.000 552.990 0.420 ;
+      RECT 1103.010 0.000 1103.150 0.420 ;
     END
   END rw0_rd_out[27]
   PIN rw0_rd_out[28]
@@ -1433,7 +1433,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 558.830 0.000 558.970 0.420 ;
+      RECT 1114.970 0.000 1115.110 0.420 ;
     END
   END rw0_rd_out[28]
   PIN rw0_rd_out[29]
@@ -1442,7 +1442,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 564.810 0.000 564.950 0.420 ;
+      RECT 1126.930 0.000 1127.070 0.420 ;
     END
   END rw0_rd_out[29]
   PIN rw0_rd_out[30]
@@ -1451,7 +1451,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 570.790 0.000 570.930 0.420 ;
+      RECT 1138.890 0.000 1139.030 0.420 ;
     END
   END rw0_rd_out[30]
   PIN rw0_rd_out[31]
@@ -1460,7 +1460,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 576.770 0.000 576.910 0.420 ;
+      RECT 1150.850 0.000 1150.990 0.420 ;
     END
   END rw0_rd_out[31]
   PIN rw0_rd_out[32]
@@ -1469,7 +1469,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 582.750 0.000 582.890 0.420 ;
+      RECT 1162.810 0.000 1162.950 0.420 ;
     END
   END rw0_rd_out[32]
   PIN rw0_rd_out[33]
@@ -1478,7 +1478,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 588.730 0.000 588.870 0.420 ;
+      RECT 1174.770 0.000 1174.910 0.420 ;
     END
   END rw0_rd_out[33]
   PIN rw0_rd_out[34]
@@ -1487,7 +1487,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 594.710 0.000 594.850 0.420 ;
+      RECT 1186.730 0.000 1186.870 0.420 ;
     END
   END rw0_rd_out[34]
   PIN rw0_rd_out[35]
@@ -1496,7 +1496,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 600.690 0.000 600.830 0.420 ;
+      RECT 1198.690 0.000 1198.830 0.420 ;
     END
   END rw0_rd_out[35]
   PIN rw0_rd_out[36]
@@ -1505,7 +1505,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 606.670 0.000 606.810 0.420 ;
+      RECT 1210.650 0.000 1210.790 0.420 ;
     END
   END rw0_rd_out[36]
   PIN rw0_rd_out[37]
@@ -1514,7 +1514,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 612.650 0.000 612.790 0.420 ;
+      RECT 1222.610 0.000 1222.750 0.420 ;
     END
   END rw0_rd_out[37]
   PIN rw0_rd_out[38]
@@ -1523,7 +1523,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 618.630 0.000 618.770 0.420 ;
+      RECT 1234.570 0.000 1234.710 0.420 ;
     END
   END rw0_rd_out[38]
   PIN rw0_rd_out[39]
@@ -1532,7 +1532,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 624.610 0.000 624.750 0.420 ;
+      RECT 1246.530 0.000 1246.670 0.420 ;
     END
   END rw0_rd_out[39]
   PIN rw0_rd_out[40]
@@ -1541,7 +1541,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 630.590 0.000 630.730 0.420 ;
+      RECT 1258.490 0.000 1258.630 0.420 ;
     END
   END rw0_rd_out[40]
   PIN rw0_rd_out[41]
@@ -1550,7 +1550,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 636.570 0.000 636.710 0.420 ;
+      RECT 1270.450 0.000 1270.590 0.420 ;
     END
   END rw0_rd_out[41]
   PIN rw0_rd_out[42]
@@ -1559,7 +1559,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 642.550 0.000 642.690 0.420 ;
+      RECT 1282.410 0.000 1282.550 0.420 ;
     END
   END rw0_rd_out[42]
   PIN rw0_rd_out[43]
@@ -1568,7 +1568,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 648.530 0.000 648.670 0.420 ;
+      RECT 1294.370 0.000 1294.510 0.420 ;
     END
   END rw0_rd_out[43]
   PIN rw0_rd_out[44]
@@ -1577,7 +1577,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 654.510 0.000 654.650 0.420 ;
+      RECT 1306.330 0.000 1306.470 0.420 ;
     END
   END rw0_rd_out[44]
   PIN rw0_rd_out[45]
@@ -1586,7 +1586,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 660.490 0.000 660.630 0.420 ;
+      RECT 1318.290 0.000 1318.430 0.420 ;
     END
   END rw0_rd_out[45]
   PIN rw0_rd_out[46]
@@ -1595,7 +1595,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 666.470 0.000 666.610 0.420 ;
+      RECT 1330.250 0.000 1330.390 0.420 ;
     END
   END rw0_rd_out[46]
   PIN rw0_rd_out[47]
@@ -1604,7 +1604,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 672.450 0.000 672.590 0.420 ;
+      RECT 1342.210 0.000 1342.350 0.420 ;
     END
   END rw0_rd_out[47]
   PIN rw0_rd_out[48]
@@ -1613,7 +1613,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 678.430 0.000 678.570 0.420 ;
+      RECT 1354.170 0.000 1354.310 0.420 ;
     END
   END rw0_rd_out[48]
   PIN rw0_rd_out[49]
@@ -1622,7 +1622,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 684.410 0.000 684.550 0.420 ;
+      RECT 1366.130 0.000 1366.270 0.420 ;
     END
   END rw0_rd_out[49]
   PIN rw0_rd_out[50]
@@ -1631,7 +1631,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 690.390 0.000 690.530 0.420 ;
+      RECT 1378.090 0.000 1378.230 0.420 ;
     END
   END rw0_rd_out[50]
   PIN rw0_rd_out[51]
@@ -1640,7 +1640,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 696.370 0.000 696.510 0.420 ;
+      RECT 1390.050 0.000 1390.190 0.420 ;
     END
   END rw0_rd_out[51]
   PIN rw0_rd_out[52]
@@ -1649,7 +1649,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 702.350 0.000 702.490 0.420 ;
+      RECT 1402.010 0.000 1402.150 0.420 ;
     END
   END rw0_rd_out[52]
   PIN rw0_rd_out[53]
@@ -1658,7 +1658,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 708.330 0.000 708.470 0.420 ;
+      RECT 1413.970 0.000 1414.110 0.420 ;
     END
   END rw0_rd_out[53]
   PIN rw0_rd_out[54]
@@ -1667,7 +1667,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 714.310 0.000 714.450 0.420 ;
+      RECT 1425.930 0.000 1426.070 0.420 ;
     END
   END rw0_rd_out[54]
   PIN rw0_rd_out[55]
@@ -1676,7 +1676,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 720.290 0.000 720.430 0.420 ;
+      RECT 1437.890 0.000 1438.030 0.420 ;
     END
   END rw0_rd_out[55]
   PIN rw0_rd_out[56]
@@ -1685,7 +1685,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 726.270 0.000 726.410 0.420 ;
+      RECT 1449.850 0.000 1449.990 0.420 ;
     END
   END rw0_rd_out[56]
   PIN rw0_rd_out[57]
@@ -1694,7 +1694,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 732.250 0.000 732.390 0.420 ;
+      RECT 1461.810 0.000 1461.950 0.420 ;
     END
   END rw0_rd_out[57]
   PIN rw0_rd_out[58]
@@ -1703,7 +1703,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 738.230 0.000 738.370 0.420 ;
+      RECT 1473.770 0.000 1473.910 0.420 ;
     END
   END rw0_rd_out[58]
   PIN rw0_rd_out[59]
@@ -1712,7 +1712,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 744.210 0.000 744.350 0.420 ;
+      RECT 1485.730 0.000 1485.870 0.420 ;
     END
   END rw0_rd_out[59]
   PIN rw0_rd_out[60]
@@ -1721,7 +1721,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 750.190 0.000 750.330 0.420 ;
+      RECT 1497.690 0.000 1497.830 0.420 ;
     END
   END rw0_rd_out[60]
   PIN rw0_rd_out[61]
@@ -1730,7 +1730,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 756.170 0.000 756.310 0.420 ;
+      RECT 1509.650 0.000 1509.790 0.420 ;
     END
   END rw0_rd_out[61]
   PIN rw0_rd_out[62]
@@ -1739,7 +1739,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 762.150 0.000 762.290 0.420 ;
+      RECT 1521.610 0.000 1521.750 0.420 ;
     END
   END rw0_rd_out[62]
   PIN rw0_rd_out[63]
@@ -1748,7 +1748,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 768.130 0.000 768.270 0.420 ;
+      RECT 1533.570 0.000 1533.710 0.420 ;
     END
   END rw0_rd_out[63]
   PIN rw0_rd_out[64]
@@ -1757,7 +1757,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 774.110 0.000 774.250 0.420 ;
+      RECT 1545.530 0.000 1545.670 0.420 ;
     END
   END rw0_rd_out[64]
   PIN rw0_rd_out[65]
@@ -1775,7 +1775,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 10.970 1895.420 11.110 1895.840 ;
+      RECT 19.710 1895.420 19.850 1895.840 ;
     END
   END rw0_rd_out[66]
   PIN rw0_rd_out[67]
@@ -1784,7 +1784,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 19.250 1895.420 19.390 1895.840 ;
+      RECT 36.730 1895.420 36.870 1895.840 ;
     END
   END rw0_rd_out[67]
   PIN rw0_rd_out[68]
@@ -1793,7 +1793,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 27.530 1895.420 27.670 1895.840 ;
+      RECT 53.750 1895.420 53.890 1895.840 ;
     END
   END rw0_rd_out[68]
   PIN rw0_rd_out[69]
@@ -1802,7 +1802,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 35.810 1895.420 35.950 1895.840 ;
+      RECT 70.770 1895.420 70.910 1895.840 ;
     END
   END rw0_rd_out[69]
   PIN rw0_rd_out[70]
@@ -1811,7 +1811,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 44.090 1895.420 44.230 1895.840 ;
+      RECT 87.790 1895.420 87.930 1895.840 ;
     END
   END rw0_rd_out[70]
   PIN rw0_rd_out[71]
@@ -1820,7 +1820,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 52.370 1895.420 52.510 1895.840 ;
+      RECT 104.810 1895.420 104.950 1895.840 ;
     END
   END rw0_rd_out[71]
   PIN rw0_rd_out[72]
@@ -1829,7 +1829,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 60.650 1895.420 60.790 1895.840 ;
+      RECT 121.830 1895.420 121.970 1895.840 ;
     END
   END rw0_rd_out[72]
   PIN rw0_rd_out[73]
@@ -1838,7 +1838,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 68.930 1895.420 69.070 1895.840 ;
+      RECT 138.850 1895.420 138.990 1895.840 ;
     END
   END rw0_rd_out[73]
   PIN rw0_rd_out[74]
@@ -1847,7 +1847,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 77.210 1895.420 77.350 1895.840 ;
+      RECT 155.870 1895.420 156.010 1895.840 ;
     END
   END rw0_rd_out[74]
   PIN rw0_rd_out[75]
@@ -1856,7 +1856,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 85.490 1895.420 85.630 1895.840 ;
+      RECT 172.890 1895.420 173.030 1895.840 ;
     END
   END rw0_rd_out[75]
   PIN rw0_rd_out[76]
@@ -1865,7 +1865,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 93.770 1895.420 93.910 1895.840 ;
+      RECT 189.910 1895.420 190.050 1895.840 ;
     END
   END rw0_rd_out[76]
   PIN rw0_rd_out[77]
@@ -1874,7 +1874,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 102.050 1895.420 102.190 1895.840 ;
+      RECT 206.930 1895.420 207.070 1895.840 ;
     END
   END rw0_rd_out[77]
   PIN rw0_rd_out[78]
@@ -1883,7 +1883,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 110.330 1895.420 110.470 1895.840 ;
+      RECT 223.950 1895.420 224.090 1895.840 ;
     END
   END rw0_rd_out[78]
   PIN rw0_rd_out[79]
@@ -1892,7 +1892,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 118.610 1895.420 118.750 1895.840 ;
+      RECT 240.970 1895.420 241.110 1895.840 ;
     END
   END rw0_rd_out[79]
   PIN rw0_rd_out[80]
@@ -1901,7 +1901,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 126.890 1895.420 127.030 1895.840 ;
+      RECT 257.990 1895.420 258.130 1895.840 ;
     END
   END rw0_rd_out[80]
   PIN rw0_rd_out[81]
@@ -1910,7 +1910,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 135.170 1895.420 135.310 1895.840 ;
+      RECT 275.010 1895.420 275.150 1895.840 ;
     END
   END rw0_rd_out[81]
   PIN rw0_rd_out[82]
@@ -1919,7 +1919,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 143.450 1895.420 143.590 1895.840 ;
+      RECT 292.030 1895.420 292.170 1895.840 ;
     END
   END rw0_rd_out[82]
   PIN rw0_rd_out[83]
@@ -1928,7 +1928,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 151.730 1895.420 151.870 1895.840 ;
+      RECT 309.050 1895.420 309.190 1895.840 ;
     END
   END rw0_rd_out[83]
   PIN rw0_rd_out[84]
@@ -1937,7 +1937,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 160.010 1895.420 160.150 1895.840 ;
+      RECT 326.070 1895.420 326.210 1895.840 ;
     END
   END rw0_rd_out[84]
   PIN rw0_rd_out[85]
@@ -1946,7 +1946,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 168.290 1895.420 168.430 1895.840 ;
+      RECT 343.090 1895.420 343.230 1895.840 ;
     END
   END rw0_rd_out[85]
   PIN rw0_rd_out[86]
@@ -1955,7 +1955,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 176.570 1895.420 176.710 1895.840 ;
+      RECT 360.110 1895.420 360.250 1895.840 ;
     END
   END rw0_rd_out[86]
   PIN rw0_rd_out[87]
@@ -1964,7 +1964,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 184.850 1895.420 184.990 1895.840 ;
+      RECT 377.130 1895.420 377.270 1895.840 ;
     END
   END rw0_rd_out[87]
   PIN rw0_rd_out[88]
@@ -1973,7 +1973,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 193.130 1895.420 193.270 1895.840 ;
+      RECT 394.150 1895.420 394.290 1895.840 ;
     END
   END rw0_rd_out[88]
   PIN rw0_rd_out[89]
@@ -1982,7 +1982,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 201.410 1895.420 201.550 1895.840 ;
+      RECT 411.170 1895.420 411.310 1895.840 ;
     END
   END rw0_rd_out[89]
   PIN rw0_rd_out[90]
@@ -1991,7 +1991,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 209.690 1895.420 209.830 1895.840 ;
+      RECT 428.190 1895.420 428.330 1895.840 ;
     END
   END rw0_rd_out[90]
   PIN rw0_rd_out[91]
@@ -2000,7 +2000,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 217.970 1895.420 218.110 1895.840 ;
+      RECT 445.210 1895.420 445.350 1895.840 ;
     END
   END rw0_rd_out[91]
   PIN rw0_rd_out[92]
@@ -2009,7 +2009,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 226.250 1895.420 226.390 1895.840 ;
+      RECT 462.230 1895.420 462.370 1895.840 ;
     END
   END rw0_rd_out[92]
   PIN rw0_rd_out[93]
@@ -2018,7 +2018,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 234.530 1895.420 234.670 1895.840 ;
+      RECT 479.250 1895.420 479.390 1895.840 ;
     END
   END rw0_rd_out[93]
   PIN rw0_rd_out[94]
@@ -2027,7 +2027,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 242.810 1895.420 242.950 1895.840 ;
+      RECT 496.270 1895.420 496.410 1895.840 ;
     END
   END rw0_rd_out[94]
   PIN rw0_rd_out[95]
@@ -2036,7 +2036,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 251.090 1895.420 251.230 1895.840 ;
+      RECT 513.290 1895.420 513.430 1895.840 ;
     END
   END rw0_rd_out[95]
   PIN rw0_rd_out[96]
@@ -2045,7 +2045,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 259.370 1895.420 259.510 1895.840 ;
+      RECT 530.310 1895.420 530.450 1895.840 ;
     END
   END rw0_rd_out[96]
   PIN rw0_rd_out[97]
@@ -2054,7 +2054,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 267.650 1895.420 267.790 1895.840 ;
+      RECT 547.330 1895.420 547.470 1895.840 ;
     END
   END rw0_rd_out[97]
   PIN rw0_rd_out[98]
@@ -2063,7 +2063,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 275.930 1895.420 276.070 1895.840 ;
+      RECT 564.350 1895.420 564.490 1895.840 ;
     END
   END rw0_rd_out[98]
   PIN rw0_rd_out[99]
@@ -2072,7 +2072,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 284.210 1895.420 284.350 1895.840 ;
+      RECT 581.370 1895.420 581.510 1895.840 ;
     END
   END rw0_rd_out[99]
   PIN rw0_rd_out[100]
@@ -2081,7 +2081,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 292.490 1895.420 292.630 1895.840 ;
+      RECT 598.390 1895.420 598.530 1895.840 ;
     END
   END rw0_rd_out[100]
   PIN rw0_rd_out[101]
@@ -2090,7 +2090,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 300.770 1895.420 300.910 1895.840 ;
+      RECT 615.410 1895.420 615.550 1895.840 ;
     END
   END rw0_rd_out[101]
   PIN rw0_rd_out[102]
@@ -2099,7 +2099,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 309.050 1895.420 309.190 1895.840 ;
+      RECT 632.430 1895.420 632.570 1895.840 ;
     END
   END rw0_rd_out[102]
   PIN rw0_rd_out[103]
@@ -2108,7 +2108,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 317.330 1895.420 317.470 1895.840 ;
+      RECT 649.450 1895.420 649.590 1895.840 ;
     END
   END rw0_rd_out[103]
   PIN rw0_rd_out[104]
@@ -2117,7 +2117,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 325.610 1895.420 325.750 1895.840 ;
+      RECT 666.470 1895.420 666.610 1895.840 ;
     END
   END rw0_rd_out[104]
   PIN rw0_rd_out[105]
@@ -2126,7 +2126,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 333.890 1895.420 334.030 1895.840 ;
+      RECT 683.490 1895.420 683.630 1895.840 ;
     END
   END rw0_rd_out[105]
   PIN rw0_rd_out[106]
@@ -2135,7 +2135,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 342.170 1895.420 342.310 1895.840 ;
+      RECT 700.510 1895.420 700.650 1895.840 ;
     END
   END rw0_rd_out[106]
   PIN rw0_rd_out[107]
@@ -2144,7 +2144,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 350.450 1895.420 350.590 1895.840 ;
+      RECT 717.530 1895.420 717.670 1895.840 ;
     END
   END rw0_rd_out[107]
   PIN rw0_rd_out[108]
@@ -2153,7 +2153,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 358.730 1895.420 358.870 1895.840 ;
+      RECT 734.550 1895.420 734.690 1895.840 ;
     END
   END rw0_rd_out[108]
   PIN rw0_rd_out[109]
@@ -2162,7 +2162,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 367.010 1895.420 367.150 1895.840 ;
+      RECT 751.570 1895.420 751.710 1895.840 ;
     END
   END rw0_rd_out[109]
   PIN rw0_rd_out[110]
@@ -2171,7 +2171,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 375.290 1895.420 375.430 1895.840 ;
+      RECT 768.590 1895.420 768.730 1895.840 ;
     END
   END rw0_rd_out[110]
   PIN rw0_rd_out[111]
@@ -2180,7 +2180,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 383.570 1895.420 383.710 1895.840 ;
+      RECT 785.610 1895.420 785.750 1895.840 ;
     END
   END rw0_rd_out[111]
   PIN rw0_rd_out[112]
@@ -2189,7 +2189,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 391.850 1895.420 391.990 1895.840 ;
+      RECT 802.630 1895.420 802.770 1895.840 ;
     END
   END rw0_rd_out[112]
   PIN rw0_rd_out[113]
@@ -2198,7 +2198,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 400.130 1895.420 400.270 1895.840 ;
+      RECT 819.650 1895.420 819.790 1895.840 ;
     END
   END rw0_rd_out[113]
   PIN rw0_rd_out[114]
@@ -2207,7 +2207,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 408.410 1895.420 408.550 1895.840 ;
+      RECT 836.670 1895.420 836.810 1895.840 ;
     END
   END rw0_rd_out[114]
   PIN rw0_rd_out[115]
@@ -2216,7 +2216,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 416.690 1895.420 416.830 1895.840 ;
+      RECT 853.690 1895.420 853.830 1895.840 ;
     END
   END rw0_rd_out[115]
   PIN rw0_rd_out[116]
@@ -2225,7 +2225,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 424.970 1895.420 425.110 1895.840 ;
+      RECT 870.710 1895.420 870.850 1895.840 ;
     END
   END rw0_rd_out[116]
   PIN rw0_rd_out[117]
@@ -2234,7 +2234,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 433.250 1895.420 433.390 1895.840 ;
+      RECT 887.730 1895.420 887.870 1895.840 ;
     END
   END rw0_rd_out[117]
   PIN rw0_rd_out[118]
@@ -2243,7 +2243,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 441.530 1895.420 441.670 1895.840 ;
+      RECT 904.750 1895.420 904.890 1895.840 ;
     END
   END rw0_rd_out[118]
   PIN rw0_rd_out[119]
@@ -2252,7 +2252,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 449.810 1895.420 449.950 1895.840 ;
+      RECT 921.770 1895.420 921.910 1895.840 ;
     END
   END rw0_rd_out[119]
   PIN rw0_rd_out[120]
@@ -2261,7 +2261,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 458.090 1895.420 458.230 1895.840 ;
+      RECT 938.790 1895.420 938.930 1895.840 ;
     END
   END rw0_rd_out[120]
   PIN rw0_rd_out[121]
@@ -2270,7 +2270,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 466.370 1895.420 466.510 1895.840 ;
+      RECT 955.810 1895.420 955.950 1895.840 ;
     END
   END rw0_rd_out[121]
   PIN rw0_rd_out[122]
@@ -2279,7 +2279,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 474.650 1895.420 474.790 1895.840 ;
+      RECT 972.830 1895.420 972.970 1895.840 ;
     END
   END rw0_rd_out[122]
   PIN rw0_rd_out[123]
@@ -2288,7 +2288,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 482.930 1895.420 483.070 1895.840 ;
+      RECT 989.850 1895.420 989.990 1895.840 ;
     END
   END rw0_rd_out[123]
   PIN rw0_rd_out[124]
@@ -2297,7 +2297,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 491.210 1895.420 491.350 1895.840 ;
+      RECT 1006.870 1895.420 1007.010 1895.840 ;
     END
   END rw0_rd_out[124]
   PIN rw0_rd_out[125]
@@ -2306,7 +2306,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 499.490 1895.420 499.630 1895.840 ;
+      RECT 1023.890 1895.420 1024.030 1895.840 ;
     END
   END rw0_rd_out[125]
   PIN rw0_rd_out[126]
@@ -2315,7 +2315,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 507.770 1895.420 507.910 1895.840 ;
+      RECT 1040.910 1895.420 1041.050 1895.840 ;
     END
   END rw0_rd_out[126]
   PIN rw0_rd_out[127]
@@ -2324,7 +2324,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 516.050 1895.420 516.190 1895.840 ;
+      RECT 1057.930 1895.420 1058.070 1895.840 ;
     END
   END rw0_rd_out[127]
   PIN rw0_rd_out[128]
@@ -2333,7 +2333,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 524.330 1895.420 524.470 1895.840 ;
+      RECT 1074.950 1895.420 1075.090 1895.840 ;
     END
   END rw0_rd_out[128]
   PIN rw0_rd_out[129]
@@ -2342,7 +2342,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 532.610 1895.420 532.750 1895.840 ;
+      RECT 1091.970 1895.420 1092.110 1895.840 ;
     END
   END rw0_rd_out[129]
   PIN r0_rd_out[0]
@@ -2351,7 +2351,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 780.090 0.000 780.230 0.420 ;
+      RECT 1557.490 0.000 1557.630 0.420 ;
     END
   END r0_rd_out[0]
   PIN r0_rd_out[1]
@@ -2360,7 +2360,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 786.070 0.000 786.210 0.420 ;
+      RECT 1569.450 0.000 1569.590 0.420 ;
     END
   END r0_rd_out[1]
   PIN r0_rd_out[2]
@@ -2369,7 +2369,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 792.050 0.000 792.190 0.420 ;
+      RECT 1581.410 0.000 1581.550 0.420 ;
     END
   END r0_rd_out[2]
   PIN r0_rd_out[3]
@@ -2378,7 +2378,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 798.030 0.000 798.170 0.420 ;
+      RECT 1593.370 0.000 1593.510 0.420 ;
     END
   END r0_rd_out[3]
   PIN r0_rd_out[4]
@@ -2387,7 +2387,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 804.010 0.000 804.150 0.420 ;
+      RECT 1605.330 0.000 1605.470 0.420 ;
     END
   END r0_rd_out[4]
   PIN r0_rd_out[5]
@@ -2396,7 +2396,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 809.990 0.000 810.130 0.420 ;
+      RECT 1617.290 0.000 1617.430 0.420 ;
     END
   END r0_rd_out[5]
   PIN r0_rd_out[6]
@@ -2405,7 +2405,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 815.970 0.000 816.110 0.420 ;
+      RECT 1629.250 0.000 1629.390 0.420 ;
     END
   END r0_rd_out[6]
   PIN r0_rd_out[7]
@@ -2414,7 +2414,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 821.950 0.000 822.090 0.420 ;
+      RECT 1641.210 0.000 1641.350 0.420 ;
     END
   END r0_rd_out[7]
   PIN r0_rd_out[8]
@@ -2423,7 +2423,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 827.930 0.000 828.070 0.420 ;
+      RECT 1653.170 0.000 1653.310 0.420 ;
     END
   END r0_rd_out[8]
   PIN r0_rd_out[9]
@@ -2432,7 +2432,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 833.910 0.000 834.050 0.420 ;
+      RECT 1665.130 0.000 1665.270 0.420 ;
     END
   END r0_rd_out[9]
   PIN r0_rd_out[10]
@@ -2441,7 +2441,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 839.890 0.000 840.030 0.420 ;
+      RECT 1677.090 0.000 1677.230 0.420 ;
     END
   END r0_rd_out[10]
   PIN r0_rd_out[11]
@@ -2450,7 +2450,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 845.870 0.000 846.010 0.420 ;
+      RECT 1689.050 0.000 1689.190 0.420 ;
     END
   END r0_rd_out[11]
   PIN r0_rd_out[12]
@@ -2459,7 +2459,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 851.850 0.000 851.990 0.420 ;
+      RECT 1701.010 0.000 1701.150 0.420 ;
     END
   END r0_rd_out[12]
   PIN r0_rd_out[13]
@@ -2468,7 +2468,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 857.830 0.000 857.970 0.420 ;
+      RECT 1712.970 0.000 1713.110 0.420 ;
     END
   END r0_rd_out[13]
   PIN r0_rd_out[14]
@@ -2477,7 +2477,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 863.810 0.000 863.950 0.420 ;
+      RECT 1724.930 0.000 1725.070 0.420 ;
     END
   END r0_rd_out[14]
   PIN r0_rd_out[15]
@@ -2486,7 +2486,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 869.790 0.000 869.930 0.420 ;
+      RECT 1736.890 0.000 1737.030 0.420 ;
     END
   END r0_rd_out[15]
   PIN r0_rd_out[16]
@@ -2495,7 +2495,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 875.770 0.000 875.910 0.420 ;
+      RECT 1748.850 0.000 1748.990 0.420 ;
     END
   END r0_rd_out[16]
   PIN r0_rd_out[17]
@@ -2504,7 +2504,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 881.750 0.000 881.890 0.420 ;
+      RECT 1760.810 0.000 1760.950 0.420 ;
     END
   END r0_rd_out[17]
   PIN r0_rd_out[18]
@@ -2513,7 +2513,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 887.730 0.000 887.870 0.420 ;
+      RECT 1772.770 0.000 1772.910 0.420 ;
     END
   END r0_rd_out[18]
   PIN r0_rd_out[19]
@@ -2522,7 +2522,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 893.710 0.000 893.850 0.420 ;
+      RECT 1784.730 0.000 1784.870 0.420 ;
     END
   END r0_rd_out[19]
   PIN r0_rd_out[20]
@@ -2531,7 +2531,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 899.690 0.000 899.830 0.420 ;
+      RECT 1796.690 0.000 1796.830 0.420 ;
     END
   END r0_rd_out[20]
   PIN r0_rd_out[21]
@@ -2540,7 +2540,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 905.670 0.000 905.810 0.420 ;
+      RECT 1808.650 0.000 1808.790 0.420 ;
     END
   END r0_rd_out[21]
   PIN r0_rd_out[22]
@@ -2549,7 +2549,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 911.650 0.000 911.790 0.420 ;
+      RECT 1820.610 0.000 1820.750 0.420 ;
     END
   END r0_rd_out[22]
   PIN r0_rd_out[23]
@@ -2558,7 +2558,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 917.630 0.000 917.770 0.420 ;
+      RECT 1832.570 0.000 1832.710 0.420 ;
     END
   END r0_rd_out[23]
   PIN r0_rd_out[24]
@@ -2567,7 +2567,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 923.610 0.000 923.750 0.420 ;
+      RECT 1844.530 0.000 1844.670 0.420 ;
     END
   END r0_rd_out[24]
   PIN r0_rd_out[25]
@@ -2576,7 +2576,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 929.590 0.000 929.730 0.420 ;
+      RECT 1856.490 0.000 1856.630 0.420 ;
     END
   END r0_rd_out[25]
   PIN r0_rd_out[26]
@@ -2585,7 +2585,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 935.570 0.000 935.710 0.420 ;
+      RECT 1868.450 0.000 1868.590 0.420 ;
     END
   END r0_rd_out[26]
   PIN r0_rd_out[27]
@@ -2594,7 +2594,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 941.550 0.000 941.690 0.420 ;
+      RECT 1880.410 0.000 1880.550 0.420 ;
     END
   END r0_rd_out[27]
   PIN r0_rd_out[28]
@@ -2603,7 +2603,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 947.530 0.000 947.670 0.420 ;
+      RECT 1892.370 0.000 1892.510 0.420 ;
     END
   END r0_rd_out[28]
   PIN r0_rd_out[29]
@@ -2612,7 +2612,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 953.510 0.000 953.650 0.420 ;
+      RECT 1904.330 0.000 1904.470 0.420 ;
     END
   END r0_rd_out[29]
   PIN r0_rd_out[30]
@@ -2621,7 +2621,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 959.490 0.000 959.630 0.420 ;
+      RECT 1916.290 0.000 1916.430 0.420 ;
     END
   END r0_rd_out[30]
   PIN r0_rd_out[31]
@@ -2630,7 +2630,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 965.470 0.000 965.610 0.420 ;
+      RECT 1928.250 0.000 1928.390 0.420 ;
     END
   END r0_rd_out[31]
   PIN r0_rd_out[32]
@@ -2639,7 +2639,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 971.450 0.000 971.590 0.420 ;
+      RECT 1940.210 0.000 1940.350 0.420 ;
     END
   END r0_rd_out[32]
   PIN r0_rd_out[33]
@@ -2648,7 +2648,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 977.430 0.000 977.570 0.420 ;
+      RECT 1952.170 0.000 1952.310 0.420 ;
     END
   END r0_rd_out[33]
   PIN r0_rd_out[34]
@@ -2657,7 +2657,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 983.410 0.000 983.550 0.420 ;
+      RECT 1964.130 0.000 1964.270 0.420 ;
     END
   END r0_rd_out[34]
   PIN r0_rd_out[35]
@@ -2666,7 +2666,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 989.390 0.000 989.530 0.420 ;
+      RECT 1976.090 0.000 1976.230 0.420 ;
     END
   END r0_rd_out[35]
   PIN r0_rd_out[36]
@@ -2675,7 +2675,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 995.370 0.000 995.510 0.420 ;
+      RECT 1988.050 0.000 1988.190 0.420 ;
     END
   END r0_rd_out[36]
   PIN r0_rd_out[37]
@@ -2684,7 +2684,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1001.350 0.000 1001.490 0.420 ;
+      RECT 2000.010 0.000 2000.150 0.420 ;
     END
   END r0_rd_out[37]
   PIN r0_rd_out[38]
@@ -2693,7 +2693,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1007.330 0.000 1007.470 0.420 ;
+      RECT 2011.970 0.000 2012.110 0.420 ;
     END
   END r0_rd_out[38]
   PIN r0_rd_out[39]
@@ -2702,7 +2702,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1013.310 0.000 1013.450 0.420 ;
+      RECT 2023.930 0.000 2024.070 0.420 ;
     END
   END r0_rd_out[39]
   PIN r0_rd_out[40]
@@ -2711,7 +2711,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1019.290 0.000 1019.430 0.420 ;
+      RECT 2035.890 0.000 2036.030 0.420 ;
     END
   END r0_rd_out[40]
   PIN r0_rd_out[41]
@@ -2720,7 +2720,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1025.270 0.000 1025.410 0.420 ;
+      RECT 2047.850 0.000 2047.990 0.420 ;
     END
   END r0_rd_out[41]
   PIN r0_rd_out[42]
@@ -2729,7 +2729,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1031.250 0.000 1031.390 0.420 ;
+      RECT 2059.810 0.000 2059.950 0.420 ;
     END
   END r0_rd_out[42]
   PIN r0_rd_out[43]
@@ -2738,7 +2738,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1037.230 0.000 1037.370 0.420 ;
+      RECT 2071.770 0.000 2071.910 0.420 ;
     END
   END r0_rd_out[43]
   PIN r0_rd_out[44]
@@ -2747,7 +2747,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1043.210 0.000 1043.350 0.420 ;
+      RECT 2083.730 0.000 2083.870 0.420 ;
     END
   END r0_rd_out[44]
   PIN r0_rd_out[45]
@@ -2756,7 +2756,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1049.190 0.000 1049.330 0.420 ;
+      RECT 2095.690 0.000 2095.830 0.420 ;
     END
   END r0_rd_out[45]
   PIN r0_rd_out[46]
@@ -2765,7 +2765,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1055.170 0.000 1055.310 0.420 ;
+      RECT 2107.650 0.000 2107.790 0.420 ;
     END
   END r0_rd_out[46]
   PIN r0_rd_out[47]
@@ -2774,7 +2774,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1061.150 0.000 1061.290 0.420 ;
+      RECT 2119.610 0.000 2119.750 0.420 ;
     END
   END r0_rd_out[47]
   PIN r0_rd_out[48]
@@ -2783,7 +2783,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1067.130 0.000 1067.270 0.420 ;
+      RECT 2131.570 0.000 2131.710 0.420 ;
     END
   END r0_rd_out[48]
   PIN r0_rd_out[49]
@@ -2792,7 +2792,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1073.110 0.000 1073.250 0.420 ;
+      RECT 2143.530 0.000 2143.670 0.420 ;
     END
   END r0_rd_out[49]
   PIN r0_rd_out[50]
@@ -2801,7 +2801,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1079.090 0.000 1079.230 0.420 ;
+      RECT 2155.490 0.000 2155.630 0.420 ;
     END
   END r0_rd_out[50]
   PIN r0_rd_out[51]
@@ -2810,7 +2810,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1085.070 0.000 1085.210 0.420 ;
+      RECT 2167.450 0.000 2167.590 0.420 ;
     END
   END r0_rd_out[51]
   PIN r0_rd_out[52]
@@ -2819,7 +2819,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1091.050 0.000 1091.190 0.420 ;
+      RECT 2179.410 0.000 2179.550 0.420 ;
     END
   END r0_rd_out[52]
   PIN r0_rd_out[53]
@@ -2828,7 +2828,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1097.030 0.000 1097.170 0.420 ;
+      RECT 2191.370 0.000 2191.510 0.420 ;
     END
   END r0_rd_out[53]
   PIN r0_rd_out[54]
@@ -2837,7 +2837,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1103.010 0.000 1103.150 0.420 ;
+      RECT 2203.330 0.000 2203.470 0.420 ;
     END
   END r0_rd_out[54]
   PIN r0_rd_out[55]
@@ -2846,7 +2846,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1108.990 0.000 1109.130 0.420 ;
+      RECT 2215.290 0.000 2215.430 0.420 ;
     END
   END r0_rd_out[55]
   PIN r0_rd_out[56]
@@ -2855,7 +2855,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1114.970 0.000 1115.110 0.420 ;
+      RECT 2227.250 0.000 2227.390 0.420 ;
     END
   END r0_rd_out[56]
   PIN r0_rd_out[57]
@@ -2864,7 +2864,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1120.950 0.000 1121.090 0.420 ;
+      RECT 2239.210 0.000 2239.350 0.420 ;
     END
   END r0_rd_out[57]
   PIN r0_rd_out[58]
@@ -2873,7 +2873,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1126.930 0.000 1127.070 0.420 ;
+      RECT 2251.170 0.000 2251.310 0.420 ;
     END
   END r0_rd_out[58]
   PIN r0_rd_out[59]
@@ -2882,7 +2882,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1132.910 0.000 1133.050 0.420 ;
+      RECT 2263.130 0.000 2263.270 0.420 ;
     END
   END r0_rd_out[59]
   PIN r0_rd_out[60]
@@ -2891,7 +2891,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1138.890 0.000 1139.030 0.420 ;
+      RECT 2275.090 0.000 2275.230 0.420 ;
     END
   END r0_rd_out[60]
   PIN r0_rd_out[61]
@@ -2900,7 +2900,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1144.870 0.000 1145.010 0.420 ;
+      RECT 2287.050 0.000 2287.190 0.420 ;
     END
   END r0_rd_out[61]
   PIN r0_rd_out[62]
@@ -2909,7 +2909,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1150.850 0.000 1150.990 0.420 ;
+      RECT 2299.010 0.000 2299.150 0.420 ;
     END
   END r0_rd_out[62]
   PIN r0_rd_out[63]
@@ -2918,7 +2918,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1156.830 0.000 1156.970 0.420 ;
+      RECT 2310.970 0.000 2311.110 0.420 ;
     END
   END r0_rd_out[63]
   PIN r0_rd_out[64]
@@ -2927,7 +2927,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1162.810 0.000 1162.950 0.420 ;
+      RECT 2322.930 0.000 2323.070 0.420 ;
     END
   END r0_rd_out[64]
   PIN r0_rd_out[65]
@@ -2936,7 +2936,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 540.890 1895.420 541.030 1895.840 ;
+      RECT 1108.990 1895.420 1109.130 1895.840 ;
     END
   END r0_rd_out[65]
   PIN r0_rd_out[66]
@@ -2945,7 +2945,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 549.170 1895.420 549.310 1895.840 ;
+      RECT 1126.010 1895.420 1126.150 1895.840 ;
     END
   END r0_rd_out[66]
   PIN r0_rd_out[67]
@@ -2954,7 +2954,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 557.450 1895.420 557.590 1895.840 ;
+      RECT 1143.030 1895.420 1143.170 1895.840 ;
     END
   END r0_rd_out[67]
   PIN r0_rd_out[68]
@@ -2963,7 +2963,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 565.730 1895.420 565.870 1895.840 ;
+      RECT 1160.050 1895.420 1160.190 1895.840 ;
     END
   END r0_rd_out[68]
   PIN r0_rd_out[69]
@@ -2972,7 +2972,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 574.010 1895.420 574.150 1895.840 ;
+      RECT 1177.070 1895.420 1177.210 1895.840 ;
     END
   END r0_rd_out[69]
   PIN r0_rd_out[70]
@@ -2981,7 +2981,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 582.290 1895.420 582.430 1895.840 ;
+      RECT 1194.090 1895.420 1194.230 1895.840 ;
     END
   END r0_rd_out[70]
   PIN r0_rd_out[71]
@@ -2990,7 +2990,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 590.570 1895.420 590.710 1895.840 ;
+      RECT 1211.110 1895.420 1211.250 1895.840 ;
     END
   END r0_rd_out[71]
   PIN r0_rd_out[72]
@@ -2999,7 +2999,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 598.850 1895.420 598.990 1895.840 ;
+      RECT 1228.130 1895.420 1228.270 1895.840 ;
     END
   END r0_rd_out[72]
   PIN r0_rd_out[73]
@@ -3008,7 +3008,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 607.130 1895.420 607.270 1895.840 ;
+      RECT 1245.150 1895.420 1245.290 1895.840 ;
     END
   END r0_rd_out[73]
   PIN r0_rd_out[74]
@@ -3017,7 +3017,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 615.410 1895.420 615.550 1895.840 ;
+      RECT 1262.170 1895.420 1262.310 1895.840 ;
     END
   END r0_rd_out[74]
   PIN r0_rd_out[75]
@@ -3026,7 +3026,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 623.690 1895.420 623.830 1895.840 ;
+      RECT 1279.190 1895.420 1279.330 1895.840 ;
     END
   END r0_rd_out[75]
   PIN r0_rd_out[76]
@@ -3035,7 +3035,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 631.970 1895.420 632.110 1895.840 ;
+      RECT 1296.210 1895.420 1296.350 1895.840 ;
     END
   END r0_rd_out[76]
   PIN r0_rd_out[77]
@@ -3044,7 +3044,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 640.250 1895.420 640.390 1895.840 ;
+      RECT 1313.230 1895.420 1313.370 1895.840 ;
     END
   END r0_rd_out[77]
   PIN r0_rd_out[78]
@@ -3053,7 +3053,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 648.530 1895.420 648.670 1895.840 ;
+      RECT 1330.250 1895.420 1330.390 1895.840 ;
     END
   END r0_rd_out[78]
   PIN r0_rd_out[79]
@@ -3062,7 +3062,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 656.810 1895.420 656.950 1895.840 ;
+      RECT 1347.270 1895.420 1347.410 1895.840 ;
     END
   END r0_rd_out[79]
   PIN r0_rd_out[80]
@@ -3071,7 +3071,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 665.090 1895.420 665.230 1895.840 ;
+      RECT 1364.290 1895.420 1364.430 1895.840 ;
     END
   END r0_rd_out[80]
   PIN r0_rd_out[81]
@@ -3080,7 +3080,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 673.370 1895.420 673.510 1895.840 ;
+      RECT 1381.310 1895.420 1381.450 1895.840 ;
     END
   END r0_rd_out[81]
   PIN r0_rd_out[82]
@@ -3089,7 +3089,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 681.650 1895.420 681.790 1895.840 ;
+      RECT 1398.330 1895.420 1398.470 1895.840 ;
     END
   END r0_rd_out[82]
   PIN r0_rd_out[83]
@@ -3098,7 +3098,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 689.930 1895.420 690.070 1895.840 ;
+      RECT 1415.350 1895.420 1415.490 1895.840 ;
     END
   END r0_rd_out[83]
   PIN r0_rd_out[84]
@@ -3107,7 +3107,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 698.210 1895.420 698.350 1895.840 ;
+      RECT 1432.370 1895.420 1432.510 1895.840 ;
     END
   END r0_rd_out[84]
   PIN r0_rd_out[85]
@@ -3116,7 +3116,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 706.490 1895.420 706.630 1895.840 ;
+      RECT 1449.390 1895.420 1449.530 1895.840 ;
     END
   END r0_rd_out[85]
   PIN r0_rd_out[86]
@@ -3125,7 +3125,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 714.770 1895.420 714.910 1895.840 ;
+      RECT 1466.410 1895.420 1466.550 1895.840 ;
     END
   END r0_rd_out[86]
   PIN r0_rd_out[87]
@@ -3134,7 +3134,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 723.050 1895.420 723.190 1895.840 ;
+      RECT 1483.430 1895.420 1483.570 1895.840 ;
     END
   END r0_rd_out[87]
   PIN r0_rd_out[88]
@@ -3143,7 +3143,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 731.330 1895.420 731.470 1895.840 ;
+      RECT 1500.450 1895.420 1500.590 1895.840 ;
     END
   END r0_rd_out[88]
   PIN r0_rd_out[89]
@@ -3152,7 +3152,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 739.610 1895.420 739.750 1895.840 ;
+      RECT 1517.470 1895.420 1517.610 1895.840 ;
     END
   END r0_rd_out[89]
   PIN r0_rd_out[90]
@@ -3161,7 +3161,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 747.890 1895.420 748.030 1895.840 ;
+      RECT 1534.490 1895.420 1534.630 1895.840 ;
     END
   END r0_rd_out[90]
   PIN r0_rd_out[91]
@@ -3170,7 +3170,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 756.170 1895.420 756.310 1895.840 ;
+      RECT 1551.510 1895.420 1551.650 1895.840 ;
     END
   END r0_rd_out[91]
   PIN r0_rd_out[92]
@@ -3179,7 +3179,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 764.450 1895.420 764.590 1895.840 ;
+      RECT 1568.530 1895.420 1568.670 1895.840 ;
     END
   END r0_rd_out[92]
   PIN r0_rd_out[93]
@@ -3188,7 +3188,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 772.730 1895.420 772.870 1895.840 ;
+      RECT 1585.550 1895.420 1585.690 1895.840 ;
     END
   END r0_rd_out[93]
   PIN r0_rd_out[94]
@@ -3197,7 +3197,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 781.010 1895.420 781.150 1895.840 ;
+      RECT 1602.570 1895.420 1602.710 1895.840 ;
     END
   END r0_rd_out[94]
   PIN r0_rd_out[95]
@@ -3206,7 +3206,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 789.290 1895.420 789.430 1895.840 ;
+      RECT 1619.590 1895.420 1619.730 1895.840 ;
     END
   END r0_rd_out[95]
   PIN r0_rd_out[96]
@@ -3215,7 +3215,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 797.570 1895.420 797.710 1895.840 ;
+      RECT 1636.610 1895.420 1636.750 1895.840 ;
     END
   END r0_rd_out[96]
   PIN r0_rd_out[97]
@@ -3224,7 +3224,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 805.850 1895.420 805.990 1895.840 ;
+      RECT 1653.630 1895.420 1653.770 1895.840 ;
     END
   END r0_rd_out[97]
   PIN r0_rd_out[98]
@@ -3233,7 +3233,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 814.130 1895.420 814.270 1895.840 ;
+      RECT 1670.650 1895.420 1670.790 1895.840 ;
     END
   END r0_rd_out[98]
   PIN r0_rd_out[99]
@@ -3242,7 +3242,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 822.410 1895.420 822.550 1895.840 ;
+      RECT 1687.670 1895.420 1687.810 1895.840 ;
     END
   END r0_rd_out[99]
   PIN r0_rd_out[100]
@@ -3251,7 +3251,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 830.690 1895.420 830.830 1895.840 ;
+      RECT 1704.690 1895.420 1704.830 1895.840 ;
     END
   END r0_rd_out[100]
   PIN r0_rd_out[101]
@@ -3260,7 +3260,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 838.970 1895.420 839.110 1895.840 ;
+      RECT 1721.710 1895.420 1721.850 1895.840 ;
     END
   END r0_rd_out[101]
   PIN r0_rd_out[102]
@@ -3269,7 +3269,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 847.250 1895.420 847.390 1895.840 ;
+      RECT 1738.730 1895.420 1738.870 1895.840 ;
     END
   END r0_rd_out[102]
   PIN r0_rd_out[103]
@@ -3278,7 +3278,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 855.530 1895.420 855.670 1895.840 ;
+      RECT 1755.750 1895.420 1755.890 1895.840 ;
     END
   END r0_rd_out[103]
   PIN r0_rd_out[104]
@@ -3287,7 +3287,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 863.810 1895.420 863.950 1895.840 ;
+      RECT 1772.770 1895.420 1772.910 1895.840 ;
     END
   END r0_rd_out[104]
   PIN r0_rd_out[105]
@@ -3296,7 +3296,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 872.090 1895.420 872.230 1895.840 ;
+      RECT 1789.790 1895.420 1789.930 1895.840 ;
     END
   END r0_rd_out[105]
   PIN r0_rd_out[106]
@@ -3305,7 +3305,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 880.370 1895.420 880.510 1895.840 ;
+      RECT 1806.810 1895.420 1806.950 1895.840 ;
     END
   END r0_rd_out[106]
   PIN r0_rd_out[107]
@@ -3314,7 +3314,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 888.650 1895.420 888.790 1895.840 ;
+      RECT 1823.830 1895.420 1823.970 1895.840 ;
     END
   END r0_rd_out[107]
   PIN r0_rd_out[108]
@@ -3323,7 +3323,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 896.930 1895.420 897.070 1895.840 ;
+      RECT 1840.850 1895.420 1840.990 1895.840 ;
     END
   END r0_rd_out[108]
   PIN r0_rd_out[109]
@@ -3332,7 +3332,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 905.210 1895.420 905.350 1895.840 ;
+      RECT 1857.870 1895.420 1858.010 1895.840 ;
     END
   END r0_rd_out[109]
   PIN r0_rd_out[110]
@@ -3341,7 +3341,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 913.490 1895.420 913.630 1895.840 ;
+      RECT 1874.890 1895.420 1875.030 1895.840 ;
     END
   END r0_rd_out[110]
   PIN r0_rd_out[111]
@@ -3350,7 +3350,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 921.770 1895.420 921.910 1895.840 ;
+      RECT 1891.910 1895.420 1892.050 1895.840 ;
     END
   END r0_rd_out[111]
   PIN r0_rd_out[112]
@@ -3359,7 +3359,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 930.050 1895.420 930.190 1895.840 ;
+      RECT 1908.930 1895.420 1909.070 1895.840 ;
     END
   END r0_rd_out[112]
   PIN r0_rd_out[113]
@@ -3368,7 +3368,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 938.330 1895.420 938.470 1895.840 ;
+      RECT 1925.950 1895.420 1926.090 1895.840 ;
     END
   END r0_rd_out[113]
   PIN r0_rd_out[114]
@@ -3377,7 +3377,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 946.610 1895.420 946.750 1895.840 ;
+      RECT 1942.970 1895.420 1943.110 1895.840 ;
     END
   END r0_rd_out[114]
   PIN r0_rd_out[115]
@@ -3386,7 +3386,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 954.890 1895.420 955.030 1895.840 ;
+      RECT 1959.990 1895.420 1960.130 1895.840 ;
     END
   END r0_rd_out[115]
   PIN r0_rd_out[116]
@@ -3395,7 +3395,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 963.170 1895.420 963.310 1895.840 ;
+      RECT 1977.010 1895.420 1977.150 1895.840 ;
     END
   END r0_rd_out[116]
   PIN r0_rd_out[117]
@@ -3404,7 +3404,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 971.450 1895.420 971.590 1895.840 ;
+      RECT 1994.030 1895.420 1994.170 1895.840 ;
     END
   END r0_rd_out[117]
   PIN r0_rd_out[118]
@@ -3413,7 +3413,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 979.730 1895.420 979.870 1895.840 ;
+      RECT 2011.050 1895.420 2011.190 1895.840 ;
     END
   END r0_rd_out[118]
   PIN r0_rd_out[119]
@@ -3422,7 +3422,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 988.010 1895.420 988.150 1895.840 ;
+      RECT 2028.070 1895.420 2028.210 1895.840 ;
     END
   END r0_rd_out[119]
   PIN r0_rd_out[120]
@@ -3431,7 +3431,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 996.290 1895.420 996.430 1895.840 ;
+      RECT 2045.090 1895.420 2045.230 1895.840 ;
     END
   END r0_rd_out[120]
   PIN r0_rd_out[121]
@@ -3440,7 +3440,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1004.570 1895.420 1004.710 1895.840 ;
+      RECT 2062.110 1895.420 2062.250 1895.840 ;
     END
   END r0_rd_out[121]
   PIN r0_rd_out[122]
@@ -3449,7 +3449,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1012.850 1895.420 1012.990 1895.840 ;
+      RECT 2079.130 1895.420 2079.270 1895.840 ;
     END
   END r0_rd_out[122]
   PIN r0_rd_out[123]
@@ -3458,7 +3458,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1021.130 1895.420 1021.270 1895.840 ;
+      RECT 2096.150 1895.420 2096.290 1895.840 ;
     END
   END r0_rd_out[123]
   PIN r0_rd_out[124]
@@ -3467,7 +3467,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1029.410 1895.420 1029.550 1895.840 ;
+      RECT 2113.170 1895.420 2113.310 1895.840 ;
     END
   END r0_rd_out[124]
   PIN r0_rd_out[125]
@@ -3476,7 +3476,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1037.690 1895.420 1037.830 1895.840 ;
+      RECT 2130.190 1895.420 2130.330 1895.840 ;
     END
   END r0_rd_out[125]
   PIN r0_rd_out[126]
@@ -3485,7 +3485,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1045.970 1895.420 1046.110 1895.840 ;
+      RECT 2147.210 1895.420 2147.350 1895.840 ;
     END
   END r0_rd_out[126]
   PIN r0_rd_out[127]
@@ -3494,7 +3494,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1054.250 1895.420 1054.390 1895.840 ;
+      RECT 2164.230 1895.420 2164.370 1895.840 ;
     END
   END r0_rd_out[127]
   PIN r0_rd_out[128]
@@ -3503,7 +3503,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1062.530 1895.420 1062.670 1895.840 ;
+      RECT 2181.250 1895.420 2181.390 1895.840 ;
     END
   END r0_rd_out[128]
   PIN r0_rd_out[129]
@@ -3512,7 +3512,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1070.810 1895.420 1070.950 1895.840 ;
+      RECT 2198.270 1895.420 2198.410 1895.840 ;
     END
   END r0_rd_out[129]
   PIN rw0_addr_in[0]
@@ -3521,7 +3521,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1484.970 0.900 1485.270 ;
+      RECT 0.000 1440.090 0.900 1440.390 ;
     END
   END rw0_addr_in[0]
   PIN rw0_addr_in[1]
@@ -3530,7 +3530,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1529.850 0.900 1530.150 ;
+      RECT 0.000 1483.610 0.900 1483.910 ;
     END
   END rw0_addr_in[1]
   PIN rw0_addr_in[2]
@@ -3539,7 +3539,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1574.730 0.900 1575.030 ;
+      RECT 0.000 1527.130 0.900 1527.430 ;
     END
   END rw0_addr_in[2]
   PIN rw0_addr_in[3]
@@ -3548,7 +3548,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1619.610 0.900 1619.910 ;
+      RECT 0.000 1570.650 0.900 1570.950 ;
     END
   END rw0_addr_in[3]
   PIN rw0_addr_in[4]
@@ -3557,7 +3557,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1664.490 0.900 1664.790 ;
+      RECT 0.000 1614.170 0.900 1614.470 ;
     END
   END rw0_addr_in[4]
   PIN rw0_addr_in[5]
@@ -3566,7 +3566,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1440.090 1182.660 1440.390 ;
+      RECT 2363.960 1396.570 2364.860 1396.870 ;
     END
   END rw0_addr_in[5]
   PIN rw0_addr_in[6]
@@ -3575,7 +3575,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1484.970 1182.660 1485.270 ;
+      RECT 2363.960 1440.090 2364.860 1440.390 ;
     END
   END rw0_addr_in[6]
   PIN rw0_addr_in[7]
@@ -3584,7 +3584,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1529.850 1182.660 1530.150 ;
+      RECT 2363.960 1483.610 2364.860 1483.910 ;
     END
   END rw0_addr_in[7]
   PIN rw0_addr_in[8]
@@ -3593,16 +3593,25 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1574.730 1182.660 1575.030 ;
+      RECT 2363.960 1527.130 2364.860 1527.430 ;
     END
   END rw0_addr_in[8]
+  PIN rw0_addr_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 2363.960 1570.650 2364.860 1570.950 ;
+    END
+  END rw0_addr_in[9]
   PIN r0_addr_in[0]
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1709.370 0.900 1709.670 ;
+      RECT 0.000 1657.690 0.900 1657.990 ;
     END
   END r0_addr_in[0]
   PIN r0_addr_in[1]
@@ -3611,7 +3620,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1754.250 0.900 1754.550 ;
+      RECT 0.000 1701.210 0.900 1701.510 ;
     END
   END r0_addr_in[1]
   PIN r0_addr_in[2]
@@ -3620,7 +3629,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1799.130 0.900 1799.430 ;
+      RECT 0.000 1744.730 0.900 1745.030 ;
     END
   END r0_addr_in[2]
   PIN r0_addr_in[3]
@@ -3629,7 +3638,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1844.010 0.900 1844.310 ;
+      RECT 0.000 1788.250 0.900 1788.550 ;
     END
   END r0_addr_in[3]
   PIN r0_addr_in[4]
@@ -3638,7 +3647,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1888.890 0.900 1889.190 ;
+      RECT 0.000 1831.770 0.900 1832.070 ;
     END
   END r0_addr_in[4]
   PIN r0_addr_in[5]
@@ -3647,7 +3656,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1619.610 1182.660 1619.910 ;
+      RECT 2363.960 1614.170 2364.860 1614.470 ;
     END
   END r0_addr_in[5]
   PIN r0_addr_in[6]
@@ -3656,7 +3665,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1664.490 1182.660 1664.790 ;
+      RECT 2363.960 1657.690 2364.860 1657.990 ;
     END
   END r0_addr_in[6]
   PIN r0_addr_in[7]
@@ -3665,7 +3674,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1709.370 1182.660 1709.670 ;
+      RECT 2363.960 1701.210 2364.860 1701.510 ;
     END
   END r0_addr_in[7]
   PIN r0_addr_in[8]
@@ -3674,16 +3683,25 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 1181.760 1754.250 1182.660 1754.550 ;
+      RECT 2363.960 1744.730 2364.860 1745.030 ;
     END
   END r0_addr_in[8]
+  PIN r0_addr_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 2363.960 1788.250 2364.860 1788.550 ;
+    END
+  END r0_addr_in[9]
   PIN rw0_we_in
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1079.090 1895.420 1079.230 1895.840 ;
+      RECT 2215.290 1895.420 2215.430 1895.840 ;
     END
   END rw0_we_in
   PIN rw0_ce_in
@@ -3692,7 +3710,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1087.370 1895.420 1087.510 1895.840 ;
+      RECT 2232.310 1895.420 2232.450 1895.840 ;
     END
   END rw0_ce_in
   PIN rw0_clk
@@ -3701,7 +3719,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1095.650 1895.420 1095.790 1895.840 ;
+      RECT 2249.330 1895.420 2249.470 1895.840 ;
     END
   END rw0_clk
   PIN r0_ce_in
@@ -3710,7 +3728,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1103.930 1895.420 1104.070 1895.840 ;
+      RECT 2266.350 1895.420 2266.490 1895.840 ;
     END
   END r0_ce_in
   PIN r0_clk
@@ -3719,7 +3737,7 @@ MACRO fakeram130_1rw1r_130w512d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1112.210 1895.420 1112.350 1895.840 ;
+      RECT 2283.370 1895.420 2283.510 1895.840 ;
     END
   END r0_clk
   PIN VSS
@@ -3836,6 +3854,115 @@ MACRO fakeram130_1rw1r_130w512d
       RECT 1155.440 4.080 1156.640 1891.760 ;
       RECT 1166.320 4.080 1167.520 1891.760 ;
       RECT 1177.200 4.080 1178.400 1891.760 ;
+      RECT 1188.080 4.080 1189.280 1891.760 ;
+      RECT 1198.960 4.080 1200.160 1891.760 ;
+      RECT 1209.840 4.080 1211.040 1891.760 ;
+      RECT 1220.720 4.080 1221.920 1891.760 ;
+      RECT 1231.600 4.080 1232.800 1891.760 ;
+      RECT 1242.480 4.080 1243.680 1891.760 ;
+      RECT 1253.360 4.080 1254.560 1891.760 ;
+      RECT 1264.240 4.080 1265.440 1891.760 ;
+      RECT 1275.120 4.080 1276.320 1891.760 ;
+      RECT 1286.000 4.080 1287.200 1891.760 ;
+      RECT 1296.880 4.080 1298.080 1891.760 ;
+      RECT 1307.760 4.080 1308.960 1891.760 ;
+      RECT 1318.640 4.080 1319.840 1891.760 ;
+      RECT 1329.520 4.080 1330.720 1891.760 ;
+      RECT 1340.400 4.080 1341.600 1891.760 ;
+      RECT 1351.280 4.080 1352.480 1891.760 ;
+      RECT 1362.160 4.080 1363.360 1891.760 ;
+      RECT 1373.040 4.080 1374.240 1891.760 ;
+      RECT 1383.920 4.080 1385.120 1891.760 ;
+      RECT 1394.800 4.080 1396.000 1891.760 ;
+      RECT 1405.680 4.080 1406.880 1891.760 ;
+      RECT 1416.560 4.080 1417.760 1891.760 ;
+      RECT 1427.440 4.080 1428.640 1891.760 ;
+      RECT 1438.320 4.080 1439.520 1891.760 ;
+      RECT 1449.200 4.080 1450.400 1891.760 ;
+      RECT 1460.080 4.080 1461.280 1891.760 ;
+      RECT 1470.960 4.080 1472.160 1891.760 ;
+      RECT 1481.840 4.080 1483.040 1891.760 ;
+      RECT 1492.720 4.080 1493.920 1891.760 ;
+      RECT 1503.600 4.080 1504.800 1891.760 ;
+      RECT 1514.480 4.080 1515.680 1891.760 ;
+      RECT 1525.360 4.080 1526.560 1891.760 ;
+      RECT 1536.240 4.080 1537.440 1891.760 ;
+      RECT 1547.120 4.080 1548.320 1891.760 ;
+      RECT 1558.000 4.080 1559.200 1891.760 ;
+      RECT 1568.880 4.080 1570.080 1891.760 ;
+      RECT 1579.760 4.080 1580.960 1891.760 ;
+      RECT 1590.640 4.080 1591.840 1891.760 ;
+      RECT 1601.520 4.080 1602.720 1891.760 ;
+      RECT 1612.400 4.080 1613.600 1891.760 ;
+      RECT 1623.280 4.080 1624.480 1891.760 ;
+      RECT 1634.160 4.080 1635.360 1891.760 ;
+      RECT 1645.040 4.080 1646.240 1891.760 ;
+      RECT 1655.920 4.080 1657.120 1891.760 ;
+      RECT 1666.800 4.080 1668.000 1891.760 ;
+      RECT 1677.680 4.080 1678.880 1891.760 ;
+      RECT 1688.560 4.080 1689.760 1891.760 ;
+      RECT 1699.440 4.080 1700.640 1891.760 ;
+      RECT 1710.320 4.080 1711.520 1891.760 ;
+      RECT 1721.200 4.080 1722.400 1891.760 ;
+      RECT 1732.080 4.080 1733.280 1891.760 ;
+      RECT 1742.960 4.080 1744.160 1891.760 ;
+      RECT 1753.840 4.080 1755.040 1891.760 ;
+      RECT 1764.720 4.080 1765.920 1891.760 ;
+      RECT 1775.600 4.080 1776.800 1891.760 ;
+      RECT 1786.480 4.080 1787.680 1891.760 ;
+      RECT 1797.360 4.080 1798.560 1891.760 ;
+      RECT 1808.240 4.080 1809.440 1891.760 ;
+      RECT 1819.120 4.080 1820.320 1891.760 ;
+      RECT 1830.000 4.080 1831.200 1891.760 ;
+      RECT 1840.880 4.080 1842.080 1891.760 ;
+      RECT 1851.760 4.080 1852.960 1891.760 ;
+      RECT 1862.640 4.080 1863.840 1891.760 ;
+      RECT 1873.520 4.080 1874.720 1891.760 ;
+      RECT 1884.400 4.080 1885.600 1891.760 ;
+      RECT 1895.280 4.080 1896.480 1891.760 ;
+      RECT 1906.160 4.080 1907.360 1891.760 ;
+      RECT 1917.040 4.080 1918.240 1891.760 ;
+      RECT 1927.920 4.080 1929.120 1891.760 ;
+      RECT 1938.800 4.080 1940.000 1891.760 ;
+      RECT 1949.680 4.080 1950.880 1891.760 ;
+      RECT 1960.560 4.080 1961.760 1891.760 ;
+      RECT 1971.440 4.080 1972.640 1891.760 ;
+      RECT 1982.320 4.080 1983.520 1891.760 ;
+      RECT 1993.200 4.080 1994.400 1891.760 ;
+      RECT 2004.080 4.080 2005.280 1891.760 ;
+      RECT 2014.960 4.080 2016.160 1891.760 ;
+      RECT 2025.840 4.080 2027.040 1891.760 ;
+      RECT 2036.720 4.080 2037.920 1891.760 ;
+      RECT 2047.600 4.080 2048.800 1891.760 ;
+      RECT 2058.480 4.080 2059.680 1891.760 ;
+      RECT 2069.360 4.080 2070.560 1891.760 ;
+      RECT 2080.240 4.080 2081.440 1891.760 ;
+      RECT 2091.120 4.080 2092.320 1891.760 ;
+      RECT 2102.000 4.080 2103.200 1891.760 ;
+      RECT 2112.880 4.080 2114.080 1891.760 ;
+      RECT 2123.760 4.080 2124.960 1891.760 ;
+      RECT 2134.640 4.080 2135.840 1891.760 ;
+      RECT 2145.520 4.080 2146.720 1891.760 ;
+      RECT 2156.400 4.080 2157.600 1891.760 ;
+      RECT 2167.280 4.080 2168.480 1891.760 ;
+      RECT 2178.160 4.080 2179.360 1891.760 ;
+      RECT 2189.040 4.080 2190.240 1891.760 ;
+      RECT 2199.920 4.080 2201.120 1891.760 ;
+      RECT 2210.800 4.080 2212.000 1891.760 ;
+      RECT 2221.680 4.080 2222.880 1891.760 ;
+      RECT 2232.560 4.080 2233.760 1891.760 ;
+      RECT 2243.440 4.080 2244.640 1891.760 ;
+      RECT 2254.320 4.080 2255.520 1891.760 ;
+      RECT 2265.200 4.080 2266.400 1891.760 ;
+      RECT 2276.080 4.080 2277.280 1891.760 ;
+      RECT 2286.960 4.080 2288.160 1891.760 ;
+      RECT 2297.840 4.080 2299.040 1891.760 ;
+      RECT 2308.720 4.080 2309.920 1891.760 ;
+      RECT 2319.600 4.080 2320.800 1891.760 ;
+      RECT 2330.480 4.080 2331.680 1891.760 ;
+      RECT 2341.360 4.080 2342.560 1891.760 ;
+      RECT 2352.240 4.080 2353.440 1891.760 ;
+      RECT 2363.120 4.080 2364.320 1891.760 ;
     END
   END VSS
   PIN VDD
@@ -3952,18 +4079,127 @@ MACRO fakeram130_1rw1r_130w512d
       RECT 1155.440 4.080 1156.640 1891.760 ;
       RECT 1166.320 4.080 1167.520 1891.760 ;
       RECT 1177.200 4.080 1178.400 1891.760 ;
+      RECT 1188.080 4.080 1189.280 1891.760 ;
+      RECT 1198.960 4.080 1200.160 1891.760 ;
+      RECT 1209.840 4.080 1211.040 1891.760 ;
+      RECT 1220.720 4.080 1221.920 1891.760 ;
+      RECT 1231.600 4.080 1232.800 1891.760 ;
+      RECT 1242.480 4.080 1243.680 1891.760 ;
+      RECT 1253.360 4.080 1254.560 1891.760 ;
+      RECT 1264.240 4.080 1265.440 1891.760 ;
+      RECT 1275.120 4.080 1276.320 1891.760 ;
+      RECT 1286.000 4.080 1287.200 1891.760 ;
+      RECT 1296.880 4.080 1298.080 1891.760 ;
+      RECT 1307.760 4.080 1308.960 1891.760 ;
+      RECT 1318.640 4.080 1319.840 1891.760 ;
+      RECT 1329.520 4.080 1330.720 1891.760 ;
+      RECT 1340.400 4.080 1341.600 1891.760 ;
+      RECT 1351.280 4.080 1352.480 1891.760 ;
+      RECT 1362.160 4.080 1363.360 1891.760 ;
+      RECT 1373.040 4.080 1374.240 1891.760 ;
+      RECT 1383.920 4.080 1385.120 1891.760 ;
+      RECT 1394.800 4.080 1396.000 1891.760 ;
+      RECT 1405.680 4.080 1406.880 1891.760 ;
+      RECT 1416.560 4.080 1417.760 1891.760 ;
+      RECT 1427.440 4.080 1428.640 1891.760 ;
+      RECT 1438.320 4.080 1439.520 1891.760 ;
+      RECT 1449.200 4.080 1450.400 1891.760 ;
+      RECT 1460.080 4.080 1461.280 1891.760 ;
+      RECT 1470.960 4.080 1472.160 1891.760 ;
+      RECT 1481.840 4.080 1483.040 1891.760 ;
+      RECT 1492.720 4.080 1493.920 1891.760 ;
+      RECT 1503.600 4.080 1504.800 1891.760 ;
+      RECT 1514.480 4.080 1515.680 1891.760 ;
+      RECT 1525.360 4.080 1526.560 1891.760 ;
+      RECT 1536.240 4.080 1537.440 1891.760 ;
+      RECT 1547.120 4.080 1548.320 1891.760 ;
+      RECT 1558.000 4.080 1559.200 1891.760 ;
+      RECT 1568.880 4.080 1570.080 1891.760 ;
+      RECT 1579.760 4.080 1580.960 1891.760 ;
+      RECT 1590.640 4.080 1591.840 1891.760 ;
+      RECT 1601.520 4.080 1602.720 1891.760 ;
+      RECT 1612.400 4.080 1613.600 1891.760 ;
+      RECT 1623.280 4.080 1624.480 1891.760 ;
+      RECT 1634.160 4.080 1635.360 1891.760 ;
+      RECT 1645.040 4.080 1646.240 1891.760 ;
+      RECT 1655.920 4.080 1657.120 1891.760 ;
+      RECT 1666.800 4.080 1668.000 1891.760 ;
+      RECT 1677.680 4.080 1678.880 1891.760 ;
+      RECT 1688.560 4.080 1689.760 1891.760 ;
+      RECT 1699.440 4.080 1700.640 1891.760 ;
+      RECT 1710.320 4.080 1711.520 1891.760 ;
+      RECT 1721.200 4.080 1722.400 1891.760 ;
+      RECT 1732.080 4.080 1733.280 1891.760 ;
+      RECT 1742.960 4.080 1744.160 1891.760 ;
+      RECT 1753.840 4.080 1755.040 1891.760 ;
+      RECT 1764.720 4.080 1765.920 1891.760 ;
+      RECT 1775.600 4.080 1776.800 1891.760 ;
+      RECT 1786.480 4.080 1787.680 1891.760 ;
+      RECT 1797.360 4.080 1798.560 1891.760 ;
+      RECT 1808.240 4.080 1809.440 1891.760 ;
+      RECT 1819.120 4.080 1820.320 1891.760 ;
+      RECT 1830.000 4.080 1831.200 1891.760 ;
+      RECT 1840.880 4.080 1842.080 1891.760 ;
+      RECT 1851.760 4.080 1852.960 1891.760 ;
+      RECT 1862.640 4.080 1863.840 1891.760 ;
+      RECT 1873.520 4.080 1874.720 1891.760 ;
+      RECT 1884.400 4.080 1885.600 1891.760 ;
+      RECT 1895.280 4.080 1896.480 1891.760 ;
+      RECT 1906.160 4.080 1907.360 1891.760 ;
+      RECT 1917.040 4.080 1918.240 1891.760 ;
+      RECT 1927.920 4.080 1929.120 1891.760 ;
+      RECT 1938.800 4.080 1940.000 1891.760 ;
+      RECT 1949.680 4.080 1950.880 1891.760 ;
+      RECT 1960.560 4.080 1961.760 1891.760 ;
+      RECT 1971.440 4.080 1972.640 1891.760 ;
+      RECT 1982.320 4.080 1983.520 1891.760 ;
+      RECT 1993.200 4.080 1994.400 1891.760 ;
+      RECT 2004.080 4.080 2005.280 1891.760 ;
+      RECT 2014.960 4.080 2016.160 1891.760 ;
+      RECT 2025.840 4.080 2027.040 1891.760 ;
+      RECT 2036.720 4.080 2037.920 1891.760 ;
+      RECT 2047.600 4.080 2048.800 1891.760 ;
+      RECT 2058.480 4.080 2059.680 1891.760 ;
+      RECT 2069.360 4.080 2070.560 1891.760 ;
+      RECT 2080.240 4.080 2081.440 1891.760 ;
+      RECT 2091.120 4.080 2092.320 1891.760 ;
+      RECT 2102.000 4.080 2103.200 1891.760 ;
+      RECT 2112.880 4.080 2114.080 1891.760 ;
+      RECT 2123.760 4.080 2124.960 1891.760 ;
+      RECT 2134.640 4.080 2135.840 1891.760 ;
+      RECT 2145.520 4.080 2146.720 1891.760 ;
+      RECT 2156.400 4.080 2157.600 1891.760 ;
+      RECT 2167.280 4.080 2168.480 1891.760 ;
+      RECT 2178.160 4.080 2179.360 1891.760 ;
+      RECT 2189.040 4.080 2190.240 1891.760 ;
+      RECT 2199.920 4.080 2201.120 1891.760 ;
+      RECT 2210.800 4.080 2212.000 1891.760 ;
+      RECT 2221.680 4.080 2222.880 1891.760 ;
+      RECT 2232.560 4.080 2233.760 1891.760 ;
+      RECT 2243.440 4.080 2244.640 1891.760 ;
+      RECT 2254.320 4.080 2255.520 1891.760 ;
+      RECT 2265.200 4.080 2266.400 1891.760 ;
+      RECT 2276.080 4.080 2277.280 1891.760 ;
+      RECT 2286.960 4.080 2288.160 1891.760 ;
+      RECT 2297.840 4.080 2299.040 1891.760 ;
+      RECT 2308.720 4.080 2309.920 1891.760 ;
+      RECT 2319.600 4.080 2320.800 1891.760 ;
+      RECT 2330.480 4.080 2331.680 1891.760 ;
+      RECT 2341.360 4.080 2342.560 1891.760 ;
+      RECT 2352.240 4.080 2353.440 1891.760 ;
+      RECT 2363.120 4.080 2364.320 1891.760 ;
     END
   END VDD
   OBS
     LAYER met1 ;
-    RECT 0 0 1182.660 1895.840 ;
+    RECT 0 0 2364.860 1895.840 ;
     LAYER met2 ;
-    RECT 0 0 1182.660 1895.840 ;
+    RECT 0 0 2364.860 1895.840 ;
     LAYER met3 ;
-    RECT 0 0 1182.660 1895.840 ;
+    RECT 0 0 2364.860 1895.840 ;
     LAYER met4 ;
-    RECT 0 0 1182.660 1895.840 ;
+    RECT 0 0 2364.860 1895.840 ;
   END
-END fakeram130_1rw1r_130w512d
+END fakeram_1rw1r_130w1024d_sram
 
 END LIBRARY

--- a/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_130w128d_sram.lef
+++ b/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_130w128d_sram.lef
@@ -1,9 +1,9 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram130_1rw1r_130w1024d
-  FOREIGN fakeram130_1rw1r_130w1024d 0 0 ;
+MACRO fakeram_1rw1r_130w128d_sram
+  FOREIGN fakeram_1rw1r_130w128d_sram 0 0 ;
   SYMMETRY X Y R90 ;
-  SIZE 2364.860 BY 1895.840 ;
+  SIZE 591.560 BY 949.280 ;
   CLASS BLOCK ;
   PIN rw0_wd_in[0]
     DIRECTION INPUT ;
@@ -20,7 +20,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 47.450 0.900 47.750 ;
+      RECT 0.000 27.050 0.900 27.350 ;
     END
   END rw0_wd_in[1]
   PIN rw0_wd_in[2]
@@ -29,7 +29,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 90.970 0.900 91.270 ;
+      RECT 0.000 50.170 0.900 50.470 ;
     END
   END rw0_wd_in[2]
   PIN rw0_wd_in[3]
@@ -38,7 +38,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 134.490 0.900 134.790 ;
+      RECT 0.000 73.290 0.900 73.590 ;
     END
   END rw0_wd_in[3]
   PIN rw0_wd_in[4]
@@ -47,7 +47,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 178.010 0.900 178.310 ;
+      RECT 0.000 96.410 0.900 96.710 ;
     END
   END rw0_wd_in[4]
   PIN rw0_wd_in[5]
@@ -56,7 +56,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 221.530 0.900 221.830 ;
+      RECT 0.000 119.530 0.900 119.830 ;
     END
   END rw0_wd_in[5]
   PIN rw0_wd_in[6]
@@ -65,7 +65,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 265.050 0.900 265.350 ;
+      RECT 0.000 142.650 0.900 142.950 ;
     END
   END rw0_wd_in[6]
   PIN rw0_wd_in[7]
@@ -74,7 +74,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 308.570 0.900 308.870 ;
+      RECT 0.000 165.770 0.900 166.070 ;
     END
   END rw0_wd_in[7]
   PIN rw0_wd_in[8]
@@ -83,7 +83,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 352.090 0.900 352.390 ;
+      RECT 0.000 188.890 0.900 189.190 ;
     END
   END rw0_wd_in[8]
   PIN rw0_wd_in[9]
@@ -92,7 +92,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 395.610 0.900 395.910 ;
+      RECT 0.000 212.010 0.900 212.310 ;
     END
   END rw0_wd_in[9]
   PIN rw0_wd_in[10]
@@ -101,7 +101,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 439.130 0.900 439.430 ;
+      RECT 0.000 235.130 0.900 235.430 ;
     END
   END rw0_wd_in[10]
   PIN rw0_wd_in[11]
@@ -110,7 +110,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 482.650 0.900 482.950 ;
+      RECT 0.000 258.250 0.900 258.550 ;
     END
   END rw0_wd_in[11]
   PIN rw0_wd_in[12]
@@ -119,7 +119,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 526.170 0.900 526.470 ;
+      RECT 0.000 281.370 0.900 281.670 ;
     END
   END rw0_wd_in[12]
   PIN rw0_wd_in[13]
@@ -128,7 +128,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 569.690 0.900 569.990 ;
+      RECT 0.000 304.490 0.900 304.790 ;
     END
   END rw0_wd_in[13]
   PIN rw0_wd_in[14]
@@ -137,7 +137,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 613.210 0.900 613.510 ;
+      RECT 0.000 327.610 0.900 327.910 ;
     END
   END rw0_wd_in[14]
   PIN rw0_wd_in[15]
@@ -146,7 +146,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 656.730 0.900 657.030 ;
+      RECT 0.000 350.730 0.900 351.030 ;
     END
   END rw0_wd_in[15]
   PIN rw0_wd_in[16]
@@ -155,7 +155,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 700.250 0.900 700.550 ;
+      RECT 0.000 373.850 0.900 374.150 ;
     END
   END rw0_wd_in[16]
   PIN rw0_wd_in[17]
@@ -164,7 +164,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 743.770 0.900 744.070 ;
+      RECT 0.000 396.970 0.900 397.270 ;
     END
   END rw0_wd_in[17]
   PIN rw0_wd_in[18]
@@ -173,7 +173,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 787.290 0.900 787.590 ;
+      RECT 0.000 420.090 0.900 420.390 ;
     END
   END rw0_wd_in[18]
   PIN rw0_wd_in[19]
@@ -182,7 +182,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 830.810 0.900 831.110 ;
+      RECT 0.000 443.210 0.900 443.510 ;
     END
   END rw0_wd_in[19]
   PIN rw0_wd_in[20]
@@ -191,7 +191,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 874.330 0.900 874.630 ;
+      RECT 0.000 466.330 0.900 466.630 ;
     END
   END rw0_wd_in[20]
   PIN rw0_wd_in[21]
@@ -200,7 +200,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 917.850 0.900 918.150 ;
+      RECT 0.000 489.450 0.900 489.750 ;
     END
   END rw0_wd_in[21]
   PIN rw0_wd_in[22]
@@ -209,7 +209,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 961.370 0.900 961.670 ;
+      RECT 0.000 512.570 0.900 512.870 ;
     END
   END rw0_wd_in[22]
   PIN rw0_wd_in[23]
@@ -218,7 +218,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1004.890 0.900 1005.190 ;
+      RECT 0.000 535.690 0.900 535.990 ;
     END
   END rw0_wd_in[23]
   PIN rw0_wd_in[24]
@@ -227,7 +227,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1048.410 0.900 1048.710 ;
+      RECT 0.000 558.810 0.900 559.110 ;
     END
   END rw0_wd_in[24]
   PIN rw0_wd_in[25]
@@ -236,7 +236,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1091.930 0.900 1092.230 ;
+      RECT 0.000 581.930 0.900 582.230 ;
     END
   END rw0_wd_in[25]
   PIN rw0_wd_in[26]
@@ -245,7 +245,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1135.450 0.900 1135.750 ;
+      RECT 0.000 605.050 0.900 605.350 ;
     END
   END rw0_wd_in[26]
   PIN rw0_wd_in[27]
@@ -254,7 +254,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1178.970 0.900 1179.270 ;
+      RECT 0.000 628.170 0.900 628.470 ;
     END
   END rw0_wd_in[27]
   PIN rw0_wd_in[28]
@@ -263,7 +263,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1222.490 0.900 1222.790 ;
+      RECT 0.000 651.290 0.900 651.590 ;
     END
   END rw0_wd_in[28]
   PIN rw0_wd_in[29]
@@ -272,7 +272,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1266.010 0.900 1266.310 ;
+      RECT 0.000 674.410 0.900 674.710 ;
     END
   END rw0_wd_in[29]
   PIN rw0_wd_in[30]
@@ -281,7 +281,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1309.530 0.900 1309.830 ;
+      RECT 0.000 697.530 0.900 697.830 ;
     END
   END rw0_wd_in[30]
   PIN rw0_wd_in[31]
@@ -290,7 +290,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1353.050 0.900 1353.350 ;
+      RECT 0.000 720.650 0.900 720.950 ;
     END
   END rw0_wd_in[31]
   PIN rw0_wd_in[32]
@@ -299,7 +299,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1396.570 0.900 1396.870 ;
+      RECT 0.000 743.770 0.900 744.070 ;
     END
   END rw0_wd_in[32]
   PIN rw0_wd_in[33]
@@ -308,7 +308,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 3.930 2364.860 4.230 ;
+      RECT 590.660 3.930 591.560 4.230 ;
     END
   END rw0_wd_in[33]
   PIN rw0_wd_in[34]
@@ -317,7 +317,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 47.450 2364.860 47.750 ;
+      RECT 590.660 27.050 591.560 27.350 ;
     END
   END rw0_wd_in[34]
   PIN rw0_wd_in[35]
@@ -326,7 +326,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 90.970 2364.860 91.270 ;
+      RECT 590.660 50.170 591.560 50.470 ;
     END
   END rw0_wd_in[35]
   PIN rw0_wd_in[36]
@@ -335,7 +335,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 134.490 2364.860 134.790 ;
+      RECT 590.660 73.290 591.560 73.590 ;
     END
   END rw0_wd_in[36]
   PIN rw0_wd_in[37]
@@ -344,7 +344,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 178.010 2364.860 178.310 ;
+      RECT 590.660 96.410 591.560 96.710 ;
     END
   END rw0_wd_in[37]
   PIN rw0_wd_in[38]
@@ -353,7 +353,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 221.530 2364.860 221.830 ;
+      RECT 590.660 119.530 591.560 119.830 ;
     END
   END rw0_wd_in[38]
   PIN rw0_wd_in[39]
@@ -362,7 +362,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 265.050 2364.860 265.350 ;
+      RECT 590.660 142.650 591.560 142.950 ;
     END
   END rw0_wd_in[39]
   PIN rw0_wd_in[40]
@@ -371,7 +371,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 308.570 2364.860 308.870 ;
+      RECT 590.660 165.770 591.560 166.070 ;
     END
   END rw0_wd_in[40]
   PIN rw0_wd_in[41]
@@ -380,7 +380,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 352.090 2364.860 352.390 ;
+      RECT 590.660 188.890 591.560 189.190 ;
     END
   END rw0_wd_in[41]
   PIN rw0_wd_in[42]
@@ -389,7 +389,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 395.610 2364.860 395.910 ;
+      RECT 590.660 212.010 591.560 212.310 ;
     END
   END rw0_wd_in[42]
   PIN rw0_wd_in[43]
@@ -398,7 +398,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 439.130 2364.860 439.430 ;
+      RECT 590.660 235.130 591.560 235.430 ;
     END
   END rw0_wd_in[43]
   PIN rw0_wd_in[44]
@@ -407,7 +407,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 482.650 2364.860 482.950 ;
+      RECT 590.660 258.250 591.560 258.550 ;
     END
   END rw0_wd_in[44]
   PIN rw0_wd_in[45]
@@ -416,7 +416,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 526.170 2364.860 526.470 ;
+      RECT 590.660 281.370 591.560 281.670 ;
     END
   END rw0_wd_in[45]
   PIN rw0_wd_in[46]
@@ -425,7 +425,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 569.690 2364.860 569.990 ;
+      RECT 590.660 304.490 591.560 304.790 ;
     END
   END rw0_wd_in[46]
   PIN rw0_wd_in[47]
@@ -434,7 +434,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 613.210 2364.860 613.510 ;
+      RECT 590.660 327.610 591.560 327.910 ;
     END
   END rw0_wd_in[47]
   PIN rw0_wd_in[48]
@@ -443,7 +443,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 656.730 2364.860 657.030 ;
+      RECT 590.660 350.730 591.560 351.030 ;
     END
   END rw0_wd_in[48]
   PIN rw0_wd_in[49]
@@ -452,7 +452,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 700.250 2364.860 700.550 ;
+      RECT 590.660 373.850 591.560 374.150 ;
     END
   END rw0_wd_in[49]
   PIN rw0_wd_in[50]
@@ -461,7 +461,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 743.770 2364.860 744.070 ;
+      RECT 590.660 396.970 591.560 397.270 ;
     END
   END rw0_wd_in[50]
   PIN rw0_wd_in[51]
@@ -470,7 +470,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 787.290 2364.860 787.590 ;
+      RECT 590.660 420.090 591.560 420.390 ;
     END
   END rw0_wd_in[51]
   PIN rw0_wd_in[52]
@@ -479,7 +479,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 830.810 2364.860 831.110 ;
+      RECT 590.660 443.210 591.560 443.510 ;
     END
   END rw0_wd_in[52]
   PIN rw0_wd_in[53]
@@ -488,7 +488,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 874.330 2364.860 874.630 ;
+      RECT 590.660 466.330 591.560 466.630 ;
     END
   END rw0_wd_in[53]
   PIN rw0_wd_in[54]
@@ -497,7 +497,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 917.850 2364.860 918.150 ;
+      RECT 590.660 489.450 591.560 489.750 ;
     END
   END rw0_wd_in[54]
   PIN rw0_wd_in[55]
@@ -506,7 +506,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 961.370 2364.860 961.670 ;
+      RECT 590.660 512.570 591.560 512.870 ;
     END
   END rw0_wd_in[55]
   PIN rw0_wd_in[56]
@@ -515,7 +515,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1004.890 2364.860 1005.190 ;
+      RECT 590.660 535.690 591.560 535.990 ;
     END
   END rw0_wd_in[56]
   PIN rw0_wd_in[57]
@@ -524,7 +524,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1048.410 2364.860 1048.710 ;
+      RECT 590.660 558.810 591.560 559.110 ;
     END
   END rw0_wd_in[57]
   PIN rw0_wd_in[58]
@@ -533,7 +533,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1091.930 2364.860 1092.230 ;
+      RECT 590.660 581.930 591.560 582.230 ;
     END
   END rw0_wd_in[58]
   PIN rw0_wd_in[59]
@@ -542,7 +542,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1135.450 2364.860 1135.750 ;
+      RECT 590.660 605.050 591.560 605.350 ;
     END
   END rw0_wd_in[59]
   PIN rw0_wd_in[60]
@@ -551,7 +551,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1178.970 2364.860 1179.270 ;
+      RECT 590.660 628.170 591.560 628.470 ;
     END
   END rw0_wd_in[60]
   PIN rw0_wd_in[61]
@@ -560,7 +560,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1222.490 2364.860 1222.790 ;
+      RECT 590.660 651.290 591.560 651.590 ;
     END
   END rw0_wd_in[61]
   PIN rw0_wd_in[62]
@@ -569,7 +569,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1266.010 2364.860 1266.310 ;
+      RECT 590.660 674.410 591.560 674.710 ;
     END
   END rw0_wd_in[62]
   PIN rw0_wd_in[63]
@@ -578,7 +578,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1309.530 2364.860 1309.830 ;
+      RECT 590.660 697.530 591.560 697.830 ;
     END
   END rw0_wd_in[63]
   PIN rw0_wd_in[64]
@@ -587,7 +587,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1353.050 2364.860 1353.350 ;
+      RECT 590.660 720.650 591.560 720.950 ;
     END
   END rw0_wd_in[64]
   PIN rw0_wd_in[65]
@@ -605,7 +605,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 14.650 0.000 14.790 0.420 ;
+      RECT 5.450 0.000 5.590 0.420 ;
     END
   END rw0_wd_in[66]
   PIN rw0_wd_in[67]
@@ -614,7 +614,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 26.610 0.000 26.750 0.420 ;
+      RECT 8.210 0.000 8.350 0.420 ;
     END
   END rw0_wd_in[67]
   PIN rw0_wd_in[68]
@@ -623,7 +623,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 38.570 0.000 38.710 0.420 ;
+      RECT 10.970 0.000 11.110 0.420 ;
     END
   END rw0_wd_in[68]
   PIN rw0_wd_in[69]
@@ -632,7 +632,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 50.530 0.000 50.670 0.420 ;
+      RECT 13.730 0.000 13.870 0.420 ;
     END
   END rw0_wd_in[69]
   PIN rw0_wd_in[70]
@@ -641,7 +641,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 62.490 0.000 62.630 0.420 ;
+      RECT 16.490 0.000 16.630 0.420 ;
     END
   END rw0_wd_in[70]
   PIN rw0_wd_in[71]
@@ -650,7 +650,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 74.450 0.000 74.590 0.420 ;
+      RECT 19.250 0.000 19.390 0.420 ;
     END
   END rw0_wd_in[71]
   PIN rw0_wd_in[72]
@@ -659,7 +659,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 86.410 0.000 86.550 0.420 ;
+      RECT 22.010 0.000 22.150 0.420 ;
     END
   END rw0_wd_in[72]
   PIN rw0_wd_in[73]
@@ -668,7 +668,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 98.370 0.000 98.510 0.420 ;
+      RECT 24.770 0.000 24.910 0.420 ;
     END
   END rw0_wd_in[73]
   PIN rw0_wd_in[74]
@@ -677,7 +677,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 110.330 0.000 110.470 0.420 ;
+      RECT 27.530 0.000 27.670 0.420 ;
     END
   END rw0_wd_in[74]
   PIN rw0_wd_in[75]
@@ -686,7 +686,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 122.290 0.000 122.430 0.420 ;
+      RECT 30.290 0.000 30.430 0.420 ;
     END
   END rw0_wd_in[75]
   PIN rw0_wd_in[76]
@@ -695,7 +695,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 134.250 0.000 134.390 0.420 ;
+      RECT 33.050 0.000 33.190 0.420 ;
     END
   END rw0_wd_in[76]
   PIN rw0_wd_in[77]
@@ -704,7 +704,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 146.210 0.000 146.350 0.420 ;
+      RECT 35.810 0.000 35.950 0.420 ;
     END
   END rw0_wd_in[77]
   PIN rw0_wd_in[78]
@@ -713,7 +713,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 158.170 0.000 158.310 0.420 ;
+      RECT 38.570 0.000 38.710 0.420 ;
     END
   END rw0_wd_in[78]
   PIN rw0_wd_in[79]
@@ -722,7 +722,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 170.130 0.000 170.270 0.420 ;
+      RECT 41.330 0.000 41.470 0.420 ;
     END
   END rw0_wd_in[79]
   PIN rw0_wd_in[80]
@@ -731,7 +731,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 182.090 0.000 182.230 0.420 ;
+      RECT 44.090 0.000 44.230 0.420 ;
     END
   END rw0_wd_in[80]
   PIN rw0_wd_in[81]
@@ -740,7 +740,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 194.050 0.000 194.190 0.420 ;
+      RECT 46.850 0.000 46.990 0.420 ;
     END
   END rw0_wd_in[81]
   PIN rw0_wd_in[82]
@@ -749,7 +749,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 206.010 0.000 206.150 0.420 ;
+      RECT 49.610 0.000 49.750 0.420 ;
     END
   END rw0_wd_in[82]
   PIN rw0_wd_in[83]
@@ -758,7 +758,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 217.970 0.000 218.110 0.420 ;
+      RECT 52.370 0.000 52.510 0.420 ;
     END
   END rw0_wd_in[83]
   PIN rw0_wd_in[84]
@@ -767,7 +767,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 229.930 0.000 230.070 0.420 ;
+      RECT 55.130 0.000 55.270 0.420 ;
     END
   END rw0_wd_in[84]
   PIN rw0_wd_in[85]
@@ -776,7 +776,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 241.890 0.000 242.030 0.420 ;
+      RECT 57.890 0.000 58.030 0.420 ;
     END
   END rw0_wd_in[85]
   PIN rw0_wd_in[86]
@@ -785,7 +785,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 253.850 0.000 253.990 0.420 ;
+      RECT 60.650 0.000 60.790 0.420 ;
     END
   END rw0_wd_in[86]
   PIN rw0_wd_in[87]
@@ -794,7 +794,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 265.810 0.000 265.950 0.420 ;
+      RECT 63.410 0.000 63.550 0.420 ;
     END
   END rw0_wd_in[87]
   PIN rw0_wd_in[88]
@@ -803,7 +803,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 277.770 0.000 277.910 0.420 ;
+      RECT 66.170 0.000 66.310 0.420 ;
     END
   END rw0_wd_in[88]
   PIN rw0_wd_in[89]
@@ -812,7 +812,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 289.730 0.000 289.870 0.420 ;
+      RECT 68.930 0.000 69.070 0.420 ;
     END
   END rw0_wd_in[89]
   PIN rw0_wd_in[90]
@@ -821,7 +821,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 301.690 0.000 301.830 0.420 ;
+      RECT 71.690 0.000 71.830 0.420 ;
     END
   END rw0_wd_in[90]
   PIN rw0_wd_in[91]
@@ -830,7 +830,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 313.650 0.000 313.790 0.420 ;
+      RECT 74.450 0.000 74.590 0.420 ;
     END
   END rw0_wd_in[91]
   PIN rw0_wd_in[92]
@@ -839,7 +839,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 325.610 0.000 325.750 0.420 ;
+      RECT 77.210 0.000 77.350 0.420 ;
     END
   END rw0_wd_in[92]
   PIN rw0_wd_in[93]
@@ -848,7 +848,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 337.570 0.000 337.710 0.420 ;
+      RECT 79.970 0.000 80.110 0.420 ;
     END
   END rw0_wd_in[93]
   PIN rw0_wd_in[94]
@@ -857,7 +857,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 349.530 0.000 349.670 0.420 ;
+      RECT 82.730 0.000 82.870 0.420 ;
     END
   END rw0_wd_in[94]
   PIN rw0_wd_in[95]
@@ -866,7 +866,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 361.490 0.000 361.630 0.420 ;
+      RECT 85.490 0.000 85.630 0.420 ;
     END
   END rw0_wd_in[95]
   PIN rw0_wd_in[96]
@@ -875,7 +875,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 373.450 0.000 373.590 0.420 ;
+      RECT 88.250 0.000 88.390 0.420 ;
     END
   END rw0_wd_in[96]
   PIN rw0_wd_in[97]
@@ -884,7 +884,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 385.410 0.000 385.550 0.420 ;
+      RECT 91.010 0.000 91.150 0.420 ;
     END
   END rw0_wd_in[97]
   PIN rw0_wd_in[98]
@@ -893,7 +893,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 397.370 0.000 397.510 0.420 ;
+      RECT 93.770 0.000 93.910 0.420 ;
     END
   END rw0_wd_in[98]
   PIN rw0_wd_in[99]
@@ -902,7 +902,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 409.330 0.000 409.470 0.420 ;
+      RECT 96.530 0.000 96.670 0.420 ;
     END
   END rw0_wd_in[99]
   PIN rw0_wd_in[100]
@@ -911,7 +911,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 421.290 0.000 421.430 0.420 ;
+      RECT 99.290 0.000 99.430 0.420 ;
     END
   END rw0_wd_in[100]
   PIN rw0_wd_in[101]
@@ -920,7 +920,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 433.250 0.000 433.390 0.420 ;
+      RECT 102.050 0.000 102.190 0.420 ;
     END
   END rw0_wd_in[101]
   PIN rw0_wd_in[102]
@@ -929,7 +929,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 445.210 0.000 445.350 0.420 ;
+      RECT 104.810 0.000 104.950 0.420 ;
     END
   END rw0_wd_in[102]
   PIN rw0_wd_in[103]
@@ -938,7 +938,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 457.170 0.000 457.310 0.420 ;
+      RECT 107.570 0.000 107.710 0.420 ;
     END
   END rw0_wd_in[103]
   PIN rw0_wd_in[104]
@@ -947,7 +947,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 469.130 0.000 469.270 0.420 ;
+      RECT 110.330 0.000 110.470 0.420 ;
     END
   END rw0_wd_in[104]
   PIN rw0_wd_in[105]
@@ -956,7 +956,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 481.090 0.000 481.230 0.420 ;
+      RECT 113.090 0.000 113.230 0.420 ;
     END
   END rw0_wd_in[105]
   PIN rw0_wd_in[106]
@@ -965,7 +965,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 493.050 0.000 493.190 0.420 ;
+      RECT 115.850 0.000 115.990 0.420 ;
     END
   END rw0_wd_in[106]
   PIN rw0_wd_in[107]
@@ -974,7 +974,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 505.010 0.000 505.150 0.420 ;
+      RECT 118.610 0.000 118.750 0.420 ;
     END
   END rw0_wd_in[107]
   PIN rw0_wd_in[108]
@@ -983,7 +983,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 516.970 0.000 517.110 0.420 ;
+      RECT 121.370 0.000 121.510 0.420 ;
     END
   END rw0_wd_in[108]
   PIN rw0_wd_in[109]
@@ -992,7 +992,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 528.930 0.000 529.070 0.420 ;
+      RECT 124.130 0.000 124.270 0.420 ;
     END
   END rw0_wd_in[109]
   PIN rw0_wd_in[110]
@@ -1001,7 +1001,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 540.890 0.000 541.030 0.420 ;
+      RECT 126.890 0.000 127.030 0.420 ;
     END
   END rw0_wd_in[110]
   PIN rw0_wd_in[111]
@@ -1010,7 +1010,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 552.850 0.000 552.990 0.420 ;
+      RECT 129.650 0.000 129.790 0.420 ;
     END
   END rw0_wd_in[111]
   PIN rw0_wd_in[112]
@@ -1019,7 +1019,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 564.810 0.000 564.950 0.420 ;
+      RECT 132.410 0.000 132.550 0.420 ;
     END
   END rw0_wd_in[112]
   PIN rw0_wd_in[113]
@@ -1028,7 +1028,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 576.770 0.000 576.910 0.420 ;
+      RECT 135.170 0.000 135.310 0.420 ;
     END
   END rw0_wd_in[113]
   PIN rw0_wd_in[114]
@@ -1037,7 +1037,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 588.730 0.000 588.870 0.420 ;
+      RECT 137.930 0.000 138.070 0.420 ;
     END
   END rw0_wd_in[114]
   PIN rw0_wd_in[115]
@@ -1046,7 +1046,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 600.690 0.000 600.830 0.420 ;
+      RECT 140.690 0.000 140.830 0.420 ;
     END
   END rw0_wd_in[115]
   PIN rw0_wd_in[116]
@@ -1055,7 +1055,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 612.650 0.000 612.790 0.420 ;
+      RECT 143.450 0.000 143.590 0.420 ;
     END
   END rw0_wd_in[116]
   PIN rw0_wd_in[117]
@@ -1064,7 +1064,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 624.610 0.000 624.750 0.420 ;
+      RECT 146.210 0.000 146.350 0.420 ;
     END
   END rw0_wd_in[117]
   PIN rw0_wd_in[118]
@@ -1073,7 +1073,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 636.570 0.000 636.710 0.420 ;
+      RECT 148.970 0.000 149.110 0.420 ;
     END
   END rw0_wd_in[118]
   PIN rw0_wd_in[119]
@@ -1082,7 +1082,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 648.530 0.000 648.670 0.420 ;
+      RECT 151.730 0.000 151.870 0.420 ;
     END
   END rw0_wd_in[119]
   PIN rw0_wd_in[120]
@@ -1091,7 +1091,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 660.490 0.000 660.630 0.420 ;
+      RECT 154.490 0.000 154.630 0.420 ;
     END
   END rw0_wd_in[120]
   PIN rw0_wd_in[121]
@@ -1100,7 +1100,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 672.450 0.000 672.590 0.420 ;
+      RECT 157.250 0.000 157.390 0.420 ;
     END
   END rw0_wd_in[121]
   PIN rw0_wd_in[122]
@@ -1109,7 +1109,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 684.410 0.000 684.550 0.420 ;
+      RECT 160.010 0.000 160.150 0.420 ;
     END
   END rw0_wd_in[122]
   PIN rw0_wd_in[123]
@@ -1118,7 +1118,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 696.370 0.000 696.510 0.420 ;
+      RECT 162.770 0.000 162.910 0.420 ;
     END
   END rw0_wd_in[123]
   PIN rw0_wd_in[124]
@@ -1127,7 +1127,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 708.330 0.000 708.470 0.420 ;
+      RECT 165.530 0.000 165.670 0.420 ;
     END
   END rw0_wd_in[124]
   PIN rw0_wd_in[125]
@@ -1136,7 +1136,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 720.290 0.000 720.430 0.420 ;
+      RECT 168.290 0.000 168.430 0.420 ;
     END
   END rw0_wd_in[125]
   PIN rw0_wd_in[126]
@@ -1145,7 +1145,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 732.250 0.000 732.390 0.420 ;
+      RECT 171.050 0.000 171.190 0.420 ;
     END
   END rw0_wd_in[126]
   PIN rw0_wd_in[127]
@@ -1154,7 +1154,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 744.210 0.000 744.350 0.420 ;
+      RECT 173.810 0.000 173.950 0.420 ;
     END
   END rw0_wd_in[127]
   PIN rw0_wd_in[128]
@@ -1163,7 +1163,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 756.170 0.000 756.310 0.420 ;
+      RECT 176.570 0.000 176.710 0.420 ;
     END
   END rw0_wd_in[128]
   PIN rw0_wd_in[129]
@@ -1172,7 +1172,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 768.130 0.000 768.270 0.420 ;
+      RECT 179.330 0.000 179.470 0.420 ;
     END
   END rw0_wd_in[129]
   PIN rw0_rd_out[0]
@@ -1181,7 +1181,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 780.090 0.000 780.230 0.420 ;
+      RECT 182.090 0.000 182.230 0.420 ;
     END
   END rw0_rd_out[0]
   PIN rw0_rd_out[1]
@@ -1190,7 +1190,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 792.050 0.000 792.190 0.420 ;
+      RECT 184.850 0.000 184.990 0.420 ;
     END
   END rw0_rd_out[1]
   PIN rw0_rd_out[2]
@@ -1199,7 +1199,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 804.010 0.000 804.150 0.420 ;
+      RECT 187.610 0.000 187.750 0.420 ;
     END
   END rw0_rd_out[2]
   PIN rw0_rd_out[3]
@@ -1208,7 +1208,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 815.970 0.000 816.110 0.420 ;
+      RECT 190.370 0.000 190.510 0.420 ;
     END
   END rw0_rd_out[3]
   PIN rw0_rd_out[4]
@@ -1217,7 +1217,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 827.930 0.000 828.070 0.420 ;
+      RECT 193.130 0.000 193.270 0.420 ;
     END
   END rw0_rd_out[4]
   PIN rw0_rd_out[5]
@@ -1226,7 +1226,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 839.890 0.000 840.030 0.420 ;
+      RECT 195.890 0.000 196.030 0.420 ;
     END
   END rw0_rd_out[5]
   PIN rw0_rd_out[6]
@@ -1235,7 +1235,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 851.850 0.000 851.990 0.420 ;
+      RECT 198.650 0.000 198.790 0.420 ;
     END
   END rw0_rd_out[6]
   PIN rw0_rd_out[7]
@@ -1244,7 +1244,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 863.810 0.000 863.950 0.420 ;
+      RECT 201.410 0.000 201.550 0.420 ;
     END
   END rw0_rd_out[7]
   PIN rw0_rd_out[8]
@@ -1253,7 +1253,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 875.770 0.000 875.910 0.420 ;
+      RECT 204.170 0.000 204.310 0.420 ;
     END
   END rw0_rd_out[8]
   PIN rw0_rd_out[9]
@@ -1262,7 +1262,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 887.730 0.000 887.870 0.420 ;
+      RECT 206.930 0.000 207.070 0.420 ;
     END
   END rw0_rd_out[9]
   PIN rw0_rd_out[10]
@@ -1271,7 +1271,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 899.690 0.000 899.830 0.420 ;
+      RECT 209.690 0.000 209.830 0.420 ;
     END
   END rw0_rd_out[10]
   PIN rw0_rd_out[11]
@@ -1280,7 +1280,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 911.650 0.000 911.790 0.420 ;
+      RECT 212.450 0.000 212.590 0.420 ;
     END
   END rw0_rd_out[11]
   PIN rw0_rd_out[12]
@@ -1289,7 +1289,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 923.610 0.000 923.750 0.420 ;
+      RECT 215.210 0.000 215.350 0.420 ;
     END
   END rw0_rd_out[12]
   PIN rw0_rd_out[13]
@@ -1298,7 +1298,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 935.570 0.000 935.710 0.420 ;
+      RECT 217.970 0.000 218.110 0.420 ;
     END
   END rw0_rd_out[13]
   PIN rw0_rd_out[14]
@@ -1307,7 +1307,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 947.530 0.000 947.670 0.420 ;
+      RECT 220.730 0.000 220.870 0.420 ;
     END
   END rw0_rd_out[14]
   PIN rw0_rd_out[15]
@@ -1316,7 +1316,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 959.490 0.000 959.630 0.420 ;
+      RECT 223.490 0.000 223.630 0.420 ;
     END
   END rw0_rd_out[15]
   PIN rw0_rd_out[16]
@@ -1325,7 +1325,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 971.450 0.000 971.590 0.420 ;
+      RECT 226.250 0.000 226.390 0.420 ;
     END
   END rw0_rd_out[16]
   PIN rw0_rd_out[17]
@@ -1334,7 +1334,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 983.410 0.000 983.550 0.420 ;
+      RECT 229.010 0.000 229.150 0.420 ;
     END
   END rw0_rd_out[17]
   PIN rw0_rd_out[18]
@@ -1343,7 +1343,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 995.370 0.000 995.510 0.420 ;
+      RECT 231.770 0.000 231.910 0.420 ;
     END
   END rw0_rd_out[18]
   PIN rw0_rd_out[19]
@@ -1352,7 +1352,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1007.330 0.000 1007.470 0.420 ;
+      RECT 234.530 0.000 234.670 0.420 ;
     END
   END rw0_rd_out[19]
   PIN rw0_rd_out[20]
@@ -1361,7 +1361,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1019.290 0.000 1019.430 0.420 ;
+      RECT 237.290 0.000 237.430 0.420 ;
     END
   END rw0_rd_out[20]
   PIN rw0_rd_out[21]
@@ -1370,7 +1370,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1031.250 0.000 1031.390 0.420 ;
+      RECT 240.050 0.000 240.190 0.420 ;
     END
   END rw0_rd_out[21]
   PIN rw0_rd_out[22]
@@ -1379,7 +1379,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1043.210 0.000 1043.350 0.420 ;
+      RECT 242.810 0.000 242.950 0.420 ;
     END
   END rw0_rd_out[22]
   PIN rw0_rd_out[23]
@@ -1388,7 +1388,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1055.170 0.000 1055.310 0.420 ;
+      RECT 245.570 0.000 245.710 0.420 ;
     END
   END rw0_rd_out[23]
   PIN rw0_rd_out[24]
@@ -1397,7 +1397,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1067.130 0.000 1067.270 0.420 ;
+      RECT 248.330 0.000 248.470 0.420 ;
     END
   END rw0_rd_out[24]
   PIN rw0_rd_out[25]
@@ -1406,7 +1406,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1079.090 0.000 1079.230 0.420 ;
+      RECT 251.090 0.000 251.230 0.420 ;
     END
   END rw0_rd_out[25]
   PIN rw0_rd_out[26]
@@ -1415,7 +1415,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1091.050 0.000 1091.190 0.420 ;
+      RECT 253.850 0.000 253.990 0.420 ;
     END
   END rw0_rd_out[26]
   PIN rw0_rd_out[27]
@@ -1424,7 +1424,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1103.010 0.000 1103.150 0.420 ;
+      RECT 256.610 0.000 256.750 0.420 ;
     END
   END rw0_rd_out[27]
   PIN rw0_rd_out[28]
@@ -1433,7 +1433,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1114.970 0.000 1115.110 0.420 ;
+      RECT 259.370 0.000 259.510 0.420 ;
     END
   END rw0_rd_out[28]
   PIN rw0_rd_out[29]
@@ -1442,7 +1442,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1126.930 0.000 1127.070 0.420 ;
+      RECT 262.130 0.000 262.270 0.420 ;
     END
   END rw0_rd_out[29]
   PIN rw0_rd_out[30]
@@ -1451,7 +1451,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1138.890 0.000 1139.030 0.420 ;
+      RECT 264.890 0.000 265.030 0.420 ;
     END
   END rw0_rd_out[30]
   PIN rw0_rd_out[31]
@@ -1460,7 +1460,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1150.850 0.000 1150.990 0.420 ;
+      RECT 267.650 0.000 267.790 0.420 ;
     END
   END rw0_rd_out[31]
   PIN rw0_rd_out[32]
@@ -1469,7 +1469,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1162.810 0.000 1162.950 0.420 ;
+      RECT 270.410 0.000 270.550 0.420 ;
     END
   END rw0_rd_out[32]
   PIN rw0_rd_out[33]
@@ -1478,7 +1478,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1174.770 0.000 1174.910 0.420 ;
+      RECT 273.170 0.000 273.310 0.420 ;
     END
   END rw0_rd_out[33]
   PIN rw0_rd_out[34]
@@ -1487,7 +1487,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1186.730 0.000 1186.870 0.420 ;
+      RECT 275.930 0.000 276.070 0.420 ;
     END
   END rw0_rd_out[34]
   PIN rw0_rd_out[35]
@@ -1496,7 +1496,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1198.690 0.000 1198.830 0.420 ;
+      RECT 278.690 0.000 278.830 0.420 ;
     END
   END rw0_rd_out[35]
   PIN rw0_rd_out[36]
@@ -1505,7 +1505,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1210.650 0.000 1210.790 0.420 ;
+      RECT 281.450 0.000 281.590 0.420 ;
     END
   END rw0_rd_out[36]
   PIN rw0_rd_out[37]
@@ -1514,7 +1514,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1222.610 0.000 1222.750 0.420 ;
+      RECT 284.210 0.000 284.350 0.420 ;
     END
   END rw0_rd_out[37]
   PIN rw0_rd_out[38]
@@ -1523,7 +1523,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1234.570 0.000 1234.710 0.420 ;
+      RECT 286.970 0.000 287.110 0.420 ;
     END
   END rw0_rd_out[38]
   PIN rw0_rd_out[39]
@@ -1532,7 +1532,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1246.530 0.000 1246.670 0.420 ;
+      RECT 289.730 0.000 289.870 0.420 ;
     END
   END rw0_rd_out[39]
   PIN rw0_rd_out[40]
@@ -1541,7 +1541,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1258.490 0.000 1258.630 0.420 ;
+      RECT 292.490 0.000 292.630 0.420 ;
     END
   END rw0_rd_out[40]
   PIN rw0_rd_out[41]
@@ -1550,7 +1550,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1270.450 0.000 1270.590 0.420 ;
+      RECT 295.250 0.000 295.390 0.420 ;
     END
   END rw0_rd_out[41]
   PIN rw0_rd_out[42]
@@ -1559,7 +1559,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1282.410 0.000 1282.550 0.420 ;
+      RECT 298.010 0.000 298.150 0.420 ;
     END
   END rw0_rd_out[42]
   PIN rw0_rd_out[43]
@@ -1568,7 +1568,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1294.370 0.000 1294.510 0.420 ;
+      RECT 300.770 0.000 300.910 0.420 ;
     END
   END rw0_rd_out[43]
   PIN rw0_rd_out[44]
@@ -1577,7 +1577,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1306.330 0.000 1306.470 0.420 ;
+      RECT 303.530 0.000 303.670 0.420 ;
     END
   END rw0_rd_out[44]
   PIN rw0_rd_out[45]
@@ -1586,7 +1586,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1318.290 0.000 1318.430 0.420 ;
+      RECT 306.290 0.000 306.430 0.420 ;
     END
   END rw0_rd_out[45]
   PIN rw0_rd_out[46]
@@ -1595,7 +1595,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1330.250 0.000 1330.390 0.420 ;
+      RECT 309.050 0.000 309.190 0.420 ;
     END
   END rw0_rd_out[46]
   PIN rw0_rd_out[47]
@@ -1604,7 +1604,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1342.210 0.000 1342.350 0.420 ;
+      RECT 311.810 0.000 311.950 0.420 ;
     END
   END rw0_rd_out[47]
   PIN rw0_rd_out[48]
@@ -1613,7 +1613,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1354.170 0.000 1354.310 0.420 ;
+      RECT 314.570 0.000 314.710 0.420 ;
     END
   END rw0_rd_out[48]
   PIN rw0_rd_out[49]
@@ -1622,7 +1622,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1366.130 0.000 1366.270 0.420 ;
+      RECT 317.330 0.000 317.470 0.420 ;
     END
   END rw0_rd_out[49]
   PIN rw0_rd_out[50]
@@ -1631,7 +1631,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1378.090 0.000 1378.230 0.420 ;
+      RECT 320.090 0.000 320.230 0.420 ;
     END
   END rw0_rd_out[50]
   PIN rw0_rd_out[51]
@@ -1640,7 +1640,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1390.050 0.000 1390.190 0.420 ;
+      RECT 322.850 0.000 322.990 0.420 ;
     END
   END rw0_rd_out[51]
   PIN rw0_rd_out[52]
@@ -1649,7 +1649,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1402.010 0.000 1402.150 0.420 ;
+      RECT 325.610 0.000 325.750 0.420 ;
     END
   END rw0_rd_out[52]
   PIN rw0_rd_out[53]
@@ -1658,7 +1658,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1413.970 0.000 1414.110 0.420 ;
+      RECT 328.370 0.000 328.510 0.420 ;
     END
   END rw0_rd_out[53]
   PIN rw0_rd_out[54]
@@ -1667,7 +1667,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1425.930 0.000 1426.070 0.420 ;
+      RECT 331.130 0.000 331.270 0.420 ;
     END
   END rw0_rd_out[54]
   PIN rw0_rd_out[55]
@@ -1676,7 +1676,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1437.890 0.000 1438.030 0.420 ;
+      RECT 333.890 0.000 334.030 0.420 ;
     END
   END rw0_rd_out[55]
   PIN rw0_rd_out[56]
@@ -1685,7 +1685,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1449.850 0.000 1449.990 0.420 ;
+      RECT 336.650 0.000 336.790 0.420 ;
     END
   END rw0_rd_out[56]
   PIN rw0_rd_out[57]
@@ -1694,7 +1694,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1461.810 0.000 1461.950 0.420 ;
+      RECT 339.410 0.000 339.550 0.420 ;
     END
   END rw0_rd_out[57]
   PIN rw0_rd_out[58]
@@ -1703,7 +1703,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1473.770 0.000 1473.910 0.420 ;
+      RECT 342.170 0.000 342.310 0.420 ;
     END
   END rw0_rd_out[58]
   PIN rw0_rd_out[59]
@@ -1712,7 +1712,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1485.730 0.000 1485.870 0.420 ;
+      RECT 344.930 0.000 345.070 0.420 ;
     END
   END rw0_rd_out[59]
   PIN rw0_rd_out[60]
@@ -1721,7 +1721,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1497.690 0.000 1497.830 0.420 ;
+      RECT 347.690 0.000 347.830 0.420 ;
     END
   END rw0_rd_out[60]
   PIN rw0_rd_out[61]
@@ -1730,7 +1730,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1509.650 0.000 1509.790 0.420 ;
+      RECT 350.450 0.000 350.590 0.420 ;
     END
   END rw0_rd_out[61]
   PIN rw0_rd_out[62]
@@ -1739,7 +1739,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1521.610 0.000 1521.750 0.420 ;
+      RECT 353.210 0.000 353.350 0.420 ;
     END
   END rw0_rd_out[62]
   PIN rw0_rd_out[63]
@@ -1748,7 +1748,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1533.570 0.000 1533.710 0.420 ;
+      RECT 355.970 0.000 356.110 0.420 ;
     END
   END rw0_rd_out[63]
   PIN rw0_rd_out[64]
@@ -1757,7 +1757,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1545.530 0.000 1545.670 0.420 ;
+      RECT 358.730 0.000 358.870 0.420 ;
     END
   END rw0_rd_out[64]
   PIN rw0_rd_out[65]
@@ -1766,7 +1766,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2.690 1895.420 2.830 1895.840 ;
+      RECT 2.690 948.860 2.830 949.280 ;
     END
   END rw0_rd_out[65]
   PIN rw0_rd_out[66]
@@ -1775,7 +1775,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 19.710 1895.420 19.850 1895.840 ;
+      RECT 6.830 948.860 6.970 949.280 ;
     END
   END rw0_rd_out[66]
   PIN rw0_rd_out[67]
@@ -1784,7 +1784,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 36.730 1895.420 36.870 1895.840 ;
+      RECT 10.970 948.860 11.110 949.280 ;
     END
   END rw0_rd_out[67]
   PIN rw0_rd_out[68]
@@ -1793,7 +1793,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 53.750 1895.420 53.890 1895.840 ;
+      RECT 15.110 948.860 15.250 949.280 ;
     END
   END rw0_rd_out[68]
   PIN rw0_rd_out[69]
@@ -1802,7 +1802,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 70.770 1895.420 70.910 1895.840 ;
+      RECT 19.250 948.860 19.390 949.280 ;
     END
   END rw0_rd_out[69]
   PIN rw0_rd_out[70]
@@ -1811,7 +1811,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 87.790 1895.420 87.930 1895.840 ;
+      RECT 23.390 948.860 23.530 949.280 ;
     END
   END rw0_rd_out[70]
   PIN rw0_rd_out[71]
@@ -1820,7 +1820,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 104.810 1895.420 104.950 1895.840 ;
+      RECT 27.530 948.860 27.670 949.280 ;
     END
   END rw0_rd_out[71]
   PIN rw0_rd_out[72]
@@ -1829,7 +1829,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 121.830 1895.420 121.970 1895.840 ;
+      RECT 31.670 948.860 31.810 949.280 ;
     END
   END rw0_rd_out[72]
   PIN rw0_rd_out[73]
@@ -1838,7 +1838,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 138.850 1895.420 138.990 1895.840 ;
+      RECT 35.810 948.860 35.950 949.280 ;
     END
   END rw0_rd_out[73]
   PIN rw0_rd_out[74]
@@ -1847,7 +1847,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 155.870 1895.420 156.010 1895.840 ;
+      RECT 39.950 948.860 40.090 949.280 ;
     END
   END rw0_rd_out[74]
   PIN rw0_rd_out[75]
@@ -1856,7 +1856,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 172.890 1895.420 173.030 1895.840 ;
+      RECT 44.090 948.860 44.230 949.280 ;
     END
   END rw0_rd_out[75]
   PIN rw0_rd_out[76]
@@ -1865,7 +1865,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 189.910 1895.420 190.050 1895.840 ;
+      RECT 48.230 948.860 48.370 949.280 ;
     END
   END rw0_rd_out[76]
   PIN rw0_rd_out[77]
@@ -1874,7 +1874,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 206.930 1895.420 207.070 1895.840 ;
+      RECT 52.370 948.860 52.510 949.280 ;
     END
   END rw0_rd_out[77]
   PIN rw0_rd_out[78]
@@ -1883,7 +1883,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 223.950 1895.420 224.090 1895.840 ;
+      RECT 56.510 948.860 56.650 949.280 ;
     END
   END rw0_rd_out[78]
   PIN rw0_rd_out[79]
@@ -1892,7 +1892,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 240.970 1895.420 241.110 1895.840 ;
+      RECT 60.650 948.860 60.790 949.280 ;
     END
   END rw0_rd_out[79]
   PIN rw0_rd_out[80]
@@ -1901,7 +1901,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 257.990 1895.420 258.130 1895.840 ;
+      RECT 64.790 948.860 64.930 949.280 ;
     END
   END rw0_rd_out[80]
   PIN rw0_rd_out[81]
@@ -1910,7 +1910,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 275.010 1895.420 275.150 1895.840 ;
+      RECT 68.930 948.860 69.070 949.280 ;
     END
   END rw0_rd_out[81]
   PIN rw0_rd_out[82]
@@ -1919,7 +1919,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 292.030 1895.420 292.170 1895.840 ;
+      RECT 73.070 948.860 73.210 949.280 ;
     END
   END rw0_rd_out[82]
   PIN rw0_rd_out[83]
@@ -1928,7 +1928,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 309.050 1895.420 309.190 1895.840 ;
+      RECT 77.210 948.860 77.350 949.280 ;
     END
   END rw0_rd_out[83]
   PIN rw0_rd_out[84]
@@ -1937,7 +1937,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 326.070 1895.420 326.210 1895.840 ;
+      RECT 81.350 948.860 81.490 949.280 ;
     END
   END rw0_rd_out[84]
   PIN rw0_rd_out[85]
@@ -1946,7 +1946,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 343.090 1895.420 343.230 1895.840 ;
+      RECT 85.490 948.860 85.630 949.280 ;
     END
   END rw0_rd_out[85]
   PIN rw0_rd_out[86]
@@ -1955,7 +1955,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 360.110 1895.420 360.250 1895.840 ;
+      RECT 89.630 948.860 89.770 949.280 ;
     END
   END rw0_rd_out[86]
   PIN rw0_rd_out[87]
@@ -1964,7 +1964,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 377.130 1895.420 377.270 1895.840 ;
+      RECT 93.770 948.860 93.910 949.280 ;
     END
   END rw0_rd_out[87]
   PIN rw0_rd_out[88]
@@ -1973,7 +1973,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 394.150 1895.420 394.290 1895.840 ;
+      RECT 97.910 948.860 98.050 949.280 ;
     END
   END rw0_rd_out[88]
   PIN rw0_rd_out[89]
@@ -1982,7 +1982,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 411.170 1895.420 411.310 1895.840 ;
+      RECT 102.050 948.860 102.190 949.280 ;
     END
   END rw0_rd_out[89]
   PIN rw0_rd_out[90]
@@ -1991,7 +1991,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 428.190 1895.420 428.330 1895.840 ;
+      RECT 106.190 948.860 106.330 949.280 ;
     END
   END rw0_rd_out[90]
   PIN rw0_rd_out[91]
@@ -2000,7 +2000,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 445.210 1895.420 445.350 1895.840 ;
+      RECT 110.330 948.860 110.470 949.280 ;
     END
   END rw0_rd_out[91]
   PIN rw0_rd_out[92]
@@ -2009,7 +2009,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 462.230 1895.420 462.370 1895.840 ;
+      RECT 114.470 948.860 114.610 949.280 ;
     END
   END rw0_rd_out[92]
   PIN rw0_rd_out[93]
@@ -2018,7 +2018,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 479.250 1895.420 479.390 1895.840 ;
+      RECT 118.610 948.860 118.750 949.280 ;
     END
   END rw0_rd_out[93]
   PIN rw0_rd_out[94]
@@ -2027,7 +2027,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 496.270 1895.420 496.410 1895.840 ;
+      RECT 122.750 948.860 122.890 949.280 ;
     END
   END rw0_rd_out[94]
   PIN rw0_rd_out[95]
@@ -2036,7 +2036,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 513.290 1895.420 513.430 1895.840 ;
+      RECT 126.890 948.860 127.030 949.280 ;
     END
   END rw0_rd_out[95]
   PIN rw0_rd_out[96]
@@ -2045,7 +2045,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 530.310 1895.420 530.450 1895.840 ;
+      RECT 131.030 948.860 131.170 949.280 ;
     END
   END rw0_rd_out[96]
   PIN rw0_rd_out[97]
@@ -2054,7 +2054,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 547.330 1895.420 547.470 1895.840 ;
+      RECT 135.170 948.860 135.310 949.280 ;
     END
   END rw0_rd_out[97]
   PIN rw0_rd_out[98]
@@ -2063,7 +2063,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 564.350 1895.420 564.490 1895.840 ;
+      RECT 139.310 948.860 139.450 949.280 ;
     END
   END rw0_rd_out[98]
   PIN rw0_rd_out[99]
@@ -2072,7 +2072,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 581.370 1895.420 581.510 1895.840 ;
+      RECT 143.450 948.860 143.590 949.280 ;
     END
   END rw0_rd_out[99]
   PIN rw0_rd_out[100]
@@ -2081,7 +2081,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 598.390 1895.420 598.530 1895.840 ;
+      RECT 147.590 948.860 147.730 949.280 ;
     END
   END rw0_rd_out[100]
   PIN rw0_rd_out[101]
@@ -2090,7 +2090,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 615.410 1895.420 615.550 1895.840 ;
+      RECT 151.730 948.860 151.870 949.280 ;
     END
   END rw0_rd_out[101]
   PIN rw0_rd_out[102]
@@ -2099,7 +2099,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 632.430 1895.420 632.570 1895.840 ;
+      RECT 155.870 948.860 156.010 949.280 ;
     END
   END rw0_rd_out[102]
   PIN rw0_rd_out[103]
@@ -2108,7 +2108,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 649.450 1895.420 649.590 1895.840 ;
+      RECT 160.010 948.860 160.150 949.280 ;
     END
   END rw0_rd_out[103]
   PIN rw0_rd_out[104]
@@ -2117,7 +2117,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 666.470 1895.420 666.610 1895.840 ;
+      RECT 164.150 948.860 164.290 949.280 ;
     END
   END rw0_rd_out[104]
   PIN rw0_rd_out[105]
@@ -2126,7 +2126,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 683.490 1895.420 683.630 1895.840 ;
+      RECT 168.290 948.860 168.430 949.280 ;
     END
   END rw0_rd_out[105]
   PIN rw0_rd_out[106]
@@ -2135,7 +2135,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 700.510 1895.420 700.650 1895.840 ;
+      RECT 172.430 948.860 172.570 949.280 ;
     END
   END rw0_rd_out[106]
   PIN rw0_rd_out[107]
@@ -2144,7 +2144,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 717.530 1895.420 717.670 1895.840 ;
+      RECT 176.570 948.860 176.710 949.280 ;
     END
   END rw0_rd_out[107]
   PIN rw0_rd_out[108]
@@ -2153,7 +2153,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 734.550 1895.420 734.690 1895.840 ;
+      RECT 180.710 948.860 180.850 949.280 ;
     END
   END rw0_rd_out[108]
   PIN rw0_rd_out[109]
@@ -2162,7 +2162,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 751.570 1895.420 751.710 1895.840 ;
+      RECT 184.850 948.860 184.990 949.280 ;
     END
   END rw0_rd_out[109]
   PIN rw0_rd_out[110]
@@ -2171,7 +2171,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 768.590 1895.420 768.730 1895.840 ;
+      RECT 188.990 948.860 189.130 949.280 ;
     END
   END rw0_rd_out[110]
   PIN rw0_rd_out[111]
@@ -2180,7 +2180,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 785.610 1895.420 785.750 1895.840 ;
+      RECT 193.130 948.860 193.270 949.280 ;
     END
   END rw0_rd_out[111]
   PIN rw0_rd_out[112]
@@ -2189,7 +2189,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 802.630 1895.420 802.770 1895.840 ;
+      RECT 197.270 948.860 197.410 949.280 ;
     END
   END rw0_rd_out[112]
   PIN rw0_rd_out[113]
@@ -2198,7 +2198,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 819.650 1895.420 819.790 1895.840 ;
+      RECT 201.410 948.860 201.550 949.280 ;
     END
   END rw0_rd_out[113]
   PIN rw0_rd_out[114]
@@ -2207,7 +2207,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 836.670 1895.420 836.810 1895.840 ;
+      RECT 205.550 948.860 205.690 949.280 ;
     END
   END rw0_rd_out[114]
   PIN rw0_rd_out[115]
@@ -2216,7 +2216,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 853.690 1895.420 853.830 1895.840 ;
+      RECT 209.690 948.860 209.830 949.280 ;
     END
   END rw0_rd_out[115]
   PIN rw0_rd_out[116]
@@ -2225,7 +2225,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 870.710 1895.420 870.850 1895.840 ;
+      RECT 213.830 948.860 213.970 949.280 ;
     END
   END rw0_rd_out[116]
   PIN rw0_rd_out[117]
@@ -2234,7 +2234,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 887.730 1895.420 887.870 1895.840 ;
+      RECT 217.970 948.860 218.110 949.280 ;
     END
   END rw0_rd_out[117]
   PIN rw0_rd_out[118]
@@ -2243,7 +2243,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 904.750 1895.420 904.890 1895.840 ;
+      RECT 222.110 948.860 222.250 949.280 ;
     END
   END rw0_rd_out[118]
   PIN rw0_rd_out[119]
@@ -2252,7 +2252,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 921.770 1895.420 921.910 1895.840 ;
+      RECT 226.250 948.860 226.390 949.280 ;
     END
   END rw0_rd_out[119]
   PIN rw0_rd_out[120]
@@ -2261,7 +2261,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 938.790 1895.420 938.930 1895.840 ;
+      RECT 230.390 948.860 230.530 949.280 ;
     END
   END rw0_rd_out[120]
   PIN rw0_rd_out[121]
@@ -2270,7 +2270,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 955.810 1895.420 955.950 1895.840 ;
+      RECT 234.530 948.860 234.670 949.280 ;
     END
   END rw0_rd_out[121]
   PIN rw0_rd_out[122]
@@ -2279,7 +2279,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 972.830 1895.420 972.970 1895.840 ;
+      RECT 238.670 948.860 238.810 949.280 ;
     END
   END rw0_rd_out[122]
   PIN rw0_rd_out[123]
@@ -2288,7 +2288,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 989.850 1895.420 989.990 1895.840 ;
+      RECT 242.810 948.860 242.950 949.280 ;
     END
   END rw0_rd_out[123]
   PIN rw0_rd_out[124]
@@ -2297,7 +2297,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1006.870 1895.420 1007.010 1895.840 ;
+      RECT 246.950 948.860 247.090 949.280 ;
     END
   END rw0_rd_out[124]
   PIN rw0_rd_out[125]
@@ -2306,7 +2306,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1023.890 1895.420 1024.030 1895.840 ;
+      RECT 251.090 948.860 251.230 949.280 ;
     END
   END rw0_rd_out[125]
   PIN rw0_rd_out[126]
@@ -2315,7 +2315,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1040.910 1895.420 1041.050 1895.840 ;
+      RECT 255.230 948.860 255.370 949.280 ;
     END
   END rw0_rd_out[126]
   PIN rw0_rd_out[127]
@@ -2324,7 +2324,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1057.930 1895.420 1058.070 1895.840 ;
+      RECT 259.370 948.860 259.510 949.280 ;
     END
   END rw0_rd_out[127]
   PIN rw0_rd_out[128]
@@ -2333,7 +2333,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1074.950 1895.420 1075.090 1895.840 ;
+      RECT 263.510 948.860 263.650 949.280 ;
     END
   END rw0_rd_out[128]
   PIN rw0_rd_out[129]
@@ -2342,7 +2342,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1091.970 1895.420 1092.110 1895.840 ;
+      RECT 267.650 948.860 267.790 949.280 ;
     END
   END rw0_rd_out[129]
   PIN r0_rd_out[0]
@@ -2351,7 +2351,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1557.490 0.000 1557.630 0.420 ;
+      RECT 361.490 0.000 361.630 0.420 ;
     END
   END r0_rd_out[0]
   PIN r0_rd_out[1]
@@ -2360,7 +2360,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1569.450 0.000 1569.590 0.420 ;
+      RECT 364.250 0.000 364.390 0.420 ;
     END
   END r0_rd_out[1]
   PIN r0_rd_out[2]
@@ -2369,7 +2369,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1581.410 0.000 1581.550 0.420 ;
+      RECT 367.010 0.000 367.150 0.420 ;
     END
   END r0_rd_out[2]
   PIN r0_rd_out[3]
@@ -2378,7 +2378,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1593.370 0.000 1593.510 0.420 ;
+      RECT 369.770 0.000 369.910 0.420 ;
     END
   END r0_rd_out[3]
   PIN r0_rd_out[4]
@@ -2387,7 +2387,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1605.330 0.000 1605.470 0.420 ;
+      RECT 372.530 0.000 372.670 0.420 ;
     END
   END r0_rd_out[4]
   PIN r0_rd_out[5]
@@ -2396,7 +2396,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1617.290 0.000 1617.430 0.420 ;
+      RECT 375.290 0.000 375.430 0.420 ;
     END
   END r0_rd_out[5]
   PIN r0_rd_out[6]
@@ -2405,7 +2405,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1629.250 0.000 1629.390 0.420 ;
+      RECT 378.050 0.000 378.190 0.420 ;
     END
   END r0_rd_out[6]
   PIN r0_rd_out[7]
@@ -2414,7 +2414,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1641.210 0.000 1641.350 0.420 ;
+      RECT 380.810 0.000 380.950 0.420 ;
     END
   END r0_rd_out[7]
   PIN r0_rd_out[8]
@@ -2423,7 +2423,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1653.170 0.000 1653.310 0.420 ;
+      RECT 383.570 0.000 383.710 0.420 ;
     END
   END r0_rd_out[8]
   PIN r0_rd_out[9]
@@ -2432,7 +2432,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1665.130 0.000 1665.270 0.420 ;
+      RECT 386.330 0.000 386.470 0.420 ;
     END
   END r0_rd_out[9]
   PIN r0_rd_out[10]
@@ -2441,7 +2441,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1677.090 0.000 1677.230 0.420 ;
+      RECT 389.090 0.000 389.230 0.420 ;
     END
   END r0_rd_out[10]
   PIN r0_rd_out[11]
@@ -2450,7 +2450,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1689.050 0.000 1689.190 0.420 ;
+      RECT 391.850 0.000 391.990 0.420 ;
     END
   END r0_rd_out[11]
   PIN r0_rd_out[12]
@@ -2459,7 +2459,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1701.010 0.000 1701.150 0.420 ;
+      RECT 394.610 0.000 394.750 0.420 ;
     END
   END r0_rd_out[12]
   PIN r0_rd_out[13]
@@ -2468,7 +2468,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1712.970 0.000 1713.110 0.420 ;
+      RECT 397.370 0.000 397.510 0.420 ;
     END
   END r0_rd_out[13]
   PIN r0_rd_out[14]
@@ -2477,7 +2477,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1724.930 0.000 1725.070 0.420 ;
+      RECT 400.130 0.000 400.270 0.420 ;
     END
   END r0_rd_out[14]
   PIN r0_rd_out[15]
@@ -2486,7 +2486,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1736.890 0.000 1737.030 0.420 ;
+      RECT 402.890 0.000 403.030 0.420 ;
     END
   END r0_rd_out[15]
   PIN r0_rd_out[16]
@@ -2495,7 +2495,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1748.850 0.000 1748.990 0.420 ;
+      RECT 405.650 0.000 405.790 0.420 ;
     END
   END r0_rd_out[16]
   PIN r0_rd_out[17]
@@ -2504,7 +2504,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1760.810 0.000 1760.950 0.420 ;
+      RECT 408.410 0.000 408.550 0.420 ;
     END
   END r0_rd_out[17]
   PIN r0_rd_out[18]
@@ -2513,7 +2513,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1772.770 0.000 1772.910 0.420 ;
+      RECT 411.170 0.000 411.310 0.420 ;
     END
   END r0_rd_out[18]
   PIN r0_rd_out[19]
@@ -2522,7 +2522,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1784.730 0.000 1784.870 0.420 ;
+      RECT 413.930 0.000 414.070 0.420 ;
     END
   END r0_rd_out[19]
   PIN r0_rd_out[20]
@@ -2531,7 +2531,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1796.690 0.000 1796.830 0.420 ;
+      RECT 416.690 0.000 416.830 0.420 ;
     END
   END r0_rd_out[20]
   PIN r0_rd_out[21]
@@ -2540,7 +2540,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1808.650 0.000 1808.790 0.420 ;
+      RECT 419.450 0.000 419.590 0.420 ;
     END
   END r0_rd_out[21]
   PIN r0_rd_out[22]
@@ -2549,7 +2549,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1820.610 0.000 1820.750 0.420 ;
+      RECT 422.210 0.000 422.350 0.420 ;
     END
   END r0_rd_out[22]
   PIN r0_rd_out[23]
@@ -2558,7 +2558,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1832.570 0.000 1832.710 0.420 ;
+      RECT 424.970 0.000 425.110 0.420 ;
     END
   END r0_rd_out[23]
   PIN r0_rd_out[24]
@@ -2567,7 +2567,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1844.530 0.000 1844.670 0.420 ;
+      RECT 427.730 0.000 427.870 0.420 ;
     END
   END r0_rd_out[24]
   PIN r0_rd_out[25]
@@ -2576,7 +2576,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1856.490 0.000 1856.630 0.420 ;
+      RECT 430.490 0.000 430.630 0.420 ;
     END
   END r0_rd_out[25]
   PIN r0_rd_out[26]
@@ -2585,7 +2585,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1868.450 0.000 1868.590 0.420 ;
+      RECT 433.250 0.000 433.390 0.420 ;
     END
   END r0_rd_out[26]
   PIN r0_rd_out[27]
@@ -2594,7 +2594,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1880.410 0.000 1880.550 0.420 ;
+      RECT 436.010 0.000 436.150 0.420 ;
     END
   END r0_rd_out[27]
   PIN r0_rd_out[28]
@@ -2603,7 +2603,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1892.370 0.000 1892.510 0.420 ;
+      RECT 438.770 0.000 438.910 0.420 ;
     END
   END r0_rd_out[28]
   PIN r0_rd_out[29]
@@ -2612,7 +2612,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1904.330 0.000 1904.470 0.420 ;
+      RECT 441.530 0.000 441.670 0.420 ;
     END
   END r0_rd_out[29]
   PIN r0_rd_out[30]
@@ -2621,7 +2621,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1916.290 0.000 1916.430 0.420 ;
+      RECT 444.290 0.000 444.430 0.420 ;
     END
   END r0_rd_out[30]
   PIN r0_rd_out[31]
@@ -2630,7 +2630,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1928.250 0.000 1928.390 0.420 ;
+      RECT 447.050 0.000 447.190 0.420 ;
     END
   END r0_rd_out[31]
   PIN r0_rd_out[32]
@@ -2639,7 +2639,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1940.210 0.000 1940.350 0.420 ;
+      RECT 449.810 0.000 449.950 0.420 ;
     END
   END r0_rd_out[32]
   PIN r0_rd_out[33]
@@ -2648,7 +2648,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1952.170 0.000 1952.310 0.420 ;
+      RECT 452.570 0.000 452.710 0.420 ;
     END
   END r0_rd_out[33]
   PIN r0_rd_out[34]
@@ -2657,7 +2657,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1964.130 0.000 1964.270 0.420 ;
+      RECT 455.330 0.000 455.470 0.420 ;
     END
   END r0_rd_out[34]
   PIN r0_rd_out[35]
@@ -2666,7 +2666,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1976.090 0.000 1976.230 0.420 ;
+      RECT 458.090 0.000 458.230 0.420 ;
     END
   END r0_rd_out[35]
   PIN r0_rd_out[36]
@@ -2675,7 +2675,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1988.050 0.000 1988.190 0.420 ;
+      RECT 460.850 0.000 460.990 0.420 ;
     END
   END r0_rd_out[36]
   PIN r0_rd_out[37]
@@ -2684,7 +2684,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2000.010 0.000 2000.150 0.420 ;
+      RECT 463.610 0.000 463.750 0.420 ;
     END
   END r0_rd_out[37]
   PIN r0_rd_out[38]
@@ -2693,7 +2693,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2011.970 0.000 2012.110 0.420 ;
+      RECT 466.370 0.000 466.510 0.420 ;
     END
   END r0_rd_out[38]
   PIN r0_rd_out[39]
@@ -2702,7 +2702,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2023.930 0.000 2024.070 0.420 ;
+      RECT 469.130 0.000 469.270 0.420 ;
     END
   END r0_rd_out[39]
   PIN r0_rd_out[40]
@@ -2711,7 +2711,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2035.890 0.000 2036.030 0.420 ;
+      RECT 471.890 0.000 472.030 0.420 ;
     END
   END r0_rd_out[40]
   PIN r0_rd_out[41]
@@ -2720,7 +2720,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2047.850 0.000 2047.990 0.420 ;
+      RECT 474.650 0.000 474.790 0.420 ;
     END
   END r0_rd_out[41]
   PIN r0_rd_out[42]
@@ -2729,7 +2729,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2059.810 0.000 2059.950 0.420 ;
+      RECT 477.410 0.000 477.550 0.420 ;
     END
   END r0_rd_out[42]
   PIN r0_rd_out[43]
@@ -2738,7 +2738,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2071.770 0.000 2071.910 0.420 ;
+      RECT 480.170 0.000 480.310 0.420 ;
     END
   END r0_rd_out[43]
   PIN r0_rd_out[44]
@@ -2747,7 +2747,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2083.730 0.000 2083.870 0.420 ;
+      RECT 482.930 0.000 483.070 0.420 ;
     END
   END r0_rd_out[44]
   PIN r0_rd_out[45]
@@ -2756,7 +2756,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2095.690 0.000 2095.830 0.420 ;
+      RECT 485.690 0.000 485.830 0.420 ;
     END
   END r0_rd_out[45]
   PIN r0_rd_out[46]
@@ -2765,7 +2765,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2107.650 0.000 2107.790 0.420 ;
+      RECT 488.450 0.000 488.590 0.420 ;
     END
   END r0_rd_out[46]
   PIN r0_rd_out[47]
@@ -2774,7 +2774,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2119.610 0.000 2119.750 0.420 ;
+      RECT 491.210 0.000 491.350 0.420 ;
     END
   END r0_rd_out[47]
   PIN r0_rd_out[48]
@@ -2783,7 +2783,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2131.570 0.000 2131.710 0.420 ;
+      RECT 493.970 0.000 494.110 0.420 ;
     END
   END r0_rd_out[48]
   PIN r0_rd_out[49]
@@ -2792,7 +2792,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2143.530 0.000 2143.670 0.420 ;
+      RECT 496.730 0.000 496.870 0.420 ;
     END
   END r0_rd_out[49]
   PIN r0_rd_out[50]
@@ -2801,7 +2801,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2155.490 0.000 2155.630 0.420 ;
+      RECT 499.490 0.000 499.630 0.420 ;
     END
   END r0_rd_out[50]
   PIN r0_rd_out[51]
@@ -2810,7 +2810,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2167.450 0.000 2167.590 0.420 ;
+      RECT 502.250 0.000 502.390 0.420 ;
     END
   END r0_rd_out[51]
   PIN r0_rd_out[52]
@@ -2819,7 +2819,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2179.410 0.000 2179.550 0.420 ;
+      RECT 505.010 0.000 505.150 0.420 ;
     END
   END r0_rd_out[52]
   PIN r0_rd_out[53]
@@ -2828,7 +2828,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2191.370 0.000 2191.510 0.420 ;
+      RECT 507.770 0.000 507.910 0.420 ;
     END
   END r0_rd_out[53]
   PIN r0_rd_out[54]
@@ -2837,7 +2837,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2203.330 0.000 2203.470 0.420 ;
+      RECT 510.530 0.000 510.670 0.420 ;
     END
   END r0_rd_out[54]
   PIN r0_rd_out[55]
@@ -2846,7 +2846,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2215.290 0.000 2215.430 0.420 ;
+      RECT 513.290 0.000 513.430 0.420 ;
     END
   END r0_rd_out[55]
   PIN r0_rd_out[56]
@@ -2855,7 +2855,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2227.250 0.000 2227.390 0.420 ;
+      RECT 516.050 0.000 516.190 0.420 ;
     END
   END r0_rd_out[56]
   PIN r0_rd_out[57]
@@ -2864,7 +2864,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2239.210 0.000 2239.350 0.420 ;
+      RECT 518.810 0.000 518.950 0.420 ;
     END
   END r0_rd_out[57]
   PIN r0_rd_out[58]
@@ -2873,7 +2873,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2251.170 0.000 2251.310 0.420 ;
+      RECT 521.570 0.000 521.710 0.420 ;
     END
   END r0_rd_out[58]
   PIN r0_rd_out[59]
@@ -2882,7 +2882,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2263.130 0.000 2263.270 0.420 ;
+      RECT 524.330 0.000 524.470 0.420 ;
     END
   END r0_rd_out[59]
   PIN r0_rd_out[60]
@@ -2891,7 +2891,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2275.090 0.000 2275.230 0.420 ;
+      RECT 527.090 0.000 527.230 0.420 ;
     END
   END r0_rd_out[60]
   PIN r0_rd_out[61]
@@ -2900,7 +2900,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2287.050 0.000 2287.190 0.420 ;
+      RECT 529.850 0.000 529.990 0.420 ;
     END
   END r0_rd_out[61]
   PIN r0_rd_out[62]
@@ -2909,7 +2909,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2299.010 0.000 2299.150 0.420 ;
+      RECT 532.610 0.000 532.750 0.420 ;
     END
   END r0_rd_out[62]
   PIN r0_rd_out[63]
@@ -2918,7 +2918,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2310.970 0.000 2311.110 0.420 ;
+      RECT 535.370 0.000 535.510 0.420 ;
     END
   END r0_rd_out[63]
   PIN r0_rd_out[64]
@@ -2927,7 +2927,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2322.930 0.000 2323.070 0.420 ;
+      RECT 538.130 0.000 538.270 0.420 ;
     END
   END r0_rd_out[64]
   PIN r0_rd_out[65]
@@ -2936,7 +2936,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1108.990 1895.420 1109.130 1895.840 ;
+      RECT 271.790 948.860 271.930 949.280 ;
     END
   END r0_rd_out[65]
   PIN r0_rd_out[66]
@@ -2945,7 +2945,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1126.010 1895.420 1126.150 1895.840 ;
+      RECT 275.930 948.860 276.070 949.280 ;
     END
   END r0_rd_out[66]
   PIN r0_rd_out[67]
@@ -2954,7 +2954,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1143.030 1895.420 1143.170 1895.840 ;
+      RECT 280.070 948.860 280.210 949.280 ;
     END
   END r0_rd_out[67]
   PIN r0_rd_out[68]
@@ -2963,7 +2963,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1160.050 1895.420 1160.190 1895.840 ;
+      RECT 284.210 948.860 284.350 949.280 ;
     END
   END r0_rd_out[68]
   PIN r0_rd_out[69]
@@ -2972,7 +2972,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1177.070 1895.420 1177.210 1895.840 ;
+      RECT 288.350 948.860 288.490 949.280 ;
     END
   END r0_rd_out[69]
   PIN r0_rd_out[70]
@@ -2981,7 +2981,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1194.090 1895.420 1194.230 1895.840 ;
+      RECT 292.490 948.860 292.630 949.280 ;
     END
   END r0_rd_out[70]
   PIN r0_rd_out[71]
@@ -2990,7 +2990,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1211.110 1895.420 1211.250 1895.840 ;
+      RECT 296.630 948.860 296.770 949.280 ;
     END
   END r0_rd_out[71]
   PIN r0_rd_out[72]
@@ -2999,7 +2999,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1228.130 1895.420 1228.270 1895.840 ;
+      RECT 300.770 948.860 300.910 949.280 ;
     END
   END r0_rd_out[72]
   PIN r0_rd_out[73]
@@ -3008,7 +3008,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1245.150 1895.420 1245.290 1895.840 ;
+      RECT 304.910 948.860 305.050 949.280 ;
     END
   END r0_rd_out[73]
   PIN r0_rd_out[74]
@@ -3017,7 +3017,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1262.170 1895.420 1262.310 1895.840 ;
+      RECT 309.050 948.860 309.190 949.280 ;
     END
   END r0_rd_out[74]
   PIN r0_rd_out[75]
@@ -3026,7 +3026,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1279.190 1895.420 1279.330 1895.840 ;
+      RECT 313.190 948.860 313.330 949.280 ;
     END
   END r0_rd_out[75]
   PIN r0_rd_out[76]
@@ -3035,7 +3035,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1296.210 1895.420 1296.350 1895.840 ;
+      RECT 317.330 948.860 317.470 949.280 ;
     END
   END r0_rd_out[76]
   PIN r0_rd_out[77]
@@ -3044,7 +3044,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1313.230 1895.420 1313.370 1895.840 ;
+      RECT 321.470 948.860 321.610 949.280 ;
     END
   END r0_rd_out[77]
   PIN r0_rd_out[78]
@@ -3053,7 +3053,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1330.250 1895.420 1330.390 1895.840 ;
+      RECT 325.610 948.860 325.750 949.280 ;
     END
   END r0_rd_out[78]
   PIN r0_rd_out[79]
@@ -3062,7 +3062,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1347.270 1895.420 1347.410 1895.840 ;
+      RECT 329.750 948.860 329.890 949.280 ;
     END
   END r0_rd_out[79]
   PIN r0_rd_out[80]
@@ -3071,7 +3071,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1364.290 1895.420 1364.430 1895.840 ;
+      RECT 333.890 948.860 334.030 949.280 ;
     END
   END r0_rd_out[80]
   PIN r0_rd_out[81]
@@ -3080,7 +3080,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1381.310 1895.420 1381.450 1895.840 ;
+      RECT 338.030 948.860 338.170 949.280 ;
     END
   END r0_rd_out[81]
   PIN r0_rd_out[82]
@@ -3089,7 +3089,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1398.330 1895.420 1398.470 1895.840 ;
+      RECT 342.170 948.860 342.310 949.280 ;
     END
   END r0_rd_out[82]
   PIN r0_rd_out[83]
@@ -3098,7 +3098,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1415.350 1895.420 1415.490 1895.840 ;
+      RECT 346.310 948.860 346.450 949.280 ;
     END
   END r0_rd_out[83]
   PIN r0_rd_out[84]
@@ -3107,7 +3107,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1432.370 1895.420 1432.510 1895.840 ;
+      RECT 350.450 948.860 350.590 949.280 ;
     END
   END r0_rd_out[84]
   PIN r0_rd_out[85]
@@ -3116,7 +3116,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1449.390 1895.420 1449.530 1895.840 ;
+      RECT 354.590 948.860 354.730 949.280 ;
     END
   END r0_rd_out[85]
   PIN r0_rd_out[86]
@@ -3125,7 +3125,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1466.410 1895.420 1466.550 1895.840 ;
+      RECT 358.730 948.860 358.870 949.280 ;
     END
   END r0_rd_out[86]
   PIN r0_rd_out[87]
@@ -3134,7 +3134,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1483.430 1895.420 1483.570 1895.840 ;
+      RECT 362.870 948.860 363.010 949.280 ;
     END
   END r0_rd_out[87]
   PIN r0_rd_out[88]
@@ -3143,7 +3143,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1500.450 1895.420 1500.590 1895.840 ;
+      RECT 367.010 948.860 367.150 949.280 ;
     END
   END r0_rd_out[88]
   PIN r0_rd_out[89]
@@ -3152,7 +3152,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1517.470 1895.420 1517.610 1895.840 ;
+      RECT 371.150 948.860 371.290 949.280 ;
     END
   END r0_rd_out[89]
   PIN r0_rd_out[90]
@@ -3161,7 +3161,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1534.490 1895.420 1534.630 1895.840 ;
+      RECT 375.290 948.860 375.430 949.280 ;
     END
   END r0_rd_out[90]
   PIN r0_rd_out[91]
@@ -3170,7 +3170,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1551.510 1895.420 1551.650 1895.840 ;
+      RECT 379.430 948.860 379.570 949.280 ;
     END
   END r0_rd_out[91]
   PIN r0_rd_out[92]
@@ -3179,7 +3179,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1568.530 1895.420 1568.670 1895.840 ;
+      RECT 383.570 948.860 383.710 949.280 ;
     END
   END r0_rd_out[92]
   PIN r0_rd_out[93]
@@ -3188,7 +3188,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1585.550 1895.420 1585.690 1895.840 ;
+      RECT 387.710 948.860 387.850 949.280 ;
     END
   END r0_rd_out[93]
   PIN r0_rd_out[94]
@@ -3197,7 +3197,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1602.570 1895.420 1602.710 1895.840 ;
+      RECT 391.850 948.860 391.990 949.280 ;
     END
   END r0_rd_out[94]
   PIN r0_rd_out[95]
@@ -3206,7 +3206,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1619.590 1895.420 1619.730 1895.840 ;
+      RECT 395.990 948.860 396.130 949.280 ;
     END
   END r0_rd_out[95]
   PIN r0_rd_out[96]
@@ -3215,7 +3215,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1636.610 1895.420 1636.750 1895.840 ;
+      RECT 400.130 948.860 400.270 949.280 ;
     END
   END r0_rd_out[96]
   PIN r0_rd_out[97]
@@ -3224,7 +3224,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1653.630 1895.420 1653.770 1895.840 ;
+      RECT 404.270 948.860 404.410 949.280 ;
     END
   END r0_rd_out[97]
   PIN r0_rd_out[98]
@@ -3233,7 +3233,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1670.650 1895.420 1670.790 1895.840 ;
+      RECT 408.410 948.860 408.550 949.280 ;
     END
   END r0_rd_out[98]
   PIN r0_rd_out[99]
@@ -3242,7 +3242,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1687.670 1895.420 1687.810 1895.840 ;
+      RECT 412.550 948.860 412.690 949.280 ;
     END
   END r0_rd_out[99]
   PIN r0_rd_out[100]
@@ -3251,7 +3251,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1704.690 1895.420 1704.830 1895.840 ;
+      RECT 416.690 948.860 416.830 949.280 ;
     END
   END r0_rd_out[100]
   PIN r0_rd_out[101]
@@ -3260,7 +3260,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1721.710 1895.420 1721.850 1895.840 ;
+      RECT 420.830 948.860 420.970 949.280 ;
     END
   END r0_rd_out[101]
   PIN r0_rd_out[102]
@@ -3269,7 +3269,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1738.730 1895.420 1738.870 1895.840 ;
+      RECT 424.970 948.860 425.110 949.280 ;
     END
   END r0_rd_out[102]
   PIN r0_rd_out[103]
@@ -3278,7 +3278,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1755.750 1895.420 1755.890 1895.840 ;
+      RECT 429.110 948.860 429.250 949.280 ;
     END
   END r0_rd_out[103]
   PIN r0_rd_out[104]
@@ -3287,7 +3287,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1772.770 1895.420 1772.910 1895.840 ;
+      RECT 433.250 948.860 433.390 949.280 ;
     END
   END r0_rd_out[104]
   PIN r0_rd_out[105]
@@ -3296,7 +3296,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1789.790 1895.420 1789.930 1895.840 ;
+      RECT 437.390 948.860 437.530 949.280 ;
     END
   END r0_rd_out[105]
   PIN r0_rd_out[106]
@@ -3305,7 +3305,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1806.810 1895.420 1806.950 1895.840 ;
+      RECT 441.530 948.860 441.670 949.280 ;
     END
   END r0_rd_out[106]
   PIN r0_rd_out[107]
@@ -3314,7 +3314,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1823.830 1895.420 1823.970 1895.840 ;
+      RECT 445.670 948.860 445.810 949.280 ;
     END
   END r0_rd_out[107]
   PIN r0_rd_out[108]
@@ -3323,7 +3323,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1840.850 1895.420 1840.990 1895.840 ;
+      RECT 449.810 948.860 449.950 949.280 ;
     END
   END r0_rd_out[108]
   PIN r0_rd_out[109]
@@ -3332,7 +3332,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1857.870 1895.420 1858.010 1895.840 ;
+      RECT 453.950 948.860 454.090 949.280 ;
     END
   END r0_rd_out[109]
   PIN r0_rd_out[110]
@@ -3341,7 +3341,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1874.890 1895.420 1875.030 1895.840 ;
+      RECT 458.090 948.860 458.230 949.280 ;
     END
   END r0_rd_out[110]
   PIN r0_rd_out[111]
@@ -3350,7 +3350,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1891.910 1895.420 1892.050 1895.840 ;
+      RECT 462.230 948.860 462.370 949.280 ;
     END
   END r0_rd_out[111]
   PIN r0_rd_out[112]
@@ -3359,7 +3359,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1908.930 1895.420 1909.070 1895.840 ;
+      RECT 466.370 948.860 466.510 949.280 ;
     END
   END r0_rd_out[112]
   PIN r0_rd_out[113]
@@ -3368,7 +3368,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1925.950 1895.420 1926.090 1895.840 ;
+      RECT 470.510 948.860 470.650 949.280 ;
     END
   END r0_rd_out[113]
   PIN r0_rd_out[114]
@@ -3377,7 +3377,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1942.970 1895.420 1943.110 1895.840 ;
+      RECT 474.650 948.860 474.790 949.280 ;
     END
   END r0_rd_out[114]
   PIN r0_rd_out[115]
@@ -3386,7 +3386,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1959.990 1895.420 1960.130 1895.840 ;
+      RECT 478.790 948.860 478.930 949.280 ;
     END
   END r0_rd_out[115]
   PIN r0_rd_out[116]
@@ -3395,7 +3395,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1977.010 1895.420 1977.150 1895.840 ;
+      RECT 482.930 948.860 483.070 949.280 ;
     END
   END r0_rd_out[116]
   PIN r0_rd_out[117]
@@ -3404,7 +3404,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 1994.030 1895.420 1994.170 1895.840 ;
+      RECT 487.070 948.860 487.210 949.280 ;
     END
   END r0_rd_out[117]
   PIN r0_rd_out[118]
@@ -3413,7 +3413,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2011.050 1895.420 2011.190 1895.840 ;
+      RECT 491.210 948.860 491.350 949.280 ;
     END
   END r0_rd_out[118]
   PIN r0_rd_out[119]
@@ -3422,7 +3422,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2028.070 1895.420 2028.210 1895.840 ;
+      RECT 495.350 948.860 495.490 949.280 ;
     END
   END r0_rd_out[119]
   PIN r0_rd_out[120]
@@ -3431,7 +3431,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2045.090 1895.420 2045.230 1895.840 ;
+      RECT 499.490 948.860 499.630 949.280 ;
     END
   END r0_rd_out[120]
   PIN r0_rd_out[121]
@@ -3440,7 +3440,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2062.110 1895.420 2062.250 1895.840 ;
+      RECT 503.630 948.860 503.770 949.280 ;
     END
   END r0_rd_out[121]
   PIN r0_rd_out[122]
@@ -3449,7 +3449,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2079.130 1895.420 2079.270 1895.840 ;
+      RECT 507.770 948.860 507.910 949.280 ;
     END
   END r0_rd_out[122]
   PIN r0_rd_out[123]
@@ -3458,7 +3458,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2096.150 1895.420 2096.290 1895.840 ;
+      RECT 511.910 948.860 512.050 949.280 ;
     END
   END r0_rd_out[123]
   PIN r0_rd_out[124]
@@ -3467,7 +3467,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2113.170 1895.420 2113.310 1895.840 ;
+      RECT 516.050 948.860 516.190 949.280 ;
     END
   END r0_rd_out[124]
   PIN r0_rd_out[125]
@@ -3476,7 +3476,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2130.190 1895.420 2130.330 1895.840 ;
+      RECT 520.190 948.860 520.330 949.280 ;
     END
   END r0_rd_out[125]
   PIN r0_rd_out[126]
@@ -3485,7 +3485,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2147.210 1895.420 2147.350 1895.840 ;
+      RECT 524.330 948.860 524.470 949.280 ;
     END
   END r0_rd_out[126]
   PIN r0_rd_out[127]
@@ -3494,7 +3494,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2164.230 1895.420 2164.370 1895.840 ;
+      RECT 528.470 948.860 528.610 949.280 ;
     END
   END r0_rd_out[127]
   PIN r0_rd_out[128]
@@ -3503,7 +3503,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2181.250 1895.420 2181.390 1895.840 ;
+      RECT 532.610 948.860 532.750 949.280 ;
     END
   END r0_rd_out[128]
   PIN r0_rd_out[129]
@@ -3512,7 +3512,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2198.270 1895.420 2198.410 1895.840 ;
+      RECT 536.750 948.860 536.890 949.280 ;
     END
   END r0_rd_out[129]
   PIN rw0_addr_in[0]
@@ -3521,7 +3521,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1440.090 0.900 1440.390 ;
+      RECT 0.000 766.890 0.900 767.190 ;
     END
   END rw0_addr_in[0]
   PIN rw0_addr_in[1]
@@ -3530,7 +3530,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1483.610 0.900 1483.910 ;
+      RECT 0.000 790.010 0.900 790.310 ;
     END
   END rw0_addr_in[1]
   PIN rw0_addr_in[2]
@@ -3539,7 +3539,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1527.130 0.900 1527.430 ;
+      RECT 0.000 813.130 0.900 813.430 ;
     END
   END rw0_addr_in[2]
   PIN rw0_addr_in[3]
@@ -3548,7 +3548,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1570.650 0.900 1570.950 ;
+      RECT 0.000 836.250 0.900 836.550 ;
     END
   END rw0_addr_in[3]
   PIN rw0_addr_in[4]
@@ -3557,7 +3557,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1614.170 0.900 1614.470 ;
+      RECT 590.660 743.770 591.560 744.070 ;
     END
   END rw0_addr_in[4]
   PIN rw0_addr_in[5]
@@ -3566,7 +3566,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1396.570 2364.860 1396.870 ;
+      RECT 590.660 766.890 591.560 767.190 ;
     END
   END rw0_addr_in[5]
   PIN rw0_addr_in[6]
@@ -3575,43 +3575,16 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1440.090 2364.860 1440.390 ;
+      RECT 590.660 790.010 591.560 790.310 ;
     END
   END rw0_addr_in[6]
-  PIN rw0_addr_in[7]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER met3 ;
-      RECT 2363.960 1483.610 2364.860 1483.910 ;
-    END
-  END rw0_addr_in[7]
-  PIN rw0_addr_in[8]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER met3 ;
-      RECT 2363.960 1527.130 2364.860 1527.430 ;
-    END
-  END rw0_addr_in[8]
-  PIN rw0_addr_in[9]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER met3 ;
-      RECT 2363.960 1570.650 2364.860 1570.950 ;
-    END
-  END rw0_addr_in[9]
   PIN r0_addr_in[0]
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1657.690 0.900 1657.990 ;
+      RECT 0.000 859.370 0.900 859.670 ;
     END
   END r0_addr_in[0]
   PIN r0_addr_in[1]
@@ -3620,7 +3593,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1701.210 0.900 1701.510 ;
+      RECT 0.000 882.490 0.900 882.790 ;
     END
   END r0_addr_in[1]
   PIN r0_addr_in[2]
@@ -3629,7 +3602,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1744.730 0.900 1745.030 ;
+      RECT 0.000 905.610 0.900 905.910 ;
     END
   END r0_addr_in[2]
   PIN r0_addr_in[3]
@@ -3638,7 +3611,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1788.250 0.900 1788.550 ;
+      RECT 0.000 928.730 0.900 929.030 ;
     END
   END r0_addr_in[3]
   PIN r0_addr_in[4]
@@ -3647,7 +3620,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 1831.770 0.900 1832.070 ;
+      RECT 590.660 813.130 591.560 813.430 ;
     END
   END r0_addr_in[4]
   PIN r0_addr_in[5]
@@ -3656,7 +3629,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1614.170 2364.860 1614.470 ;
+      RECT 590.660 836.250 591.560 836.550 ;
     END
   END r0_addr_in[5]
   PIN r0_addr_in[6]
@@ -3665,43 +3638,16 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 2363.960 1657.690 2364.860 1657.990 ;
+      RECT 590.660 859.370 591.560 859.670 ;
     END
   END r0_addr_in[6]
-  PIN r0_addr_in[7]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER met3 ;
-      RECT 2363.960 1701.210 2364.860 1701.510 ;
-    END
-  END r0_addr_in[7]
-  PIN r0_addr_in[8]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER met3 ;
-      RECT 2363.960 1744.730 2364.860 1745.030 ;
-    END
-  END r0_addr_in[8]
-  PIN r0_addr_in[9]
-    DIRECTION INPUT ;
-    USE SIGNAL ;
-    SHAPE ABUTMENT ;
-    PORT
-      LAYER met3 ;
-      RECT 2363.960 1788.250 2364.860 1788.550 ;
-    END
-  END r0_addr_in[9]
   PIN rw0_we_in
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2215.290 1895.420 2215.430 1895.840 ;
+      RECT 540.890 948.860 541.030 949.280 ;
     END
   END rw0_we_in
   PIN rw0_ce_in
@@ -3710,7 +3656,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2232.310 1895.420 2232.450 1895.840 ;
+      RECT 545.030 948.860 545.170 949.280 ;
     END
   END rw0_ce_in
   PIN rw0_clk
@@ -3719,7 +3665,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2249.330 1895.420 2249.470 1895.840 ;
+      RECT 549.170 948.860 549.310 949.280 ;
     END
   END rw0_clk
   PIN r0_ce_in
@@ -3728,7 +3674,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2266.350 1895.420 2266.490 1895.840 ;
+      RECT 553.310 948.860 553.450 949.280 ;
     END
   END r0_ce_in
   PIN r0_clk
@@ -3737,7 +3683,7 @@ MACRO fakeram130_1rw1r_130w1024d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2283.370 1895.420 2283.510 1895.840 ;
+      RECT 557.450 948.860 557.590 949.280 ;
     END
   END r0_clk
   PIN VSS
@@ -3745,224 +3691,61 @@ MACRO fakeram130_1rw1r_130w1024d
     USE GROUND ;
     PORT
       LAYER met4 ;
-      RECT 2.160 4.080 3.360 1891.760 ;
-      RECT 13.040 4.080 14.240 1891.760 ;
-      RECT 23.920 4.080 25.120 1891.760 ;
-      RECT 34.800 4.080 36.000 1891.760 ;
-      RECT 45.680 4.080 46.880 1891.760 ;
-      RECT 56.560 4.080 57.760 1891.760 ;
-      RECT 67.440 4.080 68.640 1891.760 ;
-      RECT 78.320 4.080 79.520 1891.760 ;
-      RECT 89.200 4.080 90.400 1891.760 ;
-      RECT 100.080 4.080 101.280 1891.760 ;
-      RECT 110.960 4.080 112.160 1891.760 ;
-      RECT 121.840 4.080 123.040 1891.760 ;
-      RECT 132.720 4.080 133.920 1891.760 ;
-      RECT 143.600 4.080 144.800 1891.760 ;
-      RECT 154.480 4.080 155.680 1891.760 ;
-      RECT 165.360 4.080 166.560 1891.760 ;
-      RECT 176.240 4.080 177.440 1891.760 ;
-      RECT 187.120 4.080 188.320 1891.760 ;
-      RECT 198.000 4.080 199.200 1891.760 ;
-      RECT 208.880 4.080 210.080 1891.760 ;
-      RECT 219.760 4.080 220.960 1891.760 ;
-      RECT 230.640 4.080 231.840 1891.760 ;
-      RECT 241.520 4.080 242.720 1891.760 ;
-      RECT 252.400 4.080 253.600 1891.760 ;
-      RECT 263.280 4.080 264.480 1891.760 ;
-      RECT 274.160 4.080 275.360 1891.760 ;
-      RECT 285.040 4.080 286.240 1891.760 ;
-      RECT 295.920 4.080 297.120 1891.760 ;
-      RECT 306.800 4.080 308.000 1891.760 ;
-      RECT 317.680 4.080 318.880 1891.760 ;
-      RECT 328.560 4.080 329.760 1891.760 ;
-      RECT 339.440 4.080 340.640 1891.760 ;
-      RECT 350.320 4.080 351.520 1891.760 ;
-      RECT 361.200 4.080 362.400 1891.760 ;
-      RECT 372.080 4.080 373.280 1891.760 ;
-      RECT 382.960 4.080 384.160 1891.760 ;
-      RECT 393.840 4.080 395.040 1891.760 ;
-      RECT 404.720 4.080 405.920 1891.760 ;
-      RECT 415.600 4.080 416.800 1891.760 ;
-      RECT 426.480 4.080 427.680 1891.760 ;
-      RECT 437.360 4.080 438.560 1891.760 ;
-      RECT 448.240 4.080 449.440 1891.760 ;
-      RECT 459.120 4.080 460.320 1891.760 ;
-      RECT 470.000 4.080 471.200 1891.760 ;
-      RECT 480.880 4.080 482.080 1891.760 ;
-      RECT 491.760 4.080 492.960 1891.760 ;
-      RECT 502.640 4.080 503.840 1891.760 ;
-      RECT 513.520 4.080 514.720 1891.760 ;
-      RECT 524.400 4.080 525.600 1891.760 ;
-      RECT 535.280 4.080 536.480 1891.760 ;
-      RECT 546.160 4.080 547.360 1891.760 ;
-      RECT 557.040 4.080 558.240 1891.760 ;
-      RECT 567.920 4.080 569.120 1891.760 ;
-      RECT 578.800 4.080 580.000 1891.760 ;
-      RECT 589.680 4.080 590.880 1891.760 ;
-      RECT 600.560 4.080 601.760 1891.760 ;
-      RECT 611.440 4.080 612.640 1891.760 ;
-      RECT 622.320 4.080 623.520 1891.760 ;
-      RECT 633.200 4.080 634.400 1891.760 ;
-      RECT 644.080 4.080 645.280 1891.760 ;
-      RECT 654.960 4.080 656.160 1891.760 ;
-      RECT 665.840 4.080 667.040 1891.760 ;
-      RECT 676.720 4.080 677.920 1891.760 ;
-      RECT 687.600 4.080 688.800 1891.760 ;
-      RECT 698.480 4.080 699.680 1891.760 ;
-      RECT 709.360 4.080 710.560 1891.760 ;
-      RECT 720.240 4.080 721.440 1891.760 ;
-      RECT 731.120 4.080 732.320 1891.760 ;
-      RECT 742.000 4.080 743.200 1891.760 ;
-      RECT 752.880 4.080 754.080 1891.760 ;
-      RECT 763.760 4.080 764.960 1891.760 ;
-      RECT 774.640 4.080 775.840 1891.760 ;
-      RECT 785.520 4.080 786.720 1891.760 ;
-      RECT 796.400 4.080 797.600 1891.760 ;
-      RECT 807.280 4.080 808.480 1891.760 ;
-      RECT 818.160 4.080 819.360 1891.760 ;
-      RECT 829.040 4.080 830.240 1891.760 ;
-      RECT 839.920 4.080 841.120 1891.760 ;
-      RECT 850.800 4.080 852.000 1891.760 ;
-      RECT 861.680 4.080 862.880 1891.760 ;
-      RECT 872.560 4.080 873.760 1891.760 ;
-      RECT 883.440 4.080 884.640 1891.760 ;
-      RECT 894.320 4.080 895.520 1891.760 ;
-      RECT 905.200 4.080 906.400 1891.760 ;
-      RECT 916.080 4.080 917.280 1891.760 ;
-      RECT 926.960 4.080 928.160 1891.760 ;
-      RECT 937.840 4.080 939.040 1891.760 ;
-      RECT 948.720 4.080 949.920 1891.760 ;
-      RECT 959.600 4.080 960.800 1891.760 ;
-      RECT 970.480 4.080 971.680 1891.760 ;
-      RECT 981.360 4.080 982.560 1891.760 ;
-      RECT 992.240 4.080 993.440 1891.760 ;
-      RECT 1003.120 4.080 1004.320 1891.760 ;
-      RECT 1014.000 4.080 1015.200 1891.760 ;
-      RECT 1024.880 4.080 1026.080 1891.760 ;
-      RECT 1035.760 4.080 1036.960 1891.760 ;
-      RECT 1046.640 4.080 1047.840 1891.760 ;
-      RECT 1057.520 4.080 1058.720 1891.760 ;
-      RECT 1068.400 4.080 1069.600 1891.760 ;
-      RECT 1079.280 4.080 1080.480 1891.760 ;
-      RECT 1090.160 4.080 1091.360 1891.760 ;
-      RECT 1101.040 4.080 1102.240 1891.760 ;
-      RECT 1111.920 4.080 1113.120 1891.760 ;
-      RECT 1122.800 4.080 1124.000 1891.760 ;
-      RECT 1133.680 4.080 1134.880 1891.760 ;
-      RECT 1144.560 4.080 1145.760 1891.760 ;
-      RECT 1155.440 4.080 1156.640 1891.760 ;
-      RECT 1166.320 4.080 1167.520 1891.760 ;
-      RECT 1177.200 4.080 1178.400 1891.760 ;
-      RECT 1188.080 4.080 1189.280 1891.760 ;
-      RECT 1198.960 4.080 1200.160 1891.760 ;
-      RECT 1209.840 4.080 1211.040 1891.760 ;
-      RECT 1220.720 4.080 1221.920 1891.760 ;
-      RECT 1231.600 4.080 1232.800 1891.760 ;
-      RECT 1242.480 4.080 1243.680 1891.760 ;
-      RECT 1253.360 4.080 1254.560 1891.760 ;
-      RECT 1264.240 4.080 1265.440 1891.760 ;
-      RECT 1275.120 4.080 1276.320 1891.760 ;
-      RECT 1286.000 4.080 1287.200 1891.760 ;
-      RECT 1296.880 4.080 1298.080 1891.760 ;
-      RECT 1307.760 4.080 1308.960 1891.760 ;
-      RECT 1318.640 4.080 1319.840 1891.760 ;
-      RECT 1329.520 4.080 1330.720 1891.760 ;
-      RECT 1340.400 4.080 1341.600 1891.760 ;
-      RECT 1351.280 4.080 1352.480 1891.760 ;
-      RECT 1362.160 4.080 1363.360 1891.760 ;
-      RECT 1373.040 4.080 1374.240 1891.760 ;
-      RECT 1383.920 4.080 1385.120 1891.760 ;
-      RECT 1394.800 4.080 1396.000 1891.760 ;
-      RECT 1405.680 4.080 1406.880 1891.760 ;
-      RECT 1416.560 4.080 1417.760 1891.760 ;
-      RECT 1427.440 4.080 1428.640 1891.760 ;
-      RECT 1438.320 4.080 1439.520 1891.760 ;
-      RECT 1449.200 4.080 1450.400 1891.760 ;
-      RECT 1460.080 4.080 1461.280 1891.760 ;
-      RECT 1470.960 4.080 1472.160 1891.760 ;
-      RECT 1481.840 4.080 1483.040 1891.760 ;
-      RECT 1492.720 4.080 1493.920 1891.760 ;
-      RECT 1503.600 4.080 1504.800 1891.760 ;
-      RECT 1514.480 4.080 1515.680 1891.760 ;
-      RECT 1525.360 4.080 1526.560 1891.760 ;
-      RECT 1536.240 4.080 1537.440 1891.760 ;
-      RECT 1547.120 4.080 1548.320 1891.760 ;
-      RECT 1558.000 4.080 1559.200 1891.760 ;
-      RECT 1568.880 4.080 1570.080 1891.760 ;
-      RECT 1579.760 4.080 1580.960 1891.760 ;
-      RECT 1590.640 4.080 1591.840 1891.760 ;
-      RECT 1601.520 4.080 1602.720 1891.760 ;
-      RECT 1612.400 4.080 1613.600 1891.760 ;
-      RECT 1623.280 4.080 1624.480 1891.760 ;
-      RECT 1634.160 4.080 1635.360 1891.760 ;
-      RECT 1645.040 4.080 1646.240 1891.760 ;
-      RECT 1655.920 4.080 1657.120 1891.760 ;
-      RECT 1666.800 4.080 1668.000 1891.760 ;
-      RECT 1677.680 4.080 1678.880 1891.760 ;
-      RECT 1688.560 4.080 1689.760 1891.760 ;
-      RECT 1699.440 4.080 1700.640 1891.760 ;
-      RECT 1710.320 4.080 1711.520 1891.760 ;
-      RECT 1721.200 4.080 1722.400 1891.760 ;
-      RECT 1732.080 4.080 1733.280 1891.760 ;
-      RECT 1742.960 4.080 1744.160 1891.760 ;
-      RECT 1753.840 4.080 1755.040 1891.760 ;
-      RECT 1764.720 4.080 1765.920 1891.760 ;
-      RECT 1775.600 4.080 1776.800 1891.760 ;
-      RECT 1786.480 4.080 1787.680 1891.760 ;
-      RECT 1797.360 4.080 1798.560 1891.760 ;
-      RECT 1808.240 4.080 1809.440 1891.760 ;
-      RECT 1819.120 4.080 1820.320 1891.760 ;
-      RECT 1830.000 4.080 1831.200 1891.760 ;
-      RECT 1840.880 4.080 1842.080 1891.760 ;
-      RECT 1851.760 4.080 1852.960 1891.760 ;
-      RECT 1862.640 4.080 1863.840 1891.760 ;
-      RECT 1873.520 4.080 1874.720 1891.760 ;
-      RECT 1884.400 4.080 1885.600 1891.760 ;
-      RECT 1895.280 4.080 1896.480 1891.760 ;
-      RECT 1906.160 4.080 1907.360 1891.760 ;
-      RECT 1917.040 4.080 1918.240 1891.760 ;
-      RECT 1927.920 4.080 1929.120 1891.760 ;
-      RECT 1938.800 4.080 1940.000 1891.760 ;
-      RECT 1949.680 4.080 1950.880 1891.760 ;
-      RECT 1960.560 4.080 1961.760 1891.760 ;
-      RECT 1971.440 4.080 1972.640 1891.760 ;
-      RECT 1982.320 4.080 1983.520 1891.760 ;
-      RECT 1993.200 4.080 1994.400 1891.760 ;
-      RECT 2004.080 4.080 2005.280 1891.760 ;
-      RECT 2014.960 4.080 2016.160 1891.760 ;
-      RECT 2025.840 4.080 2027.040 1891.760 ;
-      RECT 2036.720 4.080 2037.920 1891.760 ;
-      RECT 2047.600 4.080 2048.800 1891.760 ;
-      RECT 2058.480 4.080 2059.680 1891.760 ;
-      RECT 2069.360 4.080 2070.560 1891.760 ;
-      RECT 2080.240 4.080 2081.440 1891.760 ;
-      RECT 2091.120 4.080 2092.320 1891.760 ;
-      RECT 2102.000 4.080 2103.200 1891.760 ;
-      RECT 2112.880 4.080 2114.080 1891.760 ;
-      RECT 2123.760 4.080 2124.960 1891.760 ;
-      RECT 2134.640 4.080 2135.840 1891.760 ;
-      RECT 2145.520 4.080 2146.720 1891.760 ;
-      RECT 2156.400 4.080 2157.600 1891.760 ;
-      RECT 2167.280 4.080 2168.480 1891.760 ;
-      RECT 2178.160 4.080 2179.360 1891.760 ;
-      RECT 2189.040 4.080 2190.240 1891.760 ;
-      RECT 2199.920 4.080 2201.120 1891.760 ;
-      RECT 2210.800 4.080 2212.000 1891.760 ;
-      RECT 2221.680 4.080 2222.880 1891.760 ;
-      RECT 2232.560 4.080 2233.760 1891.760 ;
-      RECT 2243.440 4.080 2244.640 1891.760 ;
-      RECT 2254.320 4.080 2255.520 1891.760 ;
-      RECT 2265.200 4.080 2266.400 1891.760 ;
-      RECT 2276.080 4.080 2277.280 1891.760 ;
-      RECT 2286.960 4.080 2288.160 1891.760 ;
-      RECT 2297.840 4.080 2299.040 1891.760 ;
-      RECT 2308.720 4.080 2309.920 1891.760 ;
-      RECT 2319.600 4.080 2320.800 1891.760 ;
-      RECT 2330.480 4.080 2331.680 1891.760 ;
-      RECT 2341.360 4.080 2342.560 1891.760 ;
-      RECT 2352.240 4.080 2353.440 1891.760 ;
-      RECT 2363.120 4.080 2364.320 1891.760 ;
+      RECT 2.160 4.080 3.360 945.200 ;
+      RECT 13.040 4.080 14.240 945.200 ;
+      RECT 23.920 4.080 25.120 945.200 ;
+      RECT 34.800 4.080 36.000 945.200 ;
+      RECT 45.680 4.080 46.880 945.200 ;
+      RECT 56.560 4.080 57.760 945.200 ;
+      RECT 67.440 4.080 68.640 945.200 ;
+      RECT 78.320 4.080 79.520 945.200 ;
+      RECT 89.200 4.080 90.400 945.200 ;
+      RECT 100.080 4.080 101.280 945.200 ;
+      RECT 110.960 4.080 112.160 945.200 ;
+      RECT 121.840 4.080 123.040 945.200 ;
+      RECT 132.720 4.080 133.920 945.200 ;
+      RECT 143.600 4.080 144.800 945.200 ;
+      RECT 154.480 4.080 155.680 945.200 ;
+      RECT 165.360 4.080 166.560 945.200 ;
+      RECT 176.240 4.080 177.440 945.200 ;
+      RECT 187.120 4.080 188.320 945.200 ;
+      RECT 198.000 4.080 199.200 945.200 ;
+      RECT 208.880 4.080 210.080 945.200 ;
+      RECT 219.760 4.080 220.960 945.200 ;
+      RECT 230.640 4.080 231.840 945.200 ;
+      RECT 241.520 4.080 242.720 945.200 ;
+      RECT 252.400 4.080 253.600 945.200 ;
+      RECT 263.280 4.080 264.480 945.200 ;
+      RECT 274.160 4.080 275.360 945.200 ;
+      RECT 285.040 4.080 286.240 945.200 ;
+      RECT 295.920 4.080 297.120 945.200 ;
+      RECT 306.800 4.080 308.000 945.200 ;
+      RECT 317.680 4.080 318.880 945.200 ;
+      RECT 328.560 4.080 329.760 945.200 ;
+      RECT 339.440 4.080 340.640 945.200 ;
+      RECT 350.320 4.080 351.520 945.200 ;
+      RECT 361.200 4.080 362.400 945.200 ;
+      RECT 372.080 4.080 373.280 945.200 ;
+      RECT 382.960 4.080 384.160 945.200 ;
+      RECT 393.840 4.080 395.040 945.200 ;
+      RECT 404.720 4.080 405.920 945.200 ;
+      RECT 415.600 4.080 416.800 945.200 ;
+      RECT 426.480 4.080 427.680 945.200 ;
+      RECT 437.360 4.080 438.560 945.200 ;
+      RECT 448.240 4.080 449.440 945.200 ;
+      RECT 459.120 4.080 460.320 945.200 ;
+      RECT 470.000 4.080 471.200 945.200 ;
+      RECT 480.880 4.080 482.080 945.200 ;
+      RECT 491.760 4.080 492.960 945.200 ;
+      RECT 502.640 4.080 503.840 945.200 ;
+      RECT 513.520 4.080 514.720 945.200 ;
+      RECT 524.400 4.080 525.600 945.200 ;
+      RECT 535.280 4.080 536.480 945.200 ;
+      RECT 546.160 4.080 547.360 945.200 ;
+      RECT 557.040 4.080 558.240 945.200 ;
+      RECT 567.920 4.080 569.120 945.200 ;
+      RECT 578.800 4.080 580.000 945.200 ;
+      RECT 589.680 4.080 590.880 945.200 ;
     END
   END VSS
   PIN VDD
@@ -3970,236 +3753,73 @@ MACRO fakeram130_1rw1r_130w1024d
     USE POWER ;
     PORT
       LAYER met4 ;
-      RECT 2.160 4.080 3.360 1891.760 ;
-      RECT 13.040 4.080 14.240 1891.760 ;
-      RECT 23.920 4.080 25.120 1891.760 ;
-      RECT 34.800 4.080 36.000 1891.760 ;
-      RECT 45.680 4.080 46.880 1891.760 ;
-      RECT 56.560 4.080 57.760 1891.760 ;
-      RECT 67.440 4.080 68.640 1891.760 ;
-      RECT 78.320 4.080 79.520 1891.760 ;
-      RECT 89.200 4.080 90.400 1891.760 ;
-      RECT 100.080 4.080 101.280 1891.760 ;
-      RECT 110.960 4.080 112.160 1891.760 ;
-      RECT 121.840 4.080 123.040 1891.760 ;
-      RECT 132.720 4.080 133.920 1891.760 ;
-      RECT 143.600 4.080 144.800 1891.760 ;
-      RECT 154.480 4.080 155.680 1891.760 ;
-      RECT 165.360 4.080 166.560 1891.760 ;
-      RECT 176.240 4.080 177.440 1891.760 ;
-      RECT 187.120 4.080 188.320 1891.760 ;
-      RECT 198.000 4.080 199.200 1891.760 ;
-      RECT 208.880 4.080 210.080 1891.760 ;
-      RECT 219.760 4.080 220.960 1891.760 ;
-      RECT 230.640 4.080 231.840 1891.760 ;
-      RECT 241.520 4.080 242.720 1891.760 ;
-      RECT 252.400 4.080 253.600 1891.760 ;
-      RECT 263.280 4.080 264.480 1891.760 ;
-      RECT 274.160 4.080 275.360 1891.760 ;
-      RECT 285.040 4.080 286.240 1891.760 ;
-      RECT 295.920 4.080 297.120 1891.760 ;
-      RECT 306.800 4.080 308.000 1891.760 ;
-      RECT 317.680 4.080 318.880 1891.760 ;
-      RECT 328.560 4.080 329.760 1891.760 ;
-      RECT 339.440 4.080 340.640 1891.760 ;
-      RECT 350.320 4.080 351.520 1891.760 ;
-      RECT 361.200 4.080 362.400 1891.760 ;
-      RECT 372.080 4.080 373.280 1891.760 ;
-      RECT 382.960 4.080 384.160 1891.760 ;
-      RECT 393.840 4.080 395.040 1891.760 ;
-      RECT 404.720 4.080 405.920 1891.760 ;
-      RECT 415.600 4.080 416.800 1891.760 ;
-      RECT 426.480 4.080 427.680 1891.760 ;
-      RECT 437.360 4.080 438.560 1891.760 ;
-      RECT 448.240 4.080 449.440 1891.760 ;
-      RECT 459.120 4.080 460.320 1891.760 ;
-      RECT 470.000 4.080 471.200 1891.760 ;
-      RECT 480.880 4.080 482.080 1891.760 ;
-      RECT 491.760 4.080 492.960 1891.760 ;
-      RECT 502.640 4.080 503.840 1891.760 ;
-      RECT 513.520 4.080 514.720 1891.760 ;
-      RECT 524.400 4.080 525.600 1891.760 ;
-      RECT 535.280 4.080 536.480 1891.760 ;
-      RECT 546.160 4.080 547.360 1891.760 ;
-      RECT 557.040 4.080 558.240 1891.760 ;
-      RECT 567.920 4.080 569.120 1891.760 ;
-      RECT 578.800 4.080 580.000 1891.760 ;
-      RECT 589.680 4.080 590.880 1891.760 ;
-      RECT 600.560 4.080 601.760 1891.760 ;
-      RECT 611.440 4.080 612.640 1891.760 ;
-      RECT 622.320 4.080 623.520 1891.760 ;
-      RECT 633.200 4.080 634.400 1891.760 ;
-      RECT 644.080 4.080 645.280 1891.760 ;
-      RECT 654.960 4.080 656.160 1891.760 ;
-      RECT 665.840 4.080 667.040 1891.760 ;
-      RECT 676.720 4.080 677.920 1891.760 ;
-      RECT 687.600 4.080 688.800 1891.760 ;
-      RECT 698.480 4.080 699.680 1891.760 ;
-      RECT 709.360 4.080 710.560 1891.760 ;
-      RECT 720.240 4.080 721.440 1891.760 ;
-      RECT 731.120 4.080 732.320 1891.760 ;
-      RECT 742.000 4.080 743.200 1891.760 ;
-      RECT 752.880 4.080 754.080 1891.760 ;
-      RECT 763.760 4.080 764.960 1891.760 ;
-      RECT 774.640 4.080 775.840 1891.760 ;
-      RECT 785.520 4.080 786.720 1891.760 ;
-      RECT 796.400 4.080 797.600 1891.760 ;
-      RECT 807.280 4.080 808.480 1891.760 ;
-      RECT 818.160 4.080 819.360 1891.760 ;
-      RECT 829.040 4.080 830.240 1891.760 ;
-      RECT 839.920 4.080 841.120 1891.760 ;
-      RECT 850.800 4.080 852.000 1891.760 ;
-      RECT 861.680 4.080 862.880 1891.760 ;
-      RECT 872.560 4.080 873.760 1891.760 ;
-      RECT 883.440 4.080 884.640 1891.760 ;
-      RECT 894.320 4.080 895.520 1891.760 ;
-      RECT 905.200 4.080 906.400 1891.760 ;
-      RECT 916.080 4.080 917.280 1891.760 ;
-      RECT 926.960 4.080 928.160 1891.760 ;
-      RECT 937.840 4.080 939.040 1891.760 ;
-      RECT 948.720 4.080 949.920 1891.760 ;
-      RECT 959.600 4.080 960.800 1891.760 ;
-      RECT 970.480 4.080 971.680 1891.760 ;
-      RECT 981.360 4.080 982.560 1891.760 ;
-      RECT 992.240 4.080 993.440 1891.760 ;
-      RECT 1003.120 4.080 1004.320 1891.760 ;
-      RECT 1014.000 4.080 1015.200 1891.760 ;
-      RECT 1024.880 4.080 1026.080 1891.760 ;
-      RECT 1035.760 4.080 1036.960 1891.760 ;
-      RECT 1046.640 4.080 1047.840 1891.760 ;
-      RECT 1057.520 4.080 1058.720 1891.760 ;
-      RECT 1068.400 4.080 1069.600 1891.760 ;
-      RECT 1079.280 4.080 1080.480 1891.760 ;
-      RECT 1090.160 4.080 1091.360 1891.760 ;
-      RECT 1101.040 4.080 1102.240 1891.760 ;
-      RECT 1111.920 4.080 1113.120 1891.760 ;
-      RECT 1122.800 4.080 1124.000 1891.760 ;
-      RECT 1133.680 4.080 1134.880 1891.760 ;
-      RECT 1144.560 4.080 1145.760 1891.760 ;
-      RECT 1155.440 4.080 1156.640 1891.760 ;
-      RECT 1166.320 4.080 1167.520 1891.760 ;
-      RECT 1177.200 4.080 1178.400 1891.760 ;
-      RECT 1188.080 4.080 1189.280 1891.760 ;
-      RECT 1198.960 4.080 1200.160 1891.760 ;
-      RECT 1209.840 4.080 1211.040 1891.760 ;
-      RECT 1220.720 4.080 1221.920 1891.760 ;
-      RECT 1231.600 4.080 1232.800 1891.760 ;
-      RECT 1242.480 4.080 1243.680 1891.760 ;
-      RECT 1253.360 4.080 1254.560 1891.760 ;
-      RECT 1264.240 4.080 1265.440 1891.760 ;
-      RECT 1275.120 4.080 1276.320 1891.760 ;
-      RECT 1286.000 4.080 1287.200 1891.760 ;
-      RECT 1296.880 4.080 1298.080 1891.760 ;
-      RECT 1307.760 4.080 1308.960 1891.760 ;
-      RECT 1318.640 4.080 1319.840 1891.760 ;
-      RECT 1329.520 4.080 1330.720 1891.760 ;
-      RECT 1340.400 4.080 1341.600 1891.760 ;
-      RECT 1351.280 4.080 1352.480 1891.760 ;
-      RECT 1362.160 4.080 1363.360 1891.760 ;
-      RECT 1373.040 4.080 1374.240 1891.760 ;
-      RECT 1383.920 4.080 1385.120 1891.760 ;
-      RECT 1394.800 4.080 1396.000 1891.760 ;
-      RECT 1405.680 4.080 1406.880 1891.760 ;
-      RECT 1416.560 4.080 1417.760 1891.760 ;
-      RECT 1427.440 4.080 1428.640 1891.760 ;
-      RECT 1438.320 4.080 1439.520 1891.760 ;
-      RECT 1449.200 4.080 1450.400 1891.760 ;
-      RECT 1460.080 4.080 1461.280 1891.760 ;
-      RECT 1470.960 4.080 1472.160 1891.760 ;
-      RECT 1481.840 4.080 1483.040 1891.760 ;
-      RECT 1492.720 4.080 1493.920 1891.760 ;
-      RECT 1503.600 4.080 1504.800 1891.760 ;
-      RECT 1514.480 4.080 1515.680 1891.760 ;
-      RECT 1525.360 4.080 1526.560 1891.760 ;
-      RECT 1536.240 4.080 1537.440 1891.760 ;
-      RECT 1547.120 4.080 1548.320 1891.760 ;
-      RECT 1558.000 4.080 1559.200 1891.760 ;
-      RECT 1568.880 4.080 1570.080 1891.760 ;
-      RECT 1579.760 4.080 1580.960 1891.760 ;
-      RECT 1590.640 4.080 1591.840 1891.760 ;
-      RECT 1601.520 4.080 1602.720 1891.760 ;
-      RECT 1612.400 4.080 1613.600 1891.760 ;
-      RECT 1623.280 4.080 1624.480 1891.760 ;
-      RECT 1634.160 4.080 1635.360 1891.760 ;
-      RECT 1645.040 4.080 1646.240 1891.760 ;
-      RECT 1655.920 4.080 1657.120 1891.760 ;
-      RECT 1666.800 4.080 1668.000 1891.760 ;
-      RECT 1677.680 4.080 1678.880 1891.760 ;
-      RECT 1688.560 4.080 1689.760 1891.760 ;
-      RECT 1699.440 4.080 1700.640 1891.760 ;
-      RECT 1710.320 4.080 1711.520 1891.760 ;
-      RECT 1721.200 4.080 1722.400 1891.760 ;
-      RECT 1732.080 4.080 1733.280 1891.760 ;
-      RECT 1742.960 4.080 1744.160 1891.760 ;
-      RECT 1753.840 4.080 1755.040 1891.760 ;
-      RECT 1764.720 4.080 1765.920 1891.760 ;
-      RECT 1775.600 4.080 1776.800 1891.760 ;
-      RECT 1786.480 4.080 1787.680 1891.760 ;
-      RECT 1797.360 4.080 1798.560 1891.760 ;
-      RECT 1808.240 4.080 1809.440 1891.760 ;
-      RECT 1819.120 4.080 1820.320 1891.760 ;
-      RECT 1830.000 4.080 1831.200 1891.760 ;
-      RECT 1840.880 4.080 1842.080 1891.760 ;
-      RECT 1851.760 4.080 1852.960 1891.760 ;
-      RECT 1862.640 4.080 1863.840 1891.760 ;
-      RECT 1873.520 4.080 1874.720 1891.760 ;
-      RECT 1884.400 4.080 1885.600 1891.760 ;
-      RECT 1895.280 4.080 1896.480 1891.760 ;
-      RECT 1906.160 4.080 1907.360 1891.760 ;
-      RECT 1917.040 4.080 1918.240 1891.760 ;
-      RECT 1927.920 4.080 1929.120 1891.760 ;
-      RECT 1938.800 4.080 1940.000 1891.760 ;
-      RECT 1949.680 4.080 1950.880 1891.760 ;
-      RECT 1960.560 4.080 1961.760 1891.760 ;
-      RECT 1971.440 4.080 1972.640 1891.760 ;
-      RECT 1982.320 4.080 1983.520 1891.760 ;
-      RECT 1993.200 4.080 1994.400 1891.760 ;
-      RECT 2004.080 4.080 2005.280 1891.760 ;
-      RECT 2014.960 4.080 2016.160 1891.760 ;
-      RECT 2025.840 4.080 2027.040 1891.760 ;
-      RECT 2036.720 4.080 2037.920 1891.760 ;
-      RECT 2047.600 4.080 2048.800 1891.760 ;
-      RECT 2058.480 4.080 2059.680 1891.760 ;
-      RECT 2069.360 4.080 2070.560 1891.760 ;
-      RECT 2080.240 4.080 2081.440 1891.760 ;
-      RECT 2091.120 4.080 2092.320 1891.760 ;
-      RECT 2102.000 4.080 2103.200 1891.760 ;
-      RECT 2112.880 4.080 2114.080 1891.760 ;
-      RECT 2123.760 4.080 2124.960 1891.760 ;
-      RECT 2134.640 4.080 2135.840 1891.760 ;
-      RECT 2145.520 4.080 2146.720 1891.760 ;
-      RECT 2156.400 4.080 2157.600 1891.760 ;
-      RECT 2167.280 4.080 2168.480 1891.760 ;
-      RECT 2178.160 4.080 2179.360 1891.760 ;
-      RECT 2189.040 4.080 2190.240 1891.760 ;
-      RECT 2199.920 4.080 2201.120 1891.760 ;
-      RECT 2210.800 4.080 2212.000 1891.760 ;
-      RECT 2221.680 4.080 2222.880 1891.760 ;
-      RECT 2232.560 4.080 2233.760 1891.760 ;
-      RECT 2243.440 4.080 2244.640 1891.760 ;
-      RECT 2254.320 4.080 2255.520 1891.760 ;
-      RECT 2265.200 4.080 2266.400 1891.760 ;
-      RECT 2276.080 4.080 2277.280 1891.760 ;
-      RECT 2286.960 4.080 2288.160 1891.760 ;
-      RECT 2297.840 4.080 2299.040 1891.760 ;
-      RECT 2308.720 4.080 2309.920 1891.760 ;
-      RECT 2319.600 4.080 2320.800 1891.760 ;
-      RECT 2330.480 4.080 2331.680 1891.760 ;
-      RECT 2341.360 4.080 2342.560 1891.760 ;
-      RECT 2352.240 4.080 2353.440 1891.760 ;
-      RECT 2363.120 4.080 2364.320 1891.760 ;
+      RECT 2.160 4.080 3.360 945.200 ;
+      RECT 13.040 4.080 14.240 945.200 ;
+      RECT 23.920 4.080 25.120 945.200 ;
+      RECT 34.800 4.080 36.000 945.200 ;
+      RECT 45.680 4.080 46.880 945.200 ;
+      RECT 56.560 4.080 57.760 945.200 ;
+      RECT 67.440 4.080 68.640 945.200 ;
+      RECT 78.320 4.080 79.520 945.200 ;
+      RECT 89.200 4.080 90.400 945.200 ;
+      RECT 100.080 4.080 101.280 945.200 ;
+      RECT 110.960 4.080 112.160 945.200 ;
+      RECT 121.840 4.080 123.040 945.200 ;
+      RECT 132.720 4.080 133.920 945.200 ;
+      RECT 143.600 4.080 144.800 945.200 ;
+      RECT 154.480 4.080 155.680 945.200 ;
+      RECT 165.360 4.080 166.560 945.200 ;
+      RECT 176.240 4.080 177.440 945.200 ;
+      RECT 187.120 4.080 188.320 945.200 ;
+      RECT 198.000 4.080 199.200 945.200 ;
+      RECT 208.880 4.080 210.080 945.200 ;
+      RECT 219.760 4.080 220.960 945.200 ;
+      RECT 230.640 4.080 231.840 945.200 ;
+      RECT 241.520 4.080 242.720 945.200 ;
+      RECT 252.400 4.080 253.600 945.200 ;
+      RECT 263.280 4.080 264.480 945.200 ;
+      RECT 274.160 4.080 275.360 945.200 ;
+      RECT 285.040 4.080 286.240 945.200 ;
+      RECT 295.920 4.080 297.120 945.200 ;
+      RECT 306.800 4.080 308.000 945.200 ;
+      RECT 317.680 4.080 318.880 945.200 ;
+      RECT 328.560 4.080 329.760 945.200 ;
+      RECT 339.440 4.080 340.640 945.200 ;
+      RECT 350.320 4.080 351.520 945.200 ;
+      RECT 361.200 4.080 362.400 945.200 ;
+      RECT 372.080 4.080 373.280 945.200 ;
+      RECT 382.960 4.080 384.160 945.200 ;
+      RECT 393.840 4.080 395.040 945.200 ;
+      RECT 404.720 4.080 405.920 945.200 ;
+      RECT 415.600 4.080 416.800 945.200 ;
+      RECT 426.480 4.080 427.680 945.200 ;
+      RECT 437.360 4.080 438.560 945.200 ;
+      RECT 448.240 4.080 449.440 945.200 ;
+      RECT 459.120 4.080 460.320 945.200 ;
+      RECT 470.000 4.080 471.200 945.200 ;
+      RECT 480.880 4.080 482.080 945.200 ;
+      RECT 491.760 4.080 492.960 945.200 ;
+      RECT 502.640 4.080 503.840 945.200 ;
+      RECT 513.520 4.080 514.720 945.200 ;
+      RECT 524.400 4.080 525.600 945.200 ;
+      RECT 535.280 4.080 536.480 945.200 ;
+      RECT 546.160 4.080 547.360 945.200 ;
+      RECT 557.040 4.080 558.240 945.200 ;
+      RECT 567.920 4.080 569.120 945.200 ;
+      RECT 578.800 4.080 580.000 945.200 ;
+      RECT 589.680 4.080 590.880 945.200 ;
     END
   END VDD
   OBS
     LAYER met1 ;
-    RECT 0 0 2364.860 1895.840 ;
+    RECT 0 0 591.560 949.280 ;
     LAYER met2 ;
-    RECT 0 0 2364.860 1895.840 ;
+    RECT 0 0 591.560 949.280 ;
     LAYER met3 ;
-    RECT 0 0 2364.860 1895.840 ;
+    RECT 0 0 591.560 949.280 ;
     LAYER met4 ;
-    RECT 0 0 2364.860 1895.840 ;
+    RECT 0 0 591.560 949.280 ;
   END
-END fakeram130_1rw1r_130w1024d
+END fakeram_1rw1r_130w128d_sram
 
 END LIBRARY

--- a/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_130w512d_sram.lef
+++ b/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_130w512d_sram.lef
@@ -1,9 +1,9 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram130_1rw1r_130w128d
-  FOREIGN fakeram130_1rw1r_130w128d 0 0 ;
+MACRO fakeram_1rw1r_130w512d_sram
+  FOREIGN fakeram_1rw1r_130w512d_sram 0 0 ;
   SYMMETRY X Y R90 ;
-  SIZE 591.560 BY 949.280 ;
+  SIZE 1182.660 BY 1895.840 ;
   CLASS BLOCK ;
   PIN rw0_wd_in[0]
     DIRECTION INPUT ;
@@ -20,7 +20,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 27.050 0.900 27.350 ;
+      RECT 0.000 48.810 0.900 49.110 ;
     END
   END rw0_wd_in[1]
   PIN rw0_wd_in[2]
@@ -29,7 +29,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 50.170 0.900 50.470 ;
+      RECT 0.000 93.690 0.900 93.990 ;
     END
   END rw0_wd_in[2]
   PIN rw0_wd_in[3]
@@ -38,7 +38,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 73.290 0.900 73.590 ;
+      RECT 0.000 138.570 0.900 138.870 ;
     END
   END rw0_wd_in[3]
   PIN rw0_wd_in[4]
@@ -47,7 +47,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 96.410 0.900 96.710 ;
+      RECT 0.000 183.450 0.900 183.750 ;
     END
   END rw0_wd_in[4]
   PIN rw0_wd_in[5]
@@ -56,7 +56,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 119.530 0.900 119.830 ;
+      RECT 0.000 228.330 0.900 228.630 ;
     END
   END rw0_wd_in[5]
   PIN rw0_wd_in[6]
@@ -65,7 +65,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 142.650 0.900 142.950 ;
+      RECT 0.000 273.210 0.900 273.510 ;
     END
   END rw0_wd_in[6]
   PIN rw0_wd_in[7]
@@ -74,7 +74,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 165.770 0.900 166.070 ;
+      RECT 0.000 318.090 0.900 318.390 ;
     END
   END rw0_wd_in[7]
   PIN rw0_wd_in[8]
@@ -83,7 +83,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 188.890 0.900 189.190 ;
+      RECT 0.000 362.970 0.900 363.270 ;
     END
   END rw0_wd_in[8]
   PIN rw0_wd_in[9]
@@ -92,7 +92,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 212.010 0.900 212.310 ;
+      RECT 0.000 407.850 0.900 408.150 ;
     END
   END rw0_wd_in[9]
   PIN rw0_wd_in[10]
@@ -101,7 +101,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 235.130 0.900 235.430 ;
+      RECT 0.000 452.730 0.900 453.030 ;
     END
   END rw0_wd_in[10]
   PIN rw0_wd_in[11]
@@ -110,7 +110,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 258.250 0.900 258.550 ;
+      RECT 0.000 497.610 0.900 497.910 ;
     END
   END rw0_wd_in[11]
   PIN rw0_wd_in[12]
@@ -119,7 +119,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 281.370 0.900 281.670 ;
+      RECT 0.000 542.490 0.900 542.790 ;
     END
   END rw0_wd_in[12]
   PIN rw0_wd_in[13]
@@ -128,7 +128,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 304.490 0.900 304.790 ;
+      RECT 0.000 587.370 0.900 587.670 ;
     END
   END rw0_wd_in[13]
   PIN rw0_wd_in[14]
@@ -137,7 +137,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 327.610 0.900 327.910 ;
+      RECT 0.000 632.250 0.900 632.550 ;
     END
   END rw0_wd_in[14]
   PIN rw0_wd_in[15]
@@ -146,7 +146,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 350.730 0.900 351.030 ;
+      RECT 0.000 677.130 0.900 677.430 ;
     END
   END rw0_wd_in[15]
   PIN rw0_wd_in[16]
@@ -155,7 +155,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 373.850 0.900 374.150 ;
+      RECT 0.000 722.010 0.900 722.310 ;
     END
   END rw0_wd_in[16]
   PIN rw0_wd_in[17]
@@ -164,7 +164,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 396.970 0.900 397.270 ;
+      RECT 0.000 766.890 0.900 767.190 ;
     END
   END rw0_wd_in[17]
   PIN rw0_wd_in[18]
@@ -173,7 +173,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 420.090 0.900 420.390 ;
+      RECT 0.000 811.770 0.900 812.070 ;
     END
   END rw0_wd_in[18]
   PIN rw0_wd_in[19]
@@ -182,7 +182,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 443.210 0.900 443.510 ;
+      RECT 0.000 856.650 0.900 856.950 ;
     END
   END rw0_wd_in[19]
   PIN rw0_wd_in[20]
@@ -191,7 +191,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 466.330 0.900 466.630 ;
+      RECT 0.000 901.530 0.900 901.830 ;
     END
   END rw0_wd_in[20]
   PIN rw0_wd_in[21]
@@ -200,7 +200,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 489.450 0.900 489.750 ;
+      RECT 0.000 946.410 0.900 946.710 ;
     END
   END rw0_wd_in[21]
   PIN rw0_wd_in[22]
@@ -209,7 +209,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 512.570 0.900 512.870 ;
+      RECT 0.000 991.290 0.900 991.590 ;
     END
   END rw0_wd_in[22]
   PIN rw0_wd_in[23]
@@ -218,7 +218,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 535.690 0.900 535.990 ;
+      RECT 0.000 1036.170 0.900 1036.470 ;
     END
   END rw0_wd_in[23]
   PIN rw0_wd_in[24]
@@ -227,7 +227,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 558.810 0.900 559.110 ;
+      RECT 0.000 1081.050 0.900 1081.350 ;
     END
   END rw0_wd_in[24]
   PIN rw0_wd_in[25]
@@ -236,7 +236,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 581.930 0.900 582.230 ;
+      RECT 0.000 1125.930 0.900 1126.230 ;
     END
   END rw0_wd_in[25]
   PIN rw0_wd_in[26]
@@ -245,7 +245,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 605.050 0.900 605.350 ;
+      RECT 0.000 1170.810 0.900 1171.110 ;
     END
   END rw0_wd_in[26]
   PIN rw0_wd_in[27]
@@ -254,7 +254,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 628.170 0.900 628.470 ;
+      RECT 0.000 1215.690 0.900 1215.990 ;
     END
   END rw0_wd_in[27]
   PIN rw0_wd_in[28]
@@ -263,7 +263,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 651.290 0.900 651.590 ;
+      RECT 0.000 1260.570 0.900 1260.870 ;
     END
   END rw0_wd_in[28]
   PIN rw0_wd_in[29]
@@ -272,7 +272,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 674.410 0.900 674.710 ;
+      RECT 0.000 1305.450 0.900 1305.750 ;
     END
   END rw0_wd_in[29]
   PIN rw0_wd_in[30]
@@ -281,7 +281,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 697.530 0.900 697.830 ;
+      RECT 0.000 1350.330 0.900 1350.630 ;
     END
   END rw0_wd_in[30]
   PIN rw0_wd_in[31]
@@ -290,7 +290,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 720.650 0.900 720.950 ;
+      RECT 0.000 1395.210 0.900 1395.510 ;
     END
   END rw0_wd_in[31]
   PIN rw0_wd_in[32]
@@ -299,7 +299,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 743.770 0.900 744.070 ;
+      RECT 0.000 1440.090 0.900 1440.390 ;
     END
   END rw0_wd_in[32]
   PIN rw0_wd_in[33]
@@ -308,7 +308,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 3.930 591.560 4.230 ;
+      RECT 1181.760 3.930 1182.660 4.230 ;
     END
   END rw0_wd_in[33]
   PIN rw0_wd_in[34]
@@ -317,7 +317,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 27.050 591.560 27.350 ;
+      RECT 1181.760 48.810 1182.660 49.110 ;
     END
   END rw0_wd_in[34]
   PIN rw0_wd_in[35]
@@ -326,7 +326,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 50.170 591.560 50.470 ;
+      RECT 1181.760 93.690 1182.660 93.990 ;
     END
   END rw0_wd_in[35]
   PIN rw0_wd_in[36]
@@ -335,7 +335,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 73.290 591.560 73.590 ;
+      RECT 1181.760 138.570 1182.660 138.870 ;
     END
   END rw0_wd_in[36]
   PIN rw0_wd_in[37]
@@ -344,7 +344,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 96.410 591.560 96.710 ;
+      RECT 1181.760 183.450 1182.660 183.750 ;
     END
   END rw0_wd_in[37]
   PIN rw0_wd_in[38]
@@ -353,7 +353,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 119.530 591.560 119.830 ;
+      RECT 1181.760 228.330 1182.660 228.630 ;
     END
   END rw0_wd_in[38]
   PIN rw0_wd_in[39]
@@ -362,7 +362,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 142.650 591.560 142.950 ;
+      RECT 1181.760 273.210 1182.660 273.510 ;
     END
   END rw0_wd_in[39]
   PIN rw0_wd_in[40]
@@ -371,7 +371,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 165.770 591.560 166.070 ;
+      RECT 1181.760 318.090 1182.660 318.390 ;
     END
   END rw0_wd_in[40]
   PIN rw0_wd_in[41]
@@ -380,7 +380,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 188.890 591.560 189.190 ;
+      RECT 1181.760 362.970 1182.660 363.270 ;
     END
   END rw0_wd_in[41]
   PIN rw0_wd_in[42]
@@ -389,7 +389,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 212.010 591.560 212.310 ;
+      RECT 1181.760 407.850 1182.660 408.150 ;
     END
   END rw0_wd_in[42]
   PIN rw0_wd_in[43]
@@ -398,7 +398,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 235.130 591.560 235.430 ;
+      RECT 1181.760 452.730 1182.660 453.030 ;
     END
   END rw0_wd_in[43]
   PIN rw0_wd_in[44]
@@ -407,7 +407,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 258.250 591.560 258.550 ;
+      RECT 1181.760 497.610 1182.660 497.910 ;
     END
   END rw0_wd_in[44]
   PIN rw0_wd_in[45]
@@ -416,7 +416,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 281.370 591.560 281.670 ;
+      RECT 1181.760 542.490 1182.660 542.790 ;
     END
   END rw0_wd_in[45]
   PIN rw0_wd_in[46]
@@ -425,7 +425,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 304.490 591.560 304.790 ;
+      RECT 1181.760 587.370 1182.660 587.670 ;
     END
   END rw0_wd_in[46]
   PIN rw0_wd_in[47]
@@ -434,7 +434,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 327.610 591.560 327.910 ;
+      RECT 1181.760 632.250 1182.660 632.550 ;
     END
   END rw0_wd_in[47]
   PIN rw0_wd_in[48]
@@ -443,7 +443,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 350.730 591.560 351.030 ;
+      RECT 1181.760 677.130 1182.660 677.430 ;
     END
   END rw0_wd_in[48]
   PIN rw0_wd_in[49]
@@ -452,7 +452,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 373.850 591.560 374.150 ;
+      RECT 1181.760 722.010 1182.660 722.310 ;
     END
   END rw0_wd_in[49]
   PIN rw0_wd_in[50]
@@ -461,7 +461,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 396.970 591.560 397.270 ;
+      RECT 1181.760 766.890 1182.660 767.190 ;
     END
   END rw0_wd_in[50]
   PIN rw0_wd_in[51]
@@ -470,7 +470,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 420.090 591.560 420.390 ;
+      RECT 1181.760 811.770 1182.660 812.070 ;
     END
   END rw0_wd_in[51]
   PIN rw0_wd_in[52]
@@ -479,7 +479,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 443.210 591.560 443.510 ;
+      RECT 1181.760 856.650 1182.660 856.950 ;
     END
   END rw0_wd_in[52]
   PIN rw0_wd_in[53]
@@ -488,7 +488,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 466.330 591.560 466.630 ;
+      RECT 1181.760 901.530 1182.660 901.830 ;
     END
   END rw0_wd_in[53]
   PIN rw0_wd_in[54]
@@ -497,7 +497,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 489.450 591.560 489.750 ;
+      RECT 1181.760 946.410 1182.660 946.710 ;
     END
   END rw0_wd_in[54]
   PIN rw0_wd_in[55]
@@ -506,7 +506,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 512.570 591.560 512.870 ;
+      RECT 1181.760 991.290 1182.660 991.590 ;
     END
   END rw0_wd_in[55]
   PIN rw0_wd_in[56]
@@ -515,7 +515,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 535.690 591.560 535.990 ;
+      RECT 1181.760 1036.170 1182.660 1036.470 ;
     END
   END rw0_wd_in[56]
   PIN rw0_wd_in[57]
@@ -524,7 +524,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 558.810 591.560 559.110 ;
+      RECT 1181.760 1081.050 1182.660 1081.350 ;
     END
   END rw0_wd_in[57]
   PIN rw0_wd_in[58]
@@ -533,7 +533,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 581.930 591.560 582.230 ;
+      RECT 1181.760 1125.930 1182.660 1126.230 ;
     END
   END rw0_wd_in[58]
   PIN rw0_wd_in[59]
@@ -542,7 +542,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 605.050 591.560 605.350 ;
+      RECT 1181.760 1170.810 1182.660 1171.110 ;
     END
   END rw0_wd_in[59]
   PIN rw0_wd_in[60]
@@ -551,7 +551,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 628.170 591.560 628.470 ;
+      RECT 1181.760 1215.690 1182.660 1215.990 ;
     END
   END rw0_wd_in[60]
   PIN rw0_wd_in[61]
@@ -560,7 +560,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 651.290 591.560 651.590 ;
+      RECT 1181.760 1260.570 1182.660 1260.870 ;
     END
   END rw0_wd_in[61]
   PIN rw0_wd_in[62]
@@ -569,7 +569,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 674.410 591.560 674.710 ;
+      RECT 1181.760 1305.450 1182.660 1305.750 ;
     END
   END rw0_wd_in[62]
   PIN rw0_wd_in[63]
@@ -578,7 +578,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 697.530 591.560 697.830 ;
+      RECT 1181.760 1350.330 1182.660 1350.630 ;
     END
   END rw0_wd_in[63]
   PIN rw0_wd_in[64]
@@ -587,7 +587,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 720.650 591.560 720.950 ;
+      RECT 1181.760 1395.210 1182.660 1395.510 ;
     END
   END rw0_wd_in[64]
   PIN rw0_wd_in[65]
@@ -605,7 +605,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 5.450 0.000 5.590 0.420 ;
+      RECT 8.670 0.000 8.810 0.420 ;
     END
   END rw0_wd_in[66]
   PIN rw0_wd_in[67]
@@ -614,7 +614,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 8.210 0.000 8.350 0.420 ;
+      RECT 14.650 0.000 14.790 0.420 ;
     END
   END rw0_wd_in[67]
   PIN rw0_wd_in[68]
@@ -623,7 +623,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 10.970 0.000 11.110 0.420 ;
+      RECT 20.630 0.000 20.770 0.420 ;
     END
   END rw0_wd_in[68]
   PIN rw0_wd_in[69]
@@ -632,7 +632,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 13.730 0.000 13.870 0.420 ;
+      RECT 26.610 0.000 26.750 0.420 ;
     END
   END rw0_wd_in[69]
   PIN rw0_wd_in[70]
@@ -641,7 +641,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 16.490 0.000 16.630 0.420 ;
+      RECT 32.590 0.000 32.730 0.420 ;
     END
   END rw0_wd_in[70]
   PIN rw0_wd_in[71]
@@ -650,7 +650,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 19.250 0.000 19.390 0.420 ;
+      RECT 38.570 0.000 38.710 0.420 ;
     END
   END rw0_wd_in[71]
   PIN rw0_wd_in[72]
@@ -659,7 +659,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 22.010 0.000 22.150 0.420 ;
+      RECT 44.550 0.000 44.690 0.420 ;
     END
   END rw0_wd_in[72]
   PIN rw0_wd_in[73]
@@ -668,7 +668,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 24.770 0.000 24.910 0.420 ;
+      RECT 50.530 0.000 50.670 0.420 ;
     END
   END rw0_wd_in[73]
   PIN rw0_wd_in[74]
@@ -677,7 +677,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 27.530 0.000 27.670 0.420 ;
+      RECT 56.510 0.000 56.650 0.420 ;
     END
   END rw0_wd_in[74]
   PIN rw0_wd_in[75]
@@ -686,7 +686,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 30.290 0.000 30.430 0.420 ;
+      RECT 62.490 0.000 62.630 0.420 ;
     END
   END rw0_wd_in[75]
   PIN rw0_wd_in[76]
@@ -695,7 +695,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 33.050 0.000 33.190 0.420 ;
+      RECT 68.470 0.000 68.610 0.420 ;
     END
   END rw0_wd_in[76]
   PIN rw0_wd_in[77]
@@ -704,7 +704,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 35.810 0.000 35.950 0.420 ;
+      RECT 74.450 0.000 74.590 0.420 ;
     END
   END rw0_wd_in[77]
   PIN rw0_wd_in[78]
@@ -713,7 +713,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 38.570 0.000 38.710 0.420 ;
+      RECT 80.430 0.000 80.570 0.420 ;
     END
   END rw0_wd_in[78]
   PIN rw0_wd_in[79]
@@ -722,7 +722,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 41.330 0.000 41.470 0.420 ;
+      RECT 86.410 0.000 86.550 0.420 ;
     END
   END rw0_wd_in[79]
   PIN rw0_wd_in[80]
@@ -731,7 +731,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 44.090 0.000 44.230 0.420 ;
+      RECT 92.390 0.000 92.530 0.420 ;
     END
   END rw0_wd_in[80]
   PIN rw0_wd_in[81]
@@ -740,7 +740,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 46.850 0.000 46.990 0.420 ;
+      RECT 98.370 0.000 98.510 0.420 ;
     END
   END rw0_wd_in[81]
   PIN rw0_wd_in[82]
@@ -749,7 +749,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 49.610 0.000 49.750 0.420 ;
+      RECT 104.350 0.000 104.490 0.420 ;
     END
   END rw0_wd_in[82]
   PIN rw0_wd_in[83]
@@ -758,7 +758,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 52.370 0.000 52.510 0.420 ;
+      RECT 110.330 0.000 110.470 0.420 ;
     END
   END rw0_wd_in[83]
   PIN rw0_wd_in[84]
@@ -767,7 +767,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 55.130 0.000 55.270 0.420 ;
+      RECT 116.310 0.000 116.450 0.420 ;
     END
   END rw0_wd_in[84]
   PIN rw0_wd_in[85]
@@ -776,7 +776,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 57.890 0.000 58.030 0.420 ;
+      RECT 122.290 0.000 122.430 0.420 ;
     END
   END rw0_wd_in[85]
   PIN rw0_wd_in[86]
@@ -785,7 +785,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 60.650 0.000 60.790 0.420 ;
+      RECT 128.270 0.000 128.410 0.420 ;
     END
   END rw0_wd_in[86]
   PIN rw0_wd_in[87]
@@ -794,7 +794,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 63.410 0.000 63.550 0.420 ;
+      RECT 134.250 0.000 134.390 0.420 ;
     END
   END rw0_wd_in[87]
   PIN rw0_wd_in[88]
@@ -803,7 +803,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 66.170 0.000 66.310 0.420 ;
+      RECT 140.230 0.000 140.370 0.420 ;
     END
   END rw0_wd_in[88]
   PIN rw0_wd_in[89]
@@ -812,7 +812,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 68.930 0.000 69.070 0.420 ;
+      RECT 146.210 0.000 146.350 0.420 ;
     END
   END rw0_wd_in[89]
   PIN rw0_wd_in[90]
@@ -821,7 +821,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 71.690 0.000 71.830 0.420 ;
+      RECT 152.190 0.000 152.330 0.420 ;
     END
   END rw0_wd_in[90]
   PIN rw0_wd_in[91]
@@ -830,7 +830,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 74.450 0.000 74.590 0.420 ;
+      RECT 158.170 0.000 158.310 0.420 ;
     END
   END rw0_wd_in[91]
   PIN rw0_wd_in[92]
@@ -839,7 +839,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 77.210 0.000 77.350 0.420 ;
+      RECT 164.150 0.000 164.290 0.420 ;
     END
   END rw0_wd_in[92]
   PIN rw0_wd_in[93]
@@ -848,7 +848,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 79.970 0.000 80.110 0.420 ;
+      RECT 170.130 0.000 170.270 0.420 ;
     END
   END rw0_wd_in[93]
   PIN rw0_wd_in[94]
@@ -857,7 +857,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 82.730 0.000 82.870 0.420 ;
+      RECT 176.110 0.000 176.250 0.420 ;
     END
   END rw0_wd_in[94]
   PIN rw0_wd_in[95]
@@ -866,7 +866,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 85.490 0.000 85.630 0.420 ;
+      RECT 182.090 0.000 182.230 0.420 ;
     END
   END rw0_wd_in[95]
   PIN rw0_wd_in[96]
@@ -875,7 +875,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 88.250 0.000 88.390 0.420 ;
+      RECT 188.070 0.000 188.210 0.420 ;
     END
   END rw0_wd_in[96]
   PIN rw0_wd_in[97]
@@ -884,7 +884,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 91.010 0.000 91.150 0.420 ;
+      RECT 194.050 0.000 194.190 0.420 ;
     END
   END rw0_wd_in[97]
   PIN rw0_wd_in[98]
@@ -893,7 +893,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 93.770 0.000 93.910 0.420 ;
+      RECT 200.030 0.000 200.170 0.420 ;
     END
   END rw0_wd_in[98]
   PIN rw0_wd_in[99]
@@ -902,7 +902,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 96.530 0.000 96.670 0.420 ;
+      RECT 206.010 0.000 206.150 0.420 ;
     END
   END rw0_wd_in[99]
   PIN rw0_wd_in[100]
@@ -911,7 +911,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 99.290 0.000 99.430 0.420 ;
+      RECT 211.990 0.000 212.130 0.420 ;
     END
   END rw0_wd_in[100]
   PIN rw0_wd_in[101]
@@ -920,7 +920,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 102.050 0.000 102.190 0.420 ;
+      RECT 217.970 0.000 218.110 0.420 ;
     END
   END rw0_wd_in[101]
   PIN rw0_wd_in[102]
@@ -929,7 +929,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 104.810 0.000 104.950 0.420 ;
+      RECT 223.950 0.000 224.090 0.420 ;
     END
   END rw0_wd_in[102]
   PIN rw0_wd_in[103]
@@ -938,7 +938,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 107.570 0.000 107.710 0.420 ;
+      RECT 229.930 0.000 230.070 0.420 ;
     END
   END rw0_wd_in[103]
   PIN rw0_wd_in[104]
@@ -947,7 +947,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 110.330 0.000 110.470 0.420 ;
+      RECT 235.910 0.000 236.050 0.420 ;
     END
   END rw0_wd_in[104]
   PIN rw0_wd_in[105]
@@ -956,7 +956,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 113.090 0.000 113.230 0.420 ;
+      RECT 241.890 0.000 242.030 0.420 ;
     END
   END rw0_wd_in[105]
   PIN rw0_wd_in[106]
@@ -965,7 +965,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 115.850 0.000 115.990 0.420 ;
+      RECT 247.870 0.000 248.010 0.420 ;
     END
   END rw0_wd_in[106]
   PIN rw0_wd_in[107]
@@ -974,7 +974,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 118.610 0.000 118.750 0.420 ;
+      RECT 253.850 0.000 253.990 0.420 ;
     END
   END rw0_wd_in[107]
   PIN rw0_wd_in[108]
@@ -983,7 +983,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 121.370 0.000 121.510 0.420 ;
+      RECT 259.830 0.000 259.970 0.420 ;
     END
   END rw0_wd_in[108]
   PIN rw0_wd_in[109]
@@ -992,7 +992,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 124.130 0.000 124.270 0.420 ;
+      RECT 265.810 0.000 265.950 0.420 ;
     END
   END rw0_wd_in[109]
   PIN rw0_wd_in[110]
@@ -1001,7 +1001,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 126.890 0.000 127.030 0.420 ;
+      RECT 271.790 0.000 271.930 0.420 ;
     END
   END rw0_wd_in[110]
   PIN rw0_wd_in[111]
@@ -1010,7 +1010,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 129.650 0.000 129.790 0.420 ;
+      RECT 277.770 0.000 277.910 0.420 ;
     END
   END rw0_wd_in[111]
   PIN rw0_wd_in[112]
@@ -1019,7 +1019,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 132.410 0.000 132.550 0.420 ;
+      RECT 283.750 0.000 283.890 0.420 ;
     END
   END rw0_wd_in[112]
   PIN rw0_wd_in[113]
@@ -1028,7 +1028,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 135.170 0.000 135.310 0.420 ;
+      RECT 289.730 0.000 289.870 0.420 ;
     END
   END rw0_wd_in[113]
   PIN rw0_wd_in[114]
@@ -1037,7 +1037,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 137.930 0.000 138.070 0.420 ;
+      RECT 295.710 0.000 295.850 0.420 ;
     END
   END rw0_wd_in[114]
   PIN rw0_wd_in[115]
@@ -1046,7 +1046,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 140.690 0.000 140.830 0.420 ;
+      RECT 301.690 0.000 301.830 0.420 ;
     END
   END rw0_wd_in[115]
   PIN rw0_wd_in[116]
@@ -1055,7 +1055,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 143.450 0.000 143.590 0.420 ;
+      RECT 307.670 0.000 307.810 0.420 ;
     END
   END rw0_wd_in[116]
   PIN rw0_wd_in[117]
@@ -1064,7 +1064,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 146.210 0.000 146.350 0.420 ;
+      RECT 313.650 0.000 313.790 0.420 ;
     END
   END rw0_wd_in[117]
   PIN rw0_wd_in[118]
@@ -1073,7 +1073,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 148.970 0.000 149.110 0.420 ;
+      RECT 319.630 0.000 319.770 0.420 ;
     END
   END rw0_wd_in[118]
   PIN rw0_wd_in[119]
@@ -1082,7 +1082,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 151.730 0.000 151.870 0.420 ;
+      RECT 325.610 0.000 325.750 0.420 ;
     END
   END rw0_wd_in[119]
   PIN rw0_wd_in[120]
@@ -1091,7 +1091,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 154.490 0.000 154.630 0.420 ;
+      RECT 331.590 0.000 331.730 0.420 ;
     END
   END rw0_wd_in[120]
   PIN rw0_wd_in[121]
@@ -1100,7 +1100,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 157.250 0.000 157.390 0.420 ;
+      RECT 337.570 0.000 337.710 0.420 ;
     END
   END rw0_wd_in[121]
   PIN rw0_wd_in[122]
@@ -1109,7 +1109,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 160.010 0.000 160.150 0.420 ;
+      RECT 343.550 0.000 343.690 0.420 ;
     END
   END rw0_wd_in[122]
   PIN rw0_wd_in[123]
@@ -1118,7 +1118,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 162.770 0.000 162.910 0.420 ;
+      RECT 349.530 0.000 349.670 0.420 ;
     END
   END rw0_wd_in[123]
   PIN rw0_wd_in[124]
@@ -1127,7 +1127,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 165.530 0.000 165.670 0.420 ;
+      RECT 355.510 0.000 355.650 0.420 ;
     END
   END rw0_wd_in[124]
   PIN rw0_wd_in[125]
@@ -1136,7 +1136,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 168.290 0.000 168.430 0.420 ;
+      RECT 361.490 0.000 361.630 0.420 ;
     END
   END rw0_wd_in[125]
   PIN rw0_wd_in[126]
@@ -1145,7 +1145,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 171.050 0.000 171.190 0.420 ;
+      RECT 367.470 0.000 367.610 0.420 ;
     END
   END rw0_wd_in[126]
   PIN rw0_wd_in[127]
@@ -1154,7 +1154,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 173.810 0.000 173.950 0.420 ;
+      RECT 373.450 0.000 373.590 0.420 ;
     END
   END rw0_wd_in[127]
   PIN rw0_wd_in[128]
@@ -1163,7 +1163,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 176.570 0.000 176.710 0.420 ;
+      RECT 379.430 0.000 379.570 0.420 ;
     END
   END rw0_wd_in[128]
   PIN rw0_wd_in[129]
@@ -1172,7 +1172,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 179.330 0.000 179.470 0.420 ;
+      RECT 385.410 0.000 385.550 0.420 ;
     END
   END rw0_wd_in[129]
   PIN rw0_rd_out[0]
@@ -1181,7 +1181,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 182.090 0.000 182.230 0.420 ;
+      RECT 391.390 0.000 391.530 0.420 ;
     END
   END rw0_rd_out[0]
   PIN rw0_rd_out[1]
@@ -1190,7 +1190,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 184.850 0.000 184.990 0.420 ;
+      RECT 397.370 0.000 397.510 0.420 ;
     END
   END rw0_rd_out[1]
   PIN rw0_rd_out[2]
@@ -1199,7 +1199,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 187.610 0.000 187.750 0.420 ;
+      RECT 403.350 0.000 403.490 0.420 ;
     END
   END rw0_rd_out[2]
   PIN rw0_rd_out[3]
@@ -1208,7 +1208,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 190.370 0.000 190.510 0.420 ;
+      RECT 409.330 0.000 409.470 0.420 ;
     END
   END rw0_rd_out[3]
   PIN rw0_rd_out[4]
@@ -1217,7 +1217,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 193.130 0.000 193.270 0.420 ;
+      RECT 415.310 0.000 415.450 0.420 ;
     END
   END rw0_rd_out[4]
   PIN rw0_rd_out[5]
@@ -1226,7 +1226,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 195.890 0.000 196.030 0.420 ;
+      RECT 421.290 0.000 421.430 0.420 ;
     END
   END rw0_rd_out[5]
   PIN rw0_rd_out[6]
@@ -1235,7 +1235,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 198.650 0.000 198.790 0.420 ;
+      RECT 427.270 0.000 427.410 0.420 ;
     END
   END rw0_rd_out[6]
   PIN rw0_rd_out[7]
@@ -1244,7 +1244,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 201.410 0.000 201.550 0.420 ;
+      RECT 433.250 0.000 433.390 0.420 ;
     END
   END rw0_rd_out[7]
   PIN rw0_rd_out[8]
@@ -1253,7 +1253,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 204.170 0.000 204.310 0.420 ;
+      RECT 439.230 0.000 439.370 0.420 ;
     END
   END rw0_rd_out[8]
   PIN rw0_rd_out[9]
@@ -1262,7 +1262,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 206.930 0.000 207.070 0.420 ;
+      RECT 445.210 0.000 445.350 0.420 ;
     END
   END rw0_rd_out[9]
   PIN rw0_rd_out[10]
@@ -1271,7 +1271,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 209.690 0.000 209.830 0.420 ;
+      RECT 451.190 0.000 451.330 0.420 ;
     END
   END rw0_rd_out[10]
   PIN rw0_rd_out[11]
@@ -1280,7 +1280,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 212.450 0.000 212.590 0.420 ;
+      RECT 457.170 0.000 457.310 0.420 ;
     END
   END rw0_rd_out[11]
   PIN rw0_rd_out[12]
@@ -1289,7 +1289,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 215.210 0.000 215.350 0.420 ;
+      RECT 463.150 0.000 463.290 0.420 ;
     END
   END rw0_rd_out[12]
   PIN rw0_rd_out[13]
@@ -1298,7 +1298,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 217.970 0.000 218.110 0.420 ;
+      RECT 469.130 0.000 469.270 0.420 ;
     END
   END rw0_rd_out[13]
   PIN rw0_rd_out[14]
@@ -1307,7 +1307,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 220.730 0.000 220.870 0.420 ;
+      RECT 475.110 0.000 475.250 0.420 ;
     END
   END rw0_rd_out[14]
   PIN rw0_rd_out[15]
@@ -1316,7 +1316,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 223.490 0.000 223.630 0.420 ;
+      RECT 481.090 0.000 481.230 0.420 ;
     END
   END rw0_rd_out[15]
   PIN rw0_rd_out[16]
@@ -1325,7 +1325,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 226.250 0.000 226.390 0.420 ;
+      RECT 487.070 0.000 487.210 0.420 ;
     END
   END rw0_rd_out[16]
   PIN rw0_rd_out[17]
@@ -1334,7 +1334,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 229.010 0.000 229.150 0.420 ;
+      RECT 493.050 0.000 493.190 0.420 ;
     END
   END rw0_rd_out[17]
   PIN rw0_rd_out[18]
@@ -1343,7 +1343,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 231.770 0.000 231.910 0.420 ;
+      RECT 499.030 0.000 499.170 0.420 ;
     END
   END rw0_rd_out[18]
   PIN rw0_rd_out[19]
@@ -1352,7 +1352,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 234.530 0.000 234.670 0.420 ;
+      RECT 505.010 0.000 505.150 0.420 ;
     END
   END rw0_rd_out[19]
   PIN rw0_rd_out[20]
@@ -1361,7 +1361,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 237.290 0.000 237.430 0.420 ;
+      RECT 510.990 0.000 511.130 0.420 ;
     END
   END rw0_rd_out[20]
   PIN rw0_rd_out[21]
@@ -1370,7 +1370,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 240.050 0.000 240.190 0.420 ;
+      RECT 516.970 0.000 517.110 0.420 ;
     END
   END rw0_rd_out[21]
   PIN rw0_rd_out[22]
@@ -1379,7 +1379,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 242.810 0.000 242.950 0.420 ;
+      RECT 522.950 0.000 523.090 0.420 ;
     END
   END rw0_rd_out[22]
   PIN rw0_rd_out[23]
@@ -1388,7 +1388,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 245.570 0.000 245.710 0.420 ;
+      RECT 528.930 0.000 529.070 0.420 ;
     END
   END rw0_rd_out[23]
   PIN rw0_rd_out[24]
@@ -1397,7 +1397,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 248.330 0.000 248.470 0.420 ;
+      RECT 534.910 0.000 535.050 0.420 ;
     END
   END rw0_rd_out[24]
   PIN rw0_rd_out[25]
@@ -1406,7 +1406,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 251.090 0.000 251.230 0.420 ;
+      RECT 540.890 0.000 541.030 0.420 ;
     END
   END rw0_rd_out[25]
   PIN rw0_rd_out[26]
@@ -1415,7 +1415,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 253.850 0.000 253.990 0.420 ;
+      RECT 546.870 0.000 547.010 0.420 ;
     END
   END rw0_rd_out[26]
   PIN rw0_rd_out[27]
@@ -1424,7 +1424,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 256.610 0.000 256.750 0.420 ;
+      RECT 552.850 0.000 552.990 0.420 ;
     END
   END rw0_rd_out[27]
   PIN rw0_rd_out[28]
@@ -1433,7 +1433,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 259.370 0.000 259.510 0.420 ;
+      RECT 558.830 0.000 558.970 0.420 ;
     END
   END rw0_rd_out[28]
   PIN rw0_rd_out[29]
@@ -1442,7 +1442,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 262.130 0.000 262.270 0.420 ;
+      RECT 564.810 0.000 564.950 0.420 ;
     END
   END rw0_rd_out[29]
   PIN rw0_rd_out[30]
@@ -1451,7 +1451,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 264.890 0.000 265.030 0.420 ;
+      RECT 570.790 0.000 570.930 0.420 ;
     END
   END rw0_rd_out[30]
   PIN rw0_rd_out[31]
@@ -1460,7 +1460,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 267.650 0.000 267.790 0.420 ;
+      RECT 576.770 0.000 576.910 0.420 ;
     END
   END rw0_rd_out[31]
   PIN rw0_rd_out[32]
@@ -1469,7 +1469,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 270.410 0.000 270.550 0.420 ;
+      RECT 582.750 0.000 582.890 0.420 ;
     END
   END rw0_rd_out[32]
   PIN rw0_rd_out[33]
@@ -1478,7 +1478,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 273.170 0.000 273.310 0.420 ;
+      RECT 588.730 0.000 588.870 0.420 ;
     END
   END rw0_rd_out[33]
   PIN rw0_rd_out[34]
@@ -1487,7 +1487,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 275.930 0.000 276.070 0.420 ;
+      RECT 594.710 0.000 594.850 0.420 ;
     END
   END rw0_rd_out[34]
   PIN rw0_rd_out[35]
@@ -1496,7 +1496,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 278.690 0.000 278.830 0.420 ;
+      RECT 600.690 0.000 600.830 0.420 ;
     END
   END rw0_rd_out[35]
   PIN rw0_rd_out[36]
@@ -1505,7 +1505,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 281.450 0.000 281.590 0.420 ;
+      RECT 606.670 0.000 606.810 0.420 ;
     END
   END rw0_rd_out[36]
   PIN rw0_rd_out[37]
@@ -1514,7 +1514,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 284.210 0.000 284.350 0.420 ;
+      RECT 612.650 0.000 612.790 0.420 ;
     END
   END rw0_rd_out[37]
   PIN rw0_rd_out[38]
@@ -1523,7 +1523,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 286.970 0.000 287.110 0.420 ;
+      RECT 618.630 0.000 618.770 0.420 ;
     END
   END rw0_rd_out[38]
   PIN rw0_rd_out[39]
@@ -1532,7 +1532,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 289.730 0.000 289.870 0.420 ;
+      RECT 624.610 0.000 624.750 0.420 ;
     END
   END rw0_rd_out[39]
   PIN rw0_rd_out[40]
@@ -1541,7 +1541,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 292.490 0.000 292.630 0.420 ;
+      RECT 630.590 0.000 630.730 0.420 ;
     END
   END rw0_rd_out[40]
   PIN rw0_rd_out[41]
@@ -1550,7 +1550,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 295.250 0.000 295.390 0.420 ;
+      RECT 636.570 0.000 636.710 0.420 ;
     END
   END rw0_rd_out[41]
   PIN rw0_rd_out[42]
@@ -1559,7 +1559,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 298.010 0.000 298.150 0.420 ;
+      RECT 642.550 0.000 642.690 0.420 ;
     END
   END rw0_rd_out[42]
   PIN rw0_rd_out[43]
@@ -1568,7 +1568,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 300.770 0.000 300.910 0.420 ;
+      RECT 648.530 0.000 648.670 0.420 ;
     END
   END rw0_rd_out[43]
   PIN rw0_rd_out[44]
@@ -1577,7 +1577,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 303.530 0.000 303.670 0.420 ;
+      RECT 654.510 0.000 654.650 0.420 ;
     END
   END rw0_rd_out[44]
   PIN rw0_rd_out[45]
@@ -1586,7 +1586,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 306.290 0.000 306.430 0.420 ;
+      RECT 660.490 0.000 660.630 0.420 ;
     END
   END rw0_rd_out[45]
   PIN rw0_rd_out[46]
@@ -1595,7 +1595,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 309.050 0.000 309.190 0.420 ;
+      RECT 666.470 0.000 666.610 0.420 ;
     END
   END rw0_rd_out[46]
   PIN rw0_rd_out[47]
@@ -1604,7 +1604,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 311.810 0.000 311.950 0.420 ;
+      RECT 672.450 0.000 672.590 0.420 ;
     END
   END rw0_rd_out[47]
   PIN rw0_rd_out[48]
@@ -1613,7 +1613,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 314.570 0.000 314.710 0.420 ;
+      RECT 678.430 0.000 678.570 0.420 ;
     END
   END rw0_rd_out[48]
   PIN rw0_rd_out[49]
@@ -1622,7 +1622,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 317.330 0.000 317.470 0.420 ;
+      RECT 684.410 0.000 684.550 0.420 ;
     END
   END rw0_rd_out[49]
   PIN rw0_rd_out[50]
@@ -1631,7 +1631,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 320.090 0.000 320.230 0.420 ;
+      RECT 690.390 0.000 690.530 0.420 ;
     END
   END rw0_rd_out[50]
   PIN rw0_rd_out[51]
@@ -1640,7 +1640,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 322.850 0.000 322.990 0.420 ;
+      RECT 696.370 0.000 696.510 0.420 ;
     END
   END rw0_rd_out[51]
   PIN rw0_rd_out[52]
@@ -1649,7 +1649,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 325.610 0.000 325.750 0.420 ;
+      RECT 702.350 0.000 702.490 0.420 ;
     END
   END rw0_rd_out[52]
   PIN rw0_rd_out[53]
@@ -1658,7 +1658,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 328.370 0.000 328.510 0.420 ;
+      RECT 708.330 0.000 708.470 0.420 ;
     END
   END rw0_rd_out[53]
   PIN rw0_rd_out[54]
@@ -1667,7 +1667,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 331.130 0.000 331.270 0.420 ;
+      RECT 714.310 0.000 714.450 0.420 ;
     END
   END rw0_rd_out[54]
   PIN rw0_rd_out[55]
@@ -1676,7 +1676,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 333.890 0.000 334.030 0.420 ;
+      RECT 720.290 0.000 720.430 0.420 ;
     END
   END rw0_rd_out[55]
   PIN rw0_rd_out[56]
@@ -1685,7 +1685,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 336.650 0.000 336.790 0.420 ;
+      RECT 726.270 0.000 726.410 0.420 ;
     END
   END rw0_rd_out[56]
   PIN rw0_rd_out[57]
@@ -1694,7 +1694,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 339.410 0.000 339.550 0.420 ;
+      RECT 732.250 0.000 732.390 0.420 ;
     END
   END rw0_rd_out[57]
   PIN rw0_rd_out[58]
@@ -1703,7 +1703,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 342.170 0.000 342.310 0.420 ;
+      RECT 738.230 0.000 738.370 0.420 ;
     END
   END rw0_rd_out[58]
   PIN rw0_rd_out[59]
@@ -1712,7 +1712,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 344.930 0.000 345.070 0.420 ;
+      RECT 744.210 0.000 744.350 0.420 ;
     END
   END rw0_rd_out[59]
   PIN rw0_rd_out[60]
@@ -1721,7 +1721,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 347.690 0.000 347.830 0.420 ;
+      RECT 750.190 0.000 750.330 0.420 ;
     END
   END rw0_rd_out[60]
   PIN rw0_rd_out[61]
@@ -1730,7 +1730,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 350.450 0.000 350.590 0.420 ;
+      RECT 756.170 0.000 756.310 0.420 ;
     END
   END rw0_rd_out[61]
   PIN rw0_rd_out[62]
@@ -1739,7 +1739,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 353.210 0.000 353.350 0.420 ;
+      RECT 762.150 0.000 762.290 0.420 ;
     END
   END rw0_rd_out[62]
   PIN rw0_rd_out[63]
@@ -1748,7 +1748,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 355.970 0.000 356.110 0.420 ;
+      RECT 768.130 0.000 768.270 0.420 ;
     END
   END rw0_rd_out[63]
   PIN rw0_rd_out[64]
@@ -1757,7 +1757,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 358.730 0.000 358.870 0.420 ;
+      RECT 774.110 0.000 774.250 0.420 ;
     END
   END rw0_rd_out[64]
   PIN rw0_rd_out[65]
@@ -1766,7 +1766,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 2.690 948.860 2.830 949.280 ;
+      RECT 2.690 1895.420 2.830 1895.840 ;
     END
   END rw0_rd_out[65]
   PIN rw0_rd_out[66]
@@ -1775,7 +1775,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 6.830 948.860 6.970 949.280 ;
+      RECT 10.970 1895.420 11.110 1895.840 ;
     END
   END rw0_rd_out[66]
   PIN rw0_rd_out[67]
@@ -1784,7 +1784,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 10.970 948.860 11.110 949.280 ;
+      RECT 19.250 1895.420 19.390 1895.840 ;
     END
   END rw0_rd_out[67]
   PIN rw0_rd_out[68]
@@ -1793,7 +1793,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 15.110 948.860 15.250 949.280 ;
+      RECT 27.530 1895.420 27.670 1895.840 ;
     END
   END rw0_rd_out[68]
   PIN rw0_rd_out[69]
@@ -1802,7 +1802,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 19.250 948.860 19.390 949.280 ;
+      RECT 35.810 1895.420 35.950 1895.840 ;
     END
   END rw0_rd_out[69]
   PIN rw0_rd_out[70]
@@ -1811,7 +1811,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 23.390 948.860 23.530 949.280 ;
+      RECT 44.090 1895.420 44.230 1895.840 ;
     END
   END rw0_rd_out[70]
   PIN rw0_rd_out[71]
@@ -1820,7 +1820,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 27.530 948.860 27.670 949.280 ;
+      RECT 52.370 1895.420 52.510 1895.840 ;
     END
   END rw0_rd_out[71]
   PIN rw0_rd_out[72]
@@ -1829,7 +1829,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 31.670 948.860 31.810 949.280 ;
+      RECT 60.650 1895.420 60.790 1895.840 ;
     END
   END rw0_rd_out[72]
   PIN rw0_rd_out[73]
@@ -1838,7 +1838,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 35.810 948.860 35.950 949.280 ;
+      RECT 68.930 1895.420 69.070 1895.840 ;
     END
   END rw0_rd_out[73]
   PIN rw0_rd_out[74]
@@ -1847,7 +1847,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 39.950 948.860 40.090 949.280 ;
+      RECT 77.210 1895.420 77.350 1895.840 ;
     END
   END rw0_rd_out[74]
   PIN rw0_rd_out[75]
@@ -1856,7 +1856,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 44.090 948.860 44.230 949.280 ;
+      RECT 85.490 1895.420 85.630 1895.840 ;
     END
   END rw0_rd_out[75]
   PIN rw0_rd_out[76]
@@ -1865,7 +1865,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 48.230 948.860 48.370 949.280 ;
+      RECT 93.770 1895.420 93.910 1895.840 ;
     END
   END rw0_rd_out[76]
   PIN rw0_rd_out[77]
@@ -1874,7 +1874,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 52.370 948.860 52.510 949.280 ;
+      RECT 102.050 1895.420 102.190 1895.840 ;
     END
   END rw0_rd_out[77]
   PIN rw0_rd_out[78]
@@ -1883,7 +1883,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 56.510 948.860 56.650 949.280 ;
+      RECT 110.330 1895.420 110.470 1895.840 ;
     END
   END rw0_rd_out[78]
   PIN rw0_rd_out[79]
@@ -1892,7 +1892,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 60.650 948.860 60.790 949.280 ;
+      RECT 118.610 1895.420 118.750 1895.840 ;
     END
   END rw0_rd_out[79]
   PIN rw0_rd_out[80]
@@ -1901,7 +1901,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 64.790 948.860 64.930 949.280 ;
+      RECT 126.890 1895.420 127.030 1895.840 ;
     END
   END rw0_rd_out[80]
   PIN rw0_rd_out[81]
@@ -1910,7 +1910,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 68.930 948.860 69.070 949.280 ;
+      RECT 135.170 1895.420 135.310 1895.840 ;
     END
   END rw0_rd_out[81]
   PIN rw0_rd_out[82]
@@ -1919,7 +1919,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 73.070 948.860 73.210 949.280 ;
+      RECT 143.450 1895.420 143.590 1895.840 ;
     END
   END rw0_rd_out[82]
   PIN rw0_rd_out[83]
@@ -1928,7 +1928,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 77.210 948.860 77.350 949.280 ;
+      RECT 151.730 1895.420 151.870 1895.840 ;
     END
   END rw0_rd_out[83]
   PIN rw0_rd_out[84]
@@ -1937,7 +1937,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 81.350 948.860 81.490 949.280 ;
+      RECT 160.010 1895.420 160.150 1895.840 ;
     END
   END rw0_rd_out[84]
   PIN rw0_rd_out[85]
@@ -1946,7 +1946,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 85.490 948.860 85.630 949.280 ;
+      RECT 168.290 1895.420 168.430 1895.840 ;
     END
   END rw0_rd_out[85]
   PIN rw0_rd_out[86]
@@ -1955,7 +1955,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 89.630 948.860 89.770 949.280 ;
+      RECT 176.570 1895.420 176.710 1895.840 ;
     END
   END rw0_rd_out[86]
   PIN rw0_rd_out[87]
@@ -1964,7 +1964,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 93.770 948.860 93.910 949.280 ;
+      RECT 184.850 1895.420 184.990 1895.840 ;
     END
   END rw0_rd_out[87]
   PIN rw0_rd_out[88]
@@ -1973,7 +1973,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 97.910 948.860 98.050 949.280 ;
+      RECT 193.130 1895.420 193.270 1895.840 ;
     END
   END rw0_rd_out[88]
   PIN rw0_rd_out[89]
@@ -1982,7 +1982,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 102.050 948.860 102.190 949.280 ;
+      RECT 201.410 1895.420 201.550 1895.840 ;
     END
   END rw0_rd_out[89]
   PIN rw0_rd_out[90]
@@ -1991,7 +1991,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 106.190 948.860 106.330 949.280 ;
+      RECT 209.690 1895.420 209.830 1895.840 ;
     END
   END rw0_rd_out[90]
   PIN rw0_rd_out[91]
@@ -2000,7 +2000,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 110.330 948.860 110.470 949.280 ;
+      RECT 217.970 1895.420 218.110 1895.840 ;
     END
   END rw0_rd_out[91]
   PIN rw0_rd_out[92]
@@ -2009,7 +2009,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 114.470 948.860 114.610 949.280 ;
+      RECT 226.250 1895.420 226.390 1895.840 ;
     END
   END rw0_rd_out[92]
   PIN rw0_rd_out[93]
@@ -2018,7 +2018,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 118.610 948.860 118.750 949.280 ;
+      RECT 234.530 1895.420 234.670 1895.840 ;
     END
   END rw0_rd_out[93]
   PIN rw0_rd_out[94]
@@ -2027,7 +2027,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 122.750 948.860 122.890 949.280 ;
+      RECT 242.810 1895.420 242.950 1895.840 ;
     END
   END rw0_rd_out[94]
   PIN rw0_rd_out[95]
@@ -2036,7 +2036,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 126.890 948.860 127.030 949.280 ;
+      RECT 251.090 1895.420 251.230 1895.840 ;
     END
   END rw0_rd_out[95]
   PIN rw0_rd_out[96]
@@ -2045,7 +2045,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 131.030 948.860 131.170 949.280 ;
+      RECT 259.370 1895.420 259.510 1895.840 ;
     END
   END rw0_rd_out[96]
   PIN rw0_rd_out[97]
@@ -2054,7 +2054,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 135.170 948.860 135.310 949.280 ;
+      RECT 267.650 1895.420 267.790 1895.840 ;
     END
   END rw0_rd_out[97]
   PIN rw0_rd_out[98]
@@ -2063,7 +2063,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 139.310 948.860 139.450 949.280 ;
+      RECT 275.930 1895.420 276.070 1895.840 ;
     END
   END rw0_rd_out[98]
   PIN rw0_rd_out[99]
@@ -2072,7 +2072,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 143.450 948.860 143.590 949.280 ;
+      RECT 284.210 1895.420 284.350 1895.840 ;
     END
   END rw0_rd_out[99]
   PIN rw0_rd_out[100]
@@ -2081,7 +2081,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 147.590 948.860 147.730 949.280 ;
+      RECT 292.490 1895.420 292.630 1895.840 ;
     END
   END rw0_rd_out[100]
   PIN rw0_rd_out[101]
@@ -2090,7 +2090,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 151.730 948.860 151.870 949.280 ;
+      RECT 300.770 1895.420 300.910 1895.840 ;
     END
   END rw0_rd_out[101]
   PIN rw0_rd_out[102]
@@ -2099,7 +2099,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 155.870 948.860 156.010 949.280 ;
+      RECT 309.050 1895.420 309.190 1895.840 ;
     END
   END rw0_rd_out[102]
   PIN rw0_rd_out[103]
@@ -2108,7 +2108,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 160.010 948.860 160.150 949.280 ;
+      RECT 317.330 1895.420 317.470 1895.840 ;
     END
   END rw0_rd_out[103]
   PIN rw0_rd_out[104]
@@ -2117,7 +2117,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 164.150 948.860 164.290 949.280 ;
+      RECT 325.610 1895.420 325.750 1895.840 ;
     END
   END rw0_rd_out[104]
   PIN rw0_rd_out[105]
@@ -2126,7 +2126,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 168.290 948.860 168.430 949.280 ;
+      RECT 333.890 1895.420 334.030 1895.840 ;
     END
   END rw0_rd_out[105]
   PIN rw0_rd_out[106]
@@ -2135,7 +2135,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 172.430 948.860 172.570 949.280 ;
+      RECT 342.170 1895.420 342.310 1895.840 ;
     END
   END rw0_rd_out[106]
   PIN rw0_rd_out[107]
@@ -2144,7 +2144,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 176.570 948.860 176.710 949.280 ;
+      RECT 350.450 1895.420 350.590 1895.840 ;
     END
   END rw0_rd_out[107]
   PIN rw0_rd_out[108]
@@ -2153,7 +2153,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 180.710 948.860 180.850 949.280 ;
+      RECT 358.730 1895.420 358.870 1895.840 ;
     END
   END rw0_rd_out[108]
   PIN rw0_rd_out[109]
@@ -2162,7 +2162,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 184.850 948.860 184.990 949.280 ;
+      RECT 367.010 1895.420 367.150 1895.840 ;
     END
   END rw0_rd_out[109]
   PIN rw0_rd_out[110]
@@ -2171,7 +2171,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 188.990 948.860 189.130 949.280 ;
+      RECT 375.290 1895.420 375.430 1895.840 ;
     END
   END rw0_rd_out[110]
   PIN rw0_rd_out[111]
@@ -2180,7 +2180,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 193.130 948.860 193.270 949.280 ;
+      RECT 383.570 1895.420 383.710 1895.840 ;
     END
   END rw0_rd_out[111]
   PIN rw0_rd_out[112]
@@ -2189,7 +2189,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 197.270 948.860 197.410 949.280 ;
+      RECT 391.850 1895.420 391.990 1895.840 ;
     END
   END rw0_rd_out[112]
   PIN rw0_rd_out[113]
@@ -2198,7 +2198,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 201.410 948.860 201.550 949.280 ;
+      RECT 400.130 1895.420 400.270 1895.840 ;
     END
   END rw0_rd_out[113]
   PIN rw0_rd_out[114]
@@ -2207,7 +2207,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 205.550 948.860 205.690 949.280 ;
+      RECT 408.410 1895.420 408.550 1895.840 ;
     END
   END rw0_rd_out[114]
   PIN rw0_rd_out[115]
@@ -2216,7 +2216,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 209.690 948.860 209.830 949.280 ;
+      RECT 416.690 1895.420 416.830 1895.840 ;
     END
   END rw0_rd_out[115]
   PIN rw0_rd_out[116]
@@ -2225,7 +2225,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 213.830 948.860 213.970 949.280 ;
+      RECT 424.970 1895.420 425.110 1895.840 ;
     END
   END rw0_rd_out[116]
   PIN rw0_rd_out[117]
@@ -2234,7 +2234,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 217.970 948.860 218.110 949.280 ;
+      RECT 433.250 1895.420 433.390 1895.840 ;
     END
   END rw0_rd_out[117]
   PIN rw0_rd_out[118]
@@ -2243,7 +2243,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 222.110 948.860 222.250 949.280 ;
+      RECT 441.530 1895.420 441.670 1895.840 ;
     END
   END rw0_rd_out[118]
   PIN rw0_rd_out[119]
@@ -2252,7 +2252,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 226.250 948.860 226.390 949.280 ;
+      RECT 449.810 1895.420 449.950 1895.840 ;
     END
   END rw0_rd_out[119]
   PIN rw0_rd_out[120]
@@ -2261,7 +2261,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 230.390 948.860 230.530 949.280 ;
+      RECT 458.090 1895.420 458.230 1895.840 ;
     END
   END rw0_rd_out[120]
   PIN rw0_rd_out[121]
@@ -2270,7 +2270,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 234.530 948.860 234.670 949.280 ;
+      RECT 466.370 1895.420 466.510 1895.840 ;
     END
   END rw0_rd_out[121]
   PIN rw0_rd_out[122]
@@ -2279,7 +2279,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 238.670 948.860 238.810 949.280 ;
+      RECT 474.650 1895.420 474.790 1895.840 ;
     END
   END rw0_rd_out[122]
   PIN rw0_rd_out[123]
@@ -2288,7 +2288,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 242.810 948.860 242.950 949.280 ;
+      RECT 482.930 1895.420 483.070 1895.840 ;
     END
   END rw0_rd_out[123]
   PIN rw0_rd_out[124]
@@ -2297,7 +2297,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 246.950 948.860 247.090 949.280 ;
+      RECT 491.210 1895.420 491.350 1895.840 ;
     END
   END rw0_rd_out[124]
   PIN rw0_rd_out[125]
@@ -2306,7 +2306,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 251.090 948.860 251.230 949.280 ;
+      RECT 499.490 1895.420 499.630 1895.840 ;
     END
   END rw0_rd_out[125]
   PIN rw0_rd_out[126]
@@ -2315,7 +2315,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 255.230 948.860 255.370 949.280 ;
+      RECT 507.770 1895.420 507.910 1895.840 ;
     END
   END rw0_rd_out[126]
   PIN rw0_rd_out[127]
@@ -2324,7 +2324,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 259.370 948.860 259.510 949.280 ;
+      RECT 516.050 1895.420 516.190 1895.840 ;
     END
   END rw0_rd_out[127]
   PIN rw0_rd_out[128]
@@ -2333,7 +2333,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 263.510 948.860 263.650 949.280 ;
+      RECT 524.330 1895.420 524.470 1895.840 ;
     END
   END rw0_rd_out[128]
   PIN rw0_rd_out[129]
@@ -2342,7 +2342,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 267.650 948.860 267.790 949.280 ;
+      RECT 532.610 1895.420 532.750 1895.840 ;
     END
   END rw0_rd_out[129]
   PIN r0_rd_out[0]
@@ -2351,7 +2351,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 361.490 0.000 361.630 0.420 ;
+      RECT 780.090 0.000 780.230 0.420 ;
     END
   END r0_rd_out[0]
   PIN r0_rd_out[1]
@@ -2360,7 +2360,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 364.250 0.000 364.390 0.420 ;
+      RECT 786.070 0.000 786.210 0.420 ;
     END
   END r0_rd_out[1]
   PIN r0_rd_out[2]
@@ -2369,7 +2369,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 367.010 0.000 367.150 0.420 ;
+      RECT 792.050 0.000 792.190 0.420 ;
     END
   END r0_rd_out[2]
   PIN r0_rd_out[3]
@@ -2378,7 +2378,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 369.770 0.000 369.910 0.420 ;
+      RECT 798.030 0.000 798.170 0.420 ;
     END
   END r0_rd_out[3]
   PIN r0_rd_out[4]
@@ -2387,7 +2387,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 372.530 0.000 372.670 0.420 ;
+      RECT 804.010 0.000 804.150 0.420 ;
     END
   END r0_rd_out[4]
   PIN r0_rd_out[5]
@@ -2396,7 +2396,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 375.290 0.000 375.430 0.420 ;
+      RECT 809.990 0.000 810.130 0.420 ;
     END
   END r0_rd_out[5]
   PIN r0_rd_out[6]
@@ -2405,7 +2405,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 378.050 0.000 378.190 0.420 ;
+      RECT 815.970 0.000 816.110 0.420 ;
     END
   END r0_rd_out[6]
   PIN r0_rd_out[7]
@@ -2414,7 +2414,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 380.810 0.000 380.950 0.420 ;
+      RECT 821.950 0.000 822.090 0.420 ;
     END
   END r0_rd_out[7]
   PIN r0_rd_out[8]
@@ -2423,7 +2423,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 383.570 0.000 383.710 0.420 ;
+      RECT 827.930 0.000 828.070 0.420 ;
     END
   END r0_rd_out[8]
   PIN r0_rd_out[9]
@@ -2432,7 +2432,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 386.330 0.000 386.470 0.420 ;
+      RECT 833.910 0.000 834.050 0.420 ;
     END
   END r0_rd_out[9]
   PIN r0_rd_out[10]
@@ -2441,7 +2441,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 389.090 0.000 389.230 0.420 ;
+      RECT 839.890 0.000 840.030 0.420 ;
     END
   END r0_rd_out[10]
   PIN r0_rd_out[11]
@@ -2450,7 +2450,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 391.850 0.000 391.990 0.420 ;
+      RECT 845.870 0.000 846.010 0.420 ;
     END
   END r0_rd_out[11]
   PIN r0_rd_out[12]
@@ -2459,7 +2459,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 394.610 0.000 394.750 0.420 ;
+      RECT 851.850 0.000 851.990 0.420 ;
     END
   END r0_rd_out[12]
   PIN r0_rd_out[13]
@@ -2468,7 +2468,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 397.370 0.000 397.510 0.420 ;
+      RECT 857.830 0.000 857.970 0.420 ;
     END
   END r0_rd_out[13]
   PIN r0_rd_out[14]
@@ -2477,7 +2477,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 400.130 0.000 400.270 0.420 ;
+      RECT 863.810 0.000 863.950 0.420 ;
     END
   END r0_rd_out[14]
   PIN r0_rd_out[15]
@@ -2486,7 +2486,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 402.890 0.000 403.030 0.420 ;
+      RECT 869.790 0.000 869.930 0.420 ;
     END
   END r0_rd_out[15]
   PIN r0_rd_out[16]
@@ -2495,7 +2495,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 405.650 0.000 405.790 0.420 ;
+      RECT 875.770 0.000 875.910 0.420 ;
     END
   END r0_rd_out[16]
   PIN r0_rd_out[17]
@@ -2504,7 +2504,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 408.410 0.000 408.550 0.420 ;
+      RECT 881.750 0.000 881.890 0.420 ;
     END
   END r0_rd_out[17]
   PIN r0_rd_out[18]
@@ -2513,7 +2513,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 411.170 0.000 411.310 0.420 ;
+      RECT 887.730 0.000 887.870 0.420 ;
     END
   END r0_rd_out[18]
   PIN r0_rd_out[19]
@@ -2522,7 +2522,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 413.930 0.000 414.070 0.420 ;
+      RECT 893.710 0.000 893.850 0.420 ;
     END
   END r0_rd_out[19]
   PIN r0_rd_out[20]
@@ -2531,7 +2531,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 416.690 0.000 416.830 0.420 ;
+      RECT 899.690 0.000 899.830 0.420 ;
     END
   END r0_rd_out[20]
   PIN r0_rd_out[21]
@@ -2540,7 +2540,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 419.450 0.000 419.590 0.420 ;
+      RECT 905.670 0.000 905.810 0.420 ;
     END
   END r0_rd_out[21]
   PIN r0_rd_out[22]
@@ -2549,7 +2549,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 422.210 0.000 422.350 0.420 ;
+      RECT 911.650 0.000 911.790 0.420 ;
     END
   END r0_rd_out[22]
   PIN r0_rd_out[23]
@@ -2558,7 +2558,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 424.970 0.000 425.110 0.420 ;
+      RECT 917.630 0.000 917.770 0.420 ;
     END
   END r0_rd_out[23]
   PIN r0_rd_out[24]
@@ -2567,7 +2567,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 427.730 0.000 427.870 0.420 ;
+      RECT 923.610 0.000 923.750 0.420 ;
     END
   END r0_rd_out[24]
   PIN r0_rd_out[25]
@@ -2576,7 +2576,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 430.490 0.000 430.630 0.420 ;
+      RECT 929.590 0.000 929.730 0.420 ;
     END
   END r0_rd_out[25]
   PIN r0_rd_out[26]
@@ -2585,7 +2585,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 433.250 0.000 433.390 0.420 ;
+      RECT 935.570 0.000 935.710 0.420 ;
     END
   END r0_rd_out[26]
   PIN r0_rd_out[27]
@@ -2594,7 +2594,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 436.010 0.000 436.150 0.420 ;
+      RECT 941.550 0.000 941.690 0.420 ;
     END
   END r0_rd_out[27]
   PIN r0_rd_out[28]
@@ -2603,7 +2603,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 438.770 0.000 438.910 0.420 ;
+      RECT 947.530 0.000 947.670 0.420 ;
     END
   END r0_rd_out[28]
   PIN r0_rd_out[29]
@@ -2612,7 +2612,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 441.530 0.000 441.670 0.420 ;
+      RECT 953.510 0.000 953.650 0.420 ;
     END
   END r0_rd_out[29]
   PIN r0_rd_out[30]
@@ -2621,7 +2621,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 444.290 0.000 444.430 0.420 ;
+      RECT 959.490 0.000 959.630 0.420 ;
     END
   END r0_rd_out[30]
   PIN r0_rd_out[31]
@@ -2630,7 +2630,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 447.050 0.000 447.190 0.420 ;
+      RECT 965.470 0.000 965.610 0.420 ;
     END
   END r0_rd_out[31]
   PIN r0_rd_out[32]
@@ -2639,7 +2639,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 449.810 0.000 449.950 0.420 ;
+      RECT 971.450 0.000 971.590 0.420 ;
     END
   END r0_rd_out[32]
   PIN r0_rd_out[33]
@@ -2648,7 +2648,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 452.570 0.000 452.710 0.420 ;
+      RECT 977.430 0.000 977.570 0.420 ;
     END
   END r0_rd_out[33]
   PIN r0_rd_out[34]
@@ -2657,7 +2657,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 455.330 0.000 455.470 0.420 ;
+      RECT 983.410 0.000 983.550 0.420 ;
     END
   END r0_rd_out[34]
   PIN r0_rd_out[35]
@@ -2666,7 +2666,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 458.090 0.000 458.230 0.420 ;
+      RECT 989.390 0.000 989.530 0.420 ;
     END
   END r0_rd_out[35]
   PIN r0_rd_out[36]
@@ -2675,7 +2675,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 460.850 0.000 460.990 0.420 ;
+      RECT 995.370 0.000 995.510 0.420 ;
     END
   END r0_rd_out[36]
   PIN r0_rd_out[37]
@@ -2684,7 +2684,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 463.610 0.000 463.750 0.420 ;
+      RECT 1001.350 0.000 1001.490 0.420 ;
     END
   END r0_rd_out[37]
   PIN r0_rd_out[38]
@@ -2693,7 +2693,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 466.370 0.000 466.510 0.420 ;
+      RECT 1007.330 0.000 1007.470 0.420 ;
     END
   END r0_rd_out[38]
   PIN r0_rd_out[39]
@@ -2702,7 +2702,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 469.130 0.000 469.270 0.420 ;
+      RECT 1013.310 0.000 1013.450 0.420 ;
     END
   END r0_rd_out[39]
   PIN r0_rd_out[40]
@@ -2711,7 +2711,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 471.890 0.000 472.030 0.420 ;
+      RECT 1019.290 0.000 1019.430 0.420 ;
     END
   END r0_rd_out[40]
   PIN r0_rd_out[41]
@@ -2720,7 +2720,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 474.650 0.000 474.790 0.420 ;
+      RECT 1025.270 0.000 1025.410 0.420 ;
     END
   END r0_rd_out[41]
   PIN r0_rd_out[42]
@@ -2729,7 +2729,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 477.410 0.000 477.550 0.420 ;
+      RECT 1031.250 0.000 1031.390 0.420 ;
     END
   END r0_rd_out[42]
   PIN r0_rd_out[43]
@@ -2738,7 +2738,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 480.170 0.000 480.310 0.420 ;
+      RECT 1037.230 0.000 1037.370 0.420 ;
     END
   END r0_rd_out[43]
   PIN r0_rd_out[44]
@@ -2747,7 +2747,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 482.930 0.000 483.070 0.420 ;
+      RECT 1043.210 0.000 1043.350 0.420 ;
     END
   END r0_rd_out[44]
   PIN r0_rd_out[45]
@@ -2756,7 +2756,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 485.690 0.000 485.830 0.420 ;
+      RECT 1049.190 0.000 1049.330 0.420 ;
     END
   END r0_rd_out[45]
   PIN r0_rd_out[46]
@@ -2765,7 +2765,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 488.450 0.000 488.590 0.420 ;
+      RECT 1055.170 0.000 1055.310 0.420 ;
     END
   END r0_rd_out[46]
   PIN r0_rd_out[47]
@@ -2774,7 +2774,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 491.210 0.000 491.350 0.420 ;
+      RECT 1061.150 0.000 1061.290 0.420 ;
     END
   END r0_rd_out[47]
   PIN r0_rd_out[48]
@@ -2783,7 +2783,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 493.970 0.000 494.110 0.420 ;
+      RECT 1067.130 0.000 1067.270 0.420 ;
     END
   END r0_rd_out[48]
   PIN r0_rd_out[49]
@@ -2792,7 +2792,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 496.730 0.000 496.870 0.420 ;
+      RECT 1073.110 0.000 1073.250 0.420 ;
     END
   END r0_rd_out[49]
   PIN r0_rd_out[50]
@@ -2801,7 +2801,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 499.490 0.000 499.630 0.420 ;
+      RECT 1079.090 0.000 1079.230 0.420 ;
     END
   END r0_rd_out[50]
   PIN r0_rd_out[51]
@@ -2810,7 +2810,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 502.250 0.000 502.390 0.420 ;
+      RECT 1085.070 0.000 1085.210 0.420 ;
     END
   END r0_rd_out[51]
   PIN r0_rd_out[52]
@@ -2819,7 +2819,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 505.010 0.000 505.150 0.420 ;
+      RECT 1091.050 0.000 1091.190 0.420 ;
     END
   END r0_rd_out[52]
   PIN r0_rd_out[53]
@@ -2828,7 +2828,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 507.770 0.000 507.910 0.420 ;
+      RECT 1097.030 0.000 1097.170 0.420 ;
     END
   END r0_rd_out[53]
   PIN r0_rd_out[54]
@@ -2837,7 +2837,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 510.530 0.000 510.670 0.420 ;
+      RECT 1103.010 0.000 1103.150 0.420 ;
     END
   END r0_rd_out[54]
   PIN r0_rd_out[55]
@@ -2846,7 +2846,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 513.290 0.000 513.430 0.420 ;
+      RECT 1108.990 0.000 1109.130 0.420 ;
     END
   END r0_rd_out[55]
   PIN r0_rd_out[56]
@@ -2855,7 +2855,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 516.050 0.000 516.190 0.420 ;
+      RECT 1114.970 0.000 1115.110 0.420 ;
     END
   END r0_rd_out[56]
   PIN r0_rd_out[57]
@@ -2864,7 +2864,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 518.810 0.000 518.950 0.420 ;
+      RECT 1120.950 0.000 1121.090 0.420 ;
     END
   END r0_rd_out[57]
   PIN r0_rd_out[58]
@@ -2873,7 +2873,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 521.570 0.000 521.710 0.420 ;
+      RECT 1126.930 0.000 1127.070 0.420 ;
     END
   END r0_rd_out[58]
   PIN r0_rd_out[59]
@@ -2882,7 +2882,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 524.330 0.000 524.470 0.420 ;
+      RECT 1132.910 0.000 1133.050 0.420 ;
     END
   END r0_rd_out[59]
   PIN r0_rd_out[60]
@@ -2891,7 +2891,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 527.090 0.000 527.230 0.420 ;
+      RECT 1138.890 0.000 1139.030 0.420 ;
     END
   END r0_rd_out[60]
   PIN r0_rd_out[61]
@@ -2900,7 +2900,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 529.850 0.000 529.990 0.420 ;
+      RECT 1144.870 0.000 1145.010 0.420 ;
     END
   END r0_rd_out[61]
   PIN r0_rd_out[62]
@@ -2909,7 +2909,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 532.610 0.000 532.750 0.420 ;
+      RECT 1150.850 0.000 1150.990 0.420 ;
     END
   END r0_rd_out[62]
   PIN r0_rd_out[63]
@@ -2918,7 +2918,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 535.370 0.000 535.510 0.420 ;
+      RECT 1156.830 0.000 1156.970 0.420 ;
     END
   END r0_rd_out[63]
   PIN r0_rd_out[64]
@@ -2927,7 +2927,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 538.130 0.000 538.270 0.420 ;
+      RECT 1162.810 0.000 1162.950 0.420 ;
     END
   END r0_rd_out[64]
   PIN r0_rd_out[65]
@@ -2936,7 +2936,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 271.790 948.860 271.930 949.280 ;
+      RECT 540.890 1895.420 541.030 1895.840 ;
     END
   END r0_rd_out[65]
   PIN r0_rd_out[66]
@@ -2945,7 +2945,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 275.930 948.860 276.070 949.280 ;
+      RECT 549.170 1895.420 549.310 1895.840 ;
     END
   END r0_rd_out[66]
   PIN r0_rd_out[67]
@@ -2954,7 +2954,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 280.070 948.860 280.210 949.280 ;
+      RECT 557.450 1895.420 557.590 1895.840 ;
     END
   END r0_rd_out[67]
   PIN r0_rd_out[68]
@@ -2963,7 +2963,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 284.210 948.860 284.350 949.280 ;
+      RECT 565.730 1895.420 565.870 1895.840 ;
     END
   END r0_rd_out[68]
   PIN r0_rd_out[69]
@@ -2972,7 +2972,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 288.350 948.860 288.490 949.280 ;
+      RECT 574.010 1895.420 574.150 1895.840 ;
     END
   END r0_rd_out[69]
   PIN r0_rd_out[70]
@@ -2981,7 +2981,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 292.490 948.860 292.630 949.280 ;
+      RECT 582.290 1895.420 582.430 1895.840 ;
     END
   END r0_rd_out[70]
   PIN r0_rd_out[71]
@@ -2990,7 +2990,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 296.630 948.860 296.770 949.280 ;
+      RECT 590.570 1895.420 590.710 1895.840 ;
     END
   END r0_rd_out[71]
   PIN r0_rd_out[72]
@@ -2999,7 +2999,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 300.770 948.860 300.910 949.280 ;
+      RECT 598.850 1895.420 598.990 1895.840 ;
     END
   END r0_rd_out[72]
   PIN r0_rd_out[73]
@@ -3008,7 +3008,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 304.910 948.860 305.050 949.280 ;
+      RECT 607.130 1895.420 607.270 1895.840 ;
     END
   END r0_rd_out[73]
   PIN r0_rd_out[74]
@@ -3017,7 +3017,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 309.050 948.860 309.190 949.280 ;
+      RECT 615.410 1895.420 615.550 1895.840 ;
     END
   END r0_rd_out[74]
   PIN r0_rd_out[75]
@@ -3026,7 +3026,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 313.190 948.860 313.330 949.280 ;
+      RECT 623.690 1895.420 623.830 1895.840 ;
     END
   END r0_rd_out[75]
   PIN r0_rd_out[76]
@@ -3035,7 +3035,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 317.330 948.860 317.470 949.280 ;
+      RECT 631.970 1895.420 632.110 1895.840 ;
     END
   END r0_rd_out[76]
   PIN r0_rd_out[77]
@@ -3044,7 +3044,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 321.470 948.860 321.610 949.280 ;
+      RECT 640.250 1895.420 640.390 1895.840 ;
     END
   END r0_rd_out[77]
   PIN r0_rd_out[78]
@@ -3053,7 +3053,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 325.610 948.860 325.750 949.280 ;
+      RECT 648.530 1895.420 648.670 1895.840 ;
     END
   END r0_rd_out[78]
   PIN r0_rd_out[79]
@@ -3062,7 +3062,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 329.750 948.860 329.890 949.280 ;
+      RECT 656.810 1895.420 656.950 1895.840 ;
     END
   END r0_rd_out[79]
   PIN r0_rd_out[80]
@@ -3071,7 +3071,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 333.890 948.860 334.030 949.280 ;
+      RECT 665.090 1895.420 665.230 1895.840 ;
     END
   END r0_rd_out[80]
   PIN r0_rd_out[81]
@@ -3080,7 +3080,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 338.030 948.860 338.170 949.280 ;
+      RECT 673.370 1895.420 673.510 1895.840 ;
     END
   END r0_rd_out[81]
   PIN r0_rd_out[82]
@@ -3089,7 +3089,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 342.170 948.860 342.310 949.280 ;
+      RECT 681.650 1895.420 681.790 1895.840 ;
     END
   END r0_rd_out[82]
   PIN r0_rd_out[83]
@@ -3098,7 +3098,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 346.310 948.860 346.450 949.280 ;
+      RECT 689.930 1895.420 690.070 1895.840 ;
     END
   END r0_rd_out[83]
   PIN r0_rd_out[84]
@@ -3107,7 +3107,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 350.450 948.860 350.590 949.280 ;
+      RECT 698.210 1895.420 698.350 1895.840 ;
     END
   END r0_rd_out[84]
   PIN r0_rd_out[85]
@@ -3116,7 +3116,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 354.590 948.860 354.730 949.280 ;
+      RECT 706.490 1895.420 706.630 1895.840 ;
     END
   END r0_rd_out[85]
   PIN r0_rd_out[86]
@@ -3125,7 +3125,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 358.730 948.860 358.870 949.280 ;
+      RECT 714.770 1895.420 714.910 1895.840 ;
     END
   END r0_rd_out[86]
   PIN r0_rd_out[87]
@@ -3134,7 +3134,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 362.870 948.860 363.010 949.280 ;
+      RECT 723.050 1895.420 723.190 1895.840 ;
     END
   END r0_rd_out[87]
   PIN r0_rd_out[88]
@@ -3143,7 +3143,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 367.010 948.860 367.150 949.280 ;
+      RECT 731.330 1895.420 731.470 1895.840 ;
     END
   END r0_rd_out[88]
   PIN r0_rd_out[89]
@@ -3152,7 +3152,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 371.150 948.860 371.290 949.280 ;
+      RECT 739.610 1895.420 739.750 1895.840 ;
     END
   END r0_rd_out[89]
   PIN r0_rd_out[90]
@@ -3161,7 +3161,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 375.290 948.860 375.430 949.280 ;
+      RECT 747.890 1895.420 748.030 1895.840 ;
     END
   END r0_rd_out[90]
   PIN r0_rd_out[91]
@@ -3170,7 +3170,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 379.430 948.860 379.570 949.280 ;
+      RECT 756.170 1895.420 756.310 1895.840 ;
     END
   END r0_rd_out[91]
   PIN r0_rd_out[92]
@@ -3179,7 +3179,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 383.570 948.860 383.710 949.280 ;
+      RECT 764.450 1895.420 764.590 1895.840 ;
     END
   END r0_rd_out[92]
   PIN r0_rd_out[93]
@@ -3188,7 +3188,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 387.710 948.860 387.850 949.280 ;
+      RECT 772.730 1895.420 772.870 1895.840 ;
     END
   END r0_rd_out[93]
   PIN r0_rd_out[94]
@@ -3197,7 +3197,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 391.850 948.860 391.990 949.280 ;
+      RECT 781.010 1895.420 781.150 1895.840 ;
     END
   END r0_rd_out[94]
   PIN r0_rd_out[95]
@@ -3206,7 +3206,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 395.990 948.860 396.130 949.280 ;
+      RECT 789.290 1895.420 789.430 1895.840 ;
     END
   END r0_rd_out[95]
   PIN r0_rd_out[96]
@@ -3215,7 +3215,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 400.130 948.860 400.270 949.280 ;
+      RECT 797.570 1895.420 797.710 1895.840 ;
     END
   END r0_rd_out[96]
   PIN r0_rd_out[97]
@@ -3224,7 +3224,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 404.270 948.860 404.410 949.280 ;
+      RECT 805.850 1895.420 805.990 1895.840 ;
     END
   END r0_rd_out[97]
   PIN r0_rd_out[98]
@@ -3233,7 +3233,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 408.410 948.860 408.550 949.280 ;
+      RECT 814.130 1895.420 814.270 1895.840 ;
     END
   END r0_rd_out[98]
   PIN r0_rd_out[99]
@@ -3242,7 +3242,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 412.550 948.860 412.690 949.280 ;
+      RECT 822.410 1895.420 822.550 1895.840 ;
     END
   END r0_rd_out[99]
   PIN r0_rd_out[100]
@@ -3251,7 +3251,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 416.690 948.860 416.830 949.280 ;
+      RECT 830.690 1895.420 830.830 1895.840 ;
     END
   END r0_rd_out[100]
   PIN r0_rd_out[101]
@@ -3260,7 +3260,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 420.830 948.860 420.970 949.280 ;
+      RECT 838.970 1895.420 839.110 1895.840 ;
     END
   END r0_rd_out[101]
   PIN r0_rd_out[102]
@@ -3269,7 +3269,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 424.970 948.860 425.110 949.280 ;
+      RECT 847.250 1895.420 847.390 1895.840 ;
     END
   END r0_rd_out[102]
   PIN r0_rd_out[103]
@@ -3278,7 +3278,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 429.110 948.860 429.250 949.280 ;
+      RECT 855.530 1895.420 855.670 1895.840 ;
     END
   END r0_rd_out[103]
   PIN r0_rd_out[104]
@@ -3287,7 +3287,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 433.250 948.860 433.390 949.280 ;
+      RECT 863.810 1895.420 863.950 1895.840 ;
     END
   END r0_rd_out[104]
   PIN r0_rd_out[105]
@@ -3296,7 +3296,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 437.390 948.860 437.530 949.280 ;
+      RECT 872.090 1895.420 872.230 1895.840 ;
     END
   END r0_rd_out[105]
   PIN r0_rd_out[106]
@@ -3305,7 +3305,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 441.530 948.860 441.670 949.280 ;
+      RECT 880.370 1895.420 880.510 1895.840 ;
     END
   END r0_rd_out[106]
   PIN r0_rd_out[107]
@@ -3314,7 +3314,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 445.670 948.860 445.810 949.280 ;
+      RECT 888.650 1895.420 888.790 1895.840 ;
     END
   END r0_rd_out[107]
   PIN r0_rd_out[108]
@@ -3323,7 +3323,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 449.810 948.860 449.950 949.280 ;
+      RECT 896.930 1895.420 897.070 1895.840 ;
     END
   END r0_rd_out[108]
   PIN r0_rd_out[109]
@@ -3332,7 +3332,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 453.950 948.860 454.090 949.280 ;
+      RECT 905.210 1895.420 905.350 1895.840 ;
     END
   END r0_rd_out[109]
   PIN r0_rd_out[110]
@@ -3341,7 +3341,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 458.090 948.860 458.230 949.280 ;
+      RECT 913.490 1895.420 913.630 1895.840 ;
     END
   END r0_rd_out[110]
   PIN r0_rd_out[111]
@@ -3350,7 +3350,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 462.230 948.860 462.370 949.280 ;
+      RECT 921.770 1895.420 921.910 1895.840 ;
     END
   END r0_rd_out[111]
   PIN r0_rd_out[112]
@@ -3359,7 +3359,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 466.370 948.860 466.510 949.280 ;
+      RECT 930.050 1895.420 930.190 1895.840 ;
     END
   END r0_rd_out[112]
   PIN r0_rd_out[113]
@@ -3368,7 +3368,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 470.510 948.860 470.650 949.280 ;
+      RECT 938.330 1895.420 938.470 1895.840 ;
     END
   END r0_rd_out[113]
   PIN r0_rd_out[114]
@@ -3377,7 +3377,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 474.650 948.860 474.790 949.280 ;
+      RECT 946.610 1895.420 946.750 1895.840 ;
     END
   END r0_rd_out[114]
   PIN r0_rd_out[115]
@@ -3386,7 +3386,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 478.790 948.860 478.930 949.280 ;
+      RECT 954.890 1895.420 955.030 1895.840 ;
     END
   END r0_rd_out[115]
   PIN r0_rd_out[116]
@@ -3395,7 +3395,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 482.930 948.860 483.070 949.280 ;
+      RECT 963.170 1895.420 963.310 1895.840 ;
     END
   END r0_rd_out[116]
   PIN r0_rd_out[117]
@@ -3404,7 +3404,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 487.070 948.860 487.210 949.280 ;
+      RECT 971.450 1895.420 971.590 1895.840 ;
     END
   END r0_rd_out[117]
   PIN r0_rd_out[118]
@@ -3413,7 +3413,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 491.210 948.860 491.350 949.280 ;
+      RECT 979.730 1895.420 979.870 1895.840 ;
     END
   END r0_rd_out[118]
   PIN r0_rd_out[119]
@@ -3422,7 +3422,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 495.350 948.860 495.490 949.280 ;
+      RECT 988.010 1895.420 988.150 1895.840 ;
     END
   END r0_rd_out[119]
   PIN r0_rd_out[120]
@@ -3431,7 +3431,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 499.490 948.860 499.630 949.280 ;
+      RECT 996.290 1895.420 996.430 1895.840 ;
     END
   END r0_rd_out[120]
   PIN r0_rd_out[121]
@@ -3440,7 +3440,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 503.630 948.860 503.770 949.280 ;
+      RECT 1004.570 1895.420 1004.710 1895.840 ;
     END
   END r0_rd_out[121]
   PIN r0_rd_out[122]
@@ -3449,7 +3449,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 507.770 948.860 507.910 949.280 ;
+      RECT 1012.850 1895.420 1012.990 1895.840 ;
     END
   END r0_rd_out[122]
   PIN r0_rd_out[123]
@@ -3458,7 +3458,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 511.910 948.860 512.050 949.280 ;
+      RECT 1021.130 1895.420 1021.270 1895.840 ;
     END
   END r0_rd_out[123]
   PIN r0_rd_out[124]
@@ -3467,7 +3467,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 516.050 948.860 516.190 949.280 ;
+      RECT 1029.410 1895.420 1029.550 1895.840 ;
     END
   END r0_rd_out[124]
   PIN r0_rd_out[125]
@@ -3476,7 +3476,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 520.190 948.860 520.330 949.280 ;
+      RECT 1037.690 1895.420 1037.830 1895.840 ;
     END
   END r0_rd_out[125]
   PIN r0_rd_out[126]
@@ -3485,7 +3485,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 524.330 948.860 524.470 949.280 ;
+      RECT 1045.970 1895.420 1046.110 1895.840 ;
     END
   END r0_rd_out[126]
   PIN r0_rd_out[127]
@@ -3494,7 +3494,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 528.470 948.860 528.610 949.280 ;
+      RECT 1054.250 1895.420 1054.390 1895.840 ;
     END
   END r0_rd_out[127]
   PIN r0_rd_out[128]
@@ -3503,7 +3503,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 532.610 948.860 532.750 949.280 ;
+      RECT 1062.530 1895.420 1062.670 1895.840 ;
     END
   END r0_rd_out[128]
   PIN r0_rd_out[129]
@@ -3512,7 +3512,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 536.750 948.860 536.890 949.280 ;
+      RECT 1070.810 1895.420 1070.950 1895.840 ;
     END
   END r0_rd_out[129]
   PIN rw0_addr_in[0]
@@ -3521,7 +3521,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 766.890 0.900 767.190 ;
+      RECT 0.000 1484.970 0.900 1485.270 ;
     END
   END rw0_addr_in[0]
   PIN rw0_addr_in[1]
@@ -3530,7 +3530,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 790.010 0.900 790.310 ;
+      RECT 0.000 1529.850 0.900 1530.150 ;
     END
   END rw0_addr_in[1]
   PIN rw0_addr_in[2]
@@ -3539,7 +3539,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 813.130 0.900 813.430 ;
+      RECT 0.000 1574.730 0.900 1575.030 ;
     END
   END rw0_addr_in[2]
   PIN rw0_addr_in[3]
@@ -3548,7 +3548,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 836.250 0.900 836.550 ;
+      RECT 0.000 1619.610 0.900 1619.910 ;
     END
   END rw0_addr_in[3]
   PIN rw0_addr_in[4]
@@ -3557,7 +3557,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 743.770 591.560 744.070 ;
+      RECT 0.000 1664.490 0.900 1664.790 ;
     END
   END rw0_addr_in[4]
   PIN rw0_addr_in[5]
@@ -3566,7 +3566,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 766.890 591.560 767.190 ;
+      RECT 1181.760 1440.090 1182.660 1440.390 ;
     END
   END rw0_addr_in[5]
   PIN rw0_addr_in[6]
@@ -3575,16 +3575,34 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 790.010 591.560 790.310 ;
+      RECT 1181.760 1484.970 1182.660 1485.270 ;
     END
   END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 1181.760 1529.850 1182.660 1530.150 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 1181.760 1574.730 1182.660 1575.030 ;
+    END
+  END rw0_addr_in[8]
   PIN r0_addr_in[0]
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 859.370 0.900 859.670 ;
+      RECT 0.000 1709.370 0.900 1709.670 ;
     END
   END r0_addr_in[0]
   PIN r0_addr_in[1]
@@ -3593,7 +3611,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 882.490 0.900 882.790 ;
+      RECT 0.000 1754.250 0.900 1754.550 ;
     END
   END r0_addr_in[1]
   PIN r0_addr_in[2]
@@ -3602,7 +3620,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 905.610 0.900 905.910 ;
+      RECT 0.000 1799.130 0.900 1799.430 ;
     END
   END r0_addr_in[2]
   PIN r0_addr_in[3]
@@ -3611,7 +3629,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 0.000 928.730 0.900 929.030 ;
+      RECT 0.000 1844.010 0.900 1844.310 ;
     END
   END r0_addr_in[3]
   PIN r0_addr_in[4]
@@ -3620,7 +3638,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 813.130 591.560 813.430 ;
+      RECT 0.000 1888.890 0.900 1889.190 ;
     END
   END r0_addr_in[4]
   PIN r0_addr_in[5]
@@ -3629,7 +3647,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 836.250 591.560 836.550 ;
+      RECT 1181.760 1619.610 1182.660 1619.910 ;
     END
   END r0_addr_in[5]
   PIN r0_addr_in[6]
@@ -3638,16 +3656,34 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met3 ;
-      RECT 590.660 859.370 591.560 859.670 ;
+      RECT 1181.760 1664.490 1182.660 1664.790 ;
     END
   END r0_addr_in[6]
+  PIN r0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 1181.760 1709.370 1182.660 1709.670 ;
+    END
+  END r0_addr_in[7]
+  PIN r0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 1181.760 1754.250 1182.660 1754.550 ;
+    END
+  END r0_addr_in[8]
   PIN rw0_we_in
     DIRECTION INPUT ;
     USE SIGNAL ;
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 540.890 948.860 541.030 949.280 ;
+      RECT 1079.090 1895.420 1079.230 1895.840 ;
     END
   END rw0_we_in
   PIN rw0_ce_in
@@ -3656,7 +3692,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 545.030 948.860 545.170 949.280 ;
+      RECT 1087.370 1895.420 1087.510 1895.840 ;
     END
   END rw0_ce_in
   PIN rw0_clk
@@ -3665,7 +3701,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 549.170 948.860 549.310 949.280 ;
+      RECT 1095.650 1895.420 1095.790 1895.840 ;
     END
   END rw0_clk
   PIN r0_ce_in
@@ -3674,7 +3710,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 553.310 948.860 553.450 949.280 ;
+      RECT 1103.930 1895.420 1104.070 1895.840 ;
     END
   END r0_ce_in
   PIN r0_clk
@@ -3683,7 +3719,7 @@ MACRO fakeram130_1rw1r_130w128d
     SHAPE ABUTMENT ;
     PORT
       LAYER met2 ;
-      RECT 557.450 948.860 557.590 949.280 ;
+      RECT 1112.210 1895.420 1112.350 1895.840 ;
     END
   END r0_clk
   PIN VSS
@@ -3691,61 +3727,115 @@ MACRO fakeram130_1rw1r_130w128d
     USE GROUND ;
     PORT
       LAYER met4 ;
-      RECT 2.160 4.080 3.360 945.200 ;
-      RECT 13.040 4.080 14.240 945.200 ;
-      RECT 23.920 4.080 25.120 945.200 ;
-      RECT 34.800 4.080 36.000 945.200 ;
-      RECT 45.680 4.080 46.880 945.200 ;
-      RECT 56.560 4.080 57.760 945.200 ;
-      RECT 67.440 4.080 68.640 945.200 ;
-      RECT 78.320 4.080 79.520 945.200 ;
-      RECT 89.200 4.080 90.400 945.200 ;
-      RECT 100.080 4.080 101.280 945.200 ;
-      RECT 110.960 4.080 112.160 945.200 ;
-      RECT 121.840 4.080 123.040 945.200 ;
-      RECT 132.720 4.080 133.920 945.200 ;
-      RECT 143.600 4.080 144.800 945.200 ;
-      RECT 154.480 4.080 155.680 945.200 ;
-      RECT 165.360 4.080 166.560 945.200 ;
-      RECT 176.240 4.080 177.440 945.200 ;
-      RECT 187.120 4.080 188.320 945.200 ;
-      RECT 198.000 4.080 199.200 945.200 ;
-      RECT 208.880 4.080 210.080 945.200 ;
-      RECT 219.760 4.080 220.960 945.200 ;
-      RECT 230.640 4.080 231.840 945.200 ;
-      RECT 241.520 4.080 242.720 945.200 ;
-      RECT 252.400 4.080 253.600 945.200 ;
-      RECT 263.280 4.080 264.480 945.200 ;
-      RECT 274.160 4.080 275.360 945.200 ;
-      RECT 285.040 4.080 286.240 945.200 ;
-      RECT 295.920 4.080 297.120 945.200 ;
-      RECT 306.800 4.080 308.000 945.200 ;
-      RECT 317.680 4.080 318.880 945.200 ;
-      RECT 328.560 4.080 329.760 945.200 ;
-      RECT 339.440 4.080 340.640 945.200 ;
-      RECT 350.320 4.080 351.520 945.200 ;
-      RECT 361.200 4.080 362.400 945.200 ;
-      RECT 372.080 4.080 373.280 945.200 ;
-      RECT 382.960 4.080 384.160 945.200 ;
-      RECT 393.840 4.080 395.040 945.200 ;
-      RECT 404.720 4.080 405.920 945.200 ;
-      RECT 415.600 4.080 416.800 945.200 ;
-      RECT 426.480 4.080 427.680 945.200 ;
-      RECT 437.360 4.080 438.560 945.200 ;
-      RECT 448.240 4.080 449.440 945.200 ;
-      RECT 459.120 4.080 460.320 945.200 ;
-      RECT 470.000 4.080 471.200 945.200 ;
-      RECT 480.880 4.080 482.080 945.200 ;
-      RECT 491.760 4.080 492.960 945.200 ;
-      RECT 502.640 4.080 503.840 945.200 ;
-      RECT 513.520 4.080 514.720 945.200 ;
-      RECT 524.400 4.080 525.600 945.200 ;
-      RECT 535.280 4.080 536.480 945.200 ;
-      RECT 546.160 4.080 547.360 945.200 ;
-      RECT 557.040 4.080 558.240 945.200 ;
-      RECT 567.920 4.080 569.120 945.200 ;
-      RECT 578.800 4.080 580.000 945.200 ;
-      RECT 589.680 4.080 590.880 945.200 ;
+      RECT 2.160 4.080 3.360 1891.760 ;
+      RECT 13.040 4.080 14.240 1891.760 ;
+      RECT 23.920 4.080 25.120 1891.760 ;
+      RECT 34.800 4.080 36.000 1891.760 ;
+      RECT 45.680 4.080 46.880 1891.760 ;
+      RECT 56.560 4.080 57.760 1891.760 ;
+      RECT 67.440 4.080 68.640 1891.760 ;
+      RECT 78.320 4.080 79.520 1891.760 ;
+      RECT 89.200 4.080 90.400 1891.760 ;
+      RECT 100.080 4.080 101.280 1891.760 ;
+      RECT 110.960 4.080 112.160 1891.760 ;
+      RECT 121.840 4.080 123.040 1891.760 ;
+      RECT 132.720 4.080 133.920 1891.760 ;
+      RECT 143.600 4.080 144.800 1891.760 ;
+      RECT 154.480 4.080 155.680 1891.760 ;
+      RECT 165.360 4.080 166.560 1891.760 ;
+      RECT 176.240 4.080 177.440 1891.760 ;
+      RECT 187.120 4.080 188.320 1891.760 ;
+      RECT 198.000 4.080 199.200 1891.760 ;
+      RECT 208.880 4.080 210.080 1891.760 ;
+      RECT 219.760 4.080 220.960 1891.760 ;
+      RECT 230.640 4.080 231.840 1891.760 ;
+      RECT 241.520 4.080 242.720 1891.760 ;
+      RECT 252.400 4.080 253.600 1891.760 ;
+      RECT 263.280 4.080 264.480 1891.760 ;
+      RECT 274.160 4.080 275.360 1891.760 ;
+      RECT 285.040 4.080 286.240 1891.760 ;
+      RECT 295.920 4.080 297.120 1891.760 ;
+      RECT 306.800 4.080 308.000 1891.760 ;
+      RECT 317.680 4.080 318.880 1891.760 ;
+      RECT 328.560 4.080 329.760 1891.760 ;
+      RECT 339.440 4.080 340.640 1891.760 ;
+      RECT 350.320 4.080 351.520 1891.760 ;
+      RECT 361.200 4.080 362.400 1891.760 ;
+      RECT 372.080 4.080 373.280 1891.760 ;
+      RECT 382.960 4.080 384.160 1891.760 ;
+      RECT 393.840 4.080 395.040 1891.760 ;
+      RECT 404.720 4.080 405.920 1891.760 ;
+      RECT 415.600 4.080 416.800 1891.760 ;
+      RECT 426.480 4.080 427.680 1891.760 ;
+      RECT 437.360 4.080 438.560 1891.760 ;
+      RECT 448.240 4.080 449.440 1891.760 ;
+      RECT 459.120 4.080 460.320 1891.760 ;
+      RECT 470.000 4.080 471.200 1891.760 ;
+      RECT 480.880 4.080 482.080 1891.760 ;
+      RECT 491.760 4.080 492.960 1891.760 ;
+      RECT 502.640 4.080 503.840 1891.760 ;
+      RECT 513.520 4.080 514.720 1891.760 ;
+      RECT 524.400 4.080 525.600 1891.760 ;
+      RECT 535.280 4.080 536.480 1891.760 ;
+      RECT 546.160 4.080 547.360 1891.760 ;
+      RECT 557.040 4.080 558.240 1891.760 ;
+      RECT 567.920 4.080 569.120 1891.760 ;
+      RECT 578.800 4.080 580.000 1891.760 ;
+      RECT 589.680 4.080 590.880 1891.760 ;
+      RECT 600.560 4.080 601.760 1891.760 ;
+      RECT 611.440 4.080 612.640 1891.760 ;
+      RECT 622.320 4.080 623.520 1891.760 ;
+      RECT 633.200 4.080 634.400 1891.760 ;
+      RECT 644.080 4.080 645.280 1891.760 ;
+      RECT 654.960 4.080 656.160 1891.760 ;
+      RECT 665.840 4.080 667.040 1891.760 ;
+      RECT 676.720 4.080 677.920 1891.760 ;
+      RECT 687.600 4.080 688.800 1891.760 ;
+      RECT 698.480 4.080 699.680 1891.760 ;
+      RECT 709.360 4.080 710.560 1891.760 ;
+      RECT 720.240 4.080 721.440 1891.760 ;
+      RECT 731.120 4.080 732.320 1891.760 ;
+      RECT 742.000 4.080 743.200 1891.760 ;
+      RECT 752.880 4.080 754.080 1891.760 ;
+      RECT 763.760 4.080 764.960 1891.760 ;
+      RECT 774.640 4.080 775.840 1891.760 ;
+      RECT 785.520 4.080 786.720 1891.760 ;
+      RECT 796.400 4.080 797.600 1891.760 ;
+      RECT 807.280 4.080 808.480 1891.760 ;
+      RECT 818.160 4.080 819.360 1891.760 ;
+      RECT 829.040 4.080 830.240 1891.760 ;
+      RECT 839.920 4.080 841.120 1891.760 ;
+      RECT 850.800 4.080 852.000 1891.760 ;
+      RECT 861.680 4.080 862.880 1891.760 ;
+      RECT 872.560 4.080 873.760 1891.760 ;
+      RECT 883.440 4.080 884.640 1891.760 ;
+      RECT 894.320 4.080 895.520 1891.760 ;
+      RECT 905.200 4.080 906.400 1891.760 ;
+      RECT 916.080 4.080 917.280 1891.760 ;
+      RECT 926.960 4.080 928.160 1891.760 ;
+      RECT 937.840 4.080 939.040 1891.760 ;
+      RECT 948.720 4.080 949.920 1891.760 ;
+      RECT 959.600 4.080 960.800 1891.760 ;
+      RECT 970.480 4.080 971.680 1891.760 ;
+      RECT 981.360 4.080 982.560 1891.760 ;
+      RECT 992.240 4.080 993.440 1891.760 ;
+      RECT 1003.120 4.080 1004.320 1891.760 ;
+      RECT 1014.000 4.080 1015.200 1891.760 ;
+      RECT 1024.880 4.080 1026.080 1891.760 ;
+      RECT 1035.760 4.080 1036.960 1891.760 ;
+      RECT 1046.640 4.080 1047.840 1891.760 ;
+      RECT 1057.520 4.080 1058.720 1891.760 ;
+      RECT 1068.400 4.080 1069.600 1891.760 ;
+      RECT 1079.280 4.080 1080.480 1891.760 ;
+      RECT 1090.160 4.080 1091.360 1891.760 ;
+      RECT 1101.040 4.080 1102.240 1891.760 ;
+      RECT 1111.920 4.080 1113.120 1891.760 ;
+      RECT 1122.800 4.080 1124.000 1891.760 ;
+      RECT 1133.680 4.080 1134.880 1891.760 ;
+      RECT 1144.560 4.080 1145.760 1891.760 ;
+      RECT 1155.440 4.080 1156.640 1891.760 ;
+      RECT 1166.320 4.080 1167.520 1891.760 ;
+      RECT 1177.200 4.080 1178.400 1891.760 ;
     END
   END VSS
   PIN VDD
@@ -3753,73 +3843,127 @@ MACRO fakeram130_1rw1r_130w128d
     USE POWER ;
     PORT
       LAYER met4 ;
-      RECT 2.160 4.080 3.360 945.200 ;
-      RECT 13.040 4.080 14.240 945.200 ;
-      RECT 23.920 4.080 25.120 945.200 ;
-      RECT 34.800 4.080 36.000 945.200 ;
-      RECT 45.680 4.080 46.880 945.200 ;
-      RECT 56.560 4.080 57.760 945.200 ;
-      RECT 67.440 4.080 68.640 945.200 ;
-      RECT 78.320 4.080 79.520 945.200 ;
-      RECT 89.200 4.080 90.400 945.200 ;
-      RECT 100.080 4.080 101.280 945.200 ;
-      RECT 110.960 4.080 112.160 945.200 ;
-      RECT 121.840 4.080 123.040 945.200 ;
-      RECT 132.720 4.080 133.920 945.200 ;
-      RECT 143.600 4.080 144.800 945.200 ;
-      RECT 154.480 4.080 155.680 945.200 ;
-      RECT 165.360 4.080 166.560 945.200 ;
-      RECT 176.240 4.080 177.440 945.200 ;
-      RECT 187.120 4.080 188.320 945.200 ;
-      RECT 198.000 4.080 199.200 945.200 ;
-      RECT 208.880 4.080 210.080 945.200 ;
-      RECT 219.760 4.080 220.960 945.200 ;
-      RECT 230.640 4.080 231.840 945.200 ;
-      RECT 241.520 4.080 242.720 945.200 ;
-      RECT 252.400 4.080 253.600 945.200 ;
-      RECT 263.280 4.080 264.480 945.200 ;
-      RECT 274.160 4.080 275.360 945.200 ;
-      RECT 285.040 4.080 286.240 945.200 ;
-      RECT 295.920 4.080 297.120 945.200 ;
-      RECT 306.800 4.080 308.000 945.200 ;
-      RECT 317.680 4.080 318.880 945.200 ;
-      RECT 328.560 4.080 329.760 945.200 ;
-      RECT 339.440 4.080 340.640 945.200 ;
-      RECT 350.320 4.080 351.520 945.200 ;
-      RECT 361.200 4.080 362.400 945.200 ;
-      RECT 372.080 4.080 373.280 945.200 ;
-      RECT 382.960 4.080 384.160 945.200 ;
-      RECT 393.840 4.080 395.040 945.200 ;
-      RECT 404.720 4.080 405.920 945.200 ;
-      RECT 415.600 4.080 416.800 945.200 ;
-      RECT 426.480 4.080 427.680 945.200 ;
-      RECT 437.360 4.080 438.560 945.200 ;
-      RECT 448.240 4.080 449.440 945.200 ;
-      RECT 459.120 4.080 460.320 945.200 ;
-      RECT 470.000 4.080 471.200 945.200 ;
-      RECT 480.880 4.080 482.080 945.200 ;
-      RECT 491.760 4.080 492.960 945.200 ;
-      RECT 502.640 4.080 503.840 945.200 ;
-      RECT 513.520 4.080 514.720 945.200 ;
-      RECT 524.400 4.080 525.600 945.200 ;
-      RECT 535.280 4.080 536.480 945.200 ;
-      RECT 546.160 4.080 547.360 945.200 ;
-      RECT 557.040 4.080 558.240 945.200 ;
-      RECT 567.920 4.080 569.120 945.200 ;
-      RECT 578.800 4.080 580.000 945.200 ;
-      RECT 589.680 4.080 590.880 945.200 ;
+      RECT 2.160 4.080 3.360 1891.760 ;
+      RECT 13.040 4.080 14.240 1891.760 ;
+      RECT 23.920 4.080 25.120 1891.760 ;
+      RECT 34.800 4.080 36.000 1891.760 ;
+      RECT 45.680 4.080 46.880 1891.760 ;
+      RECT 56.560 4.080 57.760 1891.760 ;
+      RECT 67.440 4.080 68.640 1891.760 ;
+      RECT 78.320 4.080 79.520 1891.760 ;
+      RECT 89.200 4.080 90.400 1891.760 ;
+      RECT 100.080 4.080 101.280 1891.760 ;
+      RECT 110.960 4.080 112.160 1891.760 ;
+      RECT 121.840 4.080 123.040 1891.760 ;
+      RECT 132.720 4.080 133.920 1891.760 ;
+      RECT 143.600 4.080 144.800 1891.760 ;
+      RECT 154.480 4.080 155.680 1891.760 ;
+      RECT 165.360 4.080 166.560 1891.760 ;
+      RECT 176.240 4.080 177.440 1891.760 ;
+      RECT 187.120 4.080 188.320 1891.760 ;
+      RECT 198.000 4.080 199.200 1891.760 ;
+      RECT 208.880 4.080 210.080 1891.760 ;
+      RECT 219.760 4.080 220.960 1891.760 ;
+      RECT 230.640 4.080 231.840 1891.760 ;
+      RECT 241.520 4.080 242.720 1891.760 ;
+      RECT 252.400 4.080 253.600 1891.760 ;
+      RECT 263.280 4.080 264.480 1891.760 ;
+      RECT 274.160 4.080 275.360 1891.760 ;
+      RECT 285.040 4.080 286.240 1891.760 ;
+      RECT 295.920 4.080 297.120 1891.760 ;
+      RECT 306.800 4.080 308.000 1891.760 ;
+      RECT 317.680 4.080 318.880 1891.760 ;
+      RECT 328.560 4.080 329.760 1891.760 ;
+      RECT 339.440 4.080 340.640 1891.760 ;
+      RECT 350.320 4.080 351.520 1891.760 ;
+      RECT 361.200 4.080 362.400 1891.760 ;
+      RECT 372.080 4.080 373.280 1891.760 ;
+      RECT 382.960 4.080 384.160 1891.760 ;
+      RECT 393.840 4.080 395.040 1891.760 ;
+      RECT 404.720 4.080 405.920 1891.760 ;
+      RECT 415.600 4.080 416.800 1891.760 ;
+      RECT 426.480 4.080 427.680 1891.760 ;
+      RECT 437.360 4.080 438.560 1891.760 ;
+      RECT 448.240 4.080 449.440 1891.760 ;
+      RECT 459.120 4.080 460.320 1891.760 ;
+      RECT 470.000 4.080 471.200 1891.760 ;
+      RECT 480.880 4.080 482.080 1891.760 ;
+      RECT 491.760 4.080 492.960 1891.760 ;
+      RECT 502.640 4.080 503.840 1891.760 ;
+      RECT 513.520 4.080 514.720 1891.760 ;
+      RECT 524.400 4.080 525.600 1891.760 ;
+      RECT 535.280 4.080 536.480 1891.760 ;
+      RECT 546.160 4.080 547.360 1891.760 ;
+      RECT 557.040 4.080 558.240 1891.760 ;
+      RECT 567.920 4.080 569.120 1891.760 ;
+      RECT 578.800 4.080 580.000 1891.760 ;
+      RECT 589.680 4.080 590.880 1891.760 ;
+      RECT 600.560 4.080 601.760 1891.760 ;
+      RECT 611.440 4.080 612.640 1891.760 ;
+      RECT 622.320 4.080 623.520 1891.760 ;
+      RECT 633.200 4.080 634.400 1891.760 ;
+      RECT 644.080 4.080 645.280 1891.760 ;
+      RECT 654.960 4.080 656.160 1891.760 ;
+      RECT 665.840 4.080 667.040 1891.760 ;
+      RECT 676.720 4.080 677.920 1891.760 ;
+      RECT 687.600 4.080 688.800 1891.760 ;
+      RECT 698.480 4.080 699.680 1891.760 ;
+      RECT 709.360 4.080 710.560 1891.760 ;
+      RECT 720.240 4.080 721.440 1891.760 ;
+      RECT 731.120 4.080 732.320 1891.760 ;
+      RECT 742.000 4.080 743.200 1891.760 ;
+      RECT 752.880 4.080 754.080 1891.760 ;
+      RECT 763.760 4.080 764.960 1891.760 ;
+      RECT 774.640 4.080 775.840 1891.760 ;
+      RECT 785.520 4.080 786.720 1891.760 ;
+      RECT 796.400 4.080 797.600 1891.760 ;
+      RECT 807.280 4.080 808.480 1891.760 ;
+      RECT 818.160 4.080 819.360 1891.760 ;
+      RECT 829.040 4.080 830.240 1891.760 ;
+      RECT 839.920 4.080 841.120 1891.760 ;
+      RECT 850.800 4.080 852.000 1891.760 ;
+      RECT 861.680 4.080 862.880 1891.760 ;
+      RECT 872.560 4.080 873.760 1891.760 ;
+      RECT 883.440 4.080 884.640 1891.760 ;
+      RECT 894.320 4.080 895.520 1891.760 ;
+      RECT 905.200 4.080 906.400 1891.760 ;
+      RECT 916.080 4.080 917.280 1891.760 ;
+      RECT 926.960 4.080 928.160 1891.760 ;
+      RECT 937.840 4.080 939.040 1891.760 ;
+      RECT 948.720 4.080 949.920 1891.760 ;
+      RECT 959.600 4.080 960.800 1891.760 ;
+      RECT 970.480 4.080 971.680 1891.760 ;
+      RECT 981.360 4.080 982.560 1891.760 ;
+      RECT 992.240 4.080 993.440 1891.760 ;
+      RECT 1003.120 4.080 1004.320 1891.760 ;
+      RECT 1014.000 4.080 1015.200 1891.760 ;
+      RECT 1024.880 4.080 1026.080 1891.760 ;
+      RECT 1035.760 4.080 1036.960 1891.760 ;
+      RECT 1046.640 4.080 1047.840 1891.760 ;
+      RECT 1057.520 4.080 1058.720 1891.760 ;
+      RECT 1068.400 4.080 1069.600 1891.760 ;
+      RECT 1079.280 4.080 1080.480 1891.760 ;
+      RECT 1090.160 4.080 1091.360 1891.760 ;
+      RECT 1101.040 4.080 1102.240 1891.760 ;
+      RECT 1111.920 4.080 1113.120 1891.760 ;
+      RECT 1122.800 4.080 1124.000 1891.760 ;
+      RECT 1133.680 4.080 1134.880 1891.760 ;
+      RECT 1144.560 4.080 1145.760 1891.760 ;
+      RECT 1155.440 4.080 1156.640 1891.760 ;
+      RECT 1166.320 4.080 1167.520 1891.760 ;
+      RECT 1177.200 4.080 1178.400 1891.760 ;
     END
   END VDD
   OBS
     LAYER met1 ;
-    RECT 0 0 591.560 949.280 ;
+    RECT 0 0 1182.660 1895.840 ;
     LAYER met2 ;
-    RECT 0 0 591.560 949.280 ;
+    RECT 0 0 1182.660 1895.840 ;
     LAYER met3 ;
-    RECT 0 0 591.560 949.280 ;
+    RECT 0 0 1182.660 1895.840 ;
     LAYER met4 ;
-    RECT 0 0 591.560 949.280 ;
+    RECT 0 0 1182.660 1895.840 ;
   END
-END fakeram130_1rw1r_130w128d
+END fakeram_1rw1r_130w512d_sram
 
 END LIBRARY

--- a/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_230w128d_sram.lef
+++ b/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_230w128d_sram.lef
@@ -1,7 +1,7 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram130_1rw1r_230w128d
-  FOREIGN fakeram130_1rw1r_230w128d 0 0 ;
+MACRO fakeram_1rw1r_230w128d_sram
+  FOREIGN fakeram_1rw1r_230w128d_sram 0 0 ;
   SYMMETRY X Y R90 ;
   SIZE 1046.040 BY 949.280 ;
   CLASS BLOCK ;
@@ -6602,6 +6602,6 @@ MACRO fakeram130_1rw1r_230w128d
     LAYER met4 ;
     RECT 0 0 1046.040 949.280 ;
   END
-END fakeram130_1rw1r_230w128d
+END fakeram_1rw1r_230w128d_sram
 
 END LIBRARY

--- a/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_92w256d_sram.lef
+++ b/designs/sky130hd/litepci/sram/lef/fakeram_1rw1r_92w256d_sram.lef
@@ -1,7 +1,7 @@
 VERSION 5.7 ;
 BUSBITCHARS "[]" ;
-MACRO fakeram130_1rw1r_92w256d
-  FOREIGN fakeram130_1rw1r_92w256d 0 0 ;
+MACRO fakeram_1rw1r_92w256d_sram
+  FOREIGN fakeram_1rw1r_92w256d_sram 0 0 ;
   SYMMETRY X Y R90 ;
   SIZE 837.200 BY 949.280 ;
   CLASS BLOCK ;
@@ -2856,6 +2856,6 @@ MACRO fakeram130_1rw1r_92w256d
     LAYER met4 ;
     RECT 0 0 837.200 949.280 ;
   END
-END fakeram130_1rw1r_92w256d
+END fakeram_1rw1r_92w256d_sram
 
 END LIBRARY

--- a/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_130w1024d_sram.lib
+++ b/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_130w1024d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram130_1rw1r_130w512d) {
+library(fakeram_1rw1r_130w1024d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:51Z";
+    date : "2026-05-19 17:28:17Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,32 +46,32 @@ library(fakeram130_1rw1r_130w512d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram130_1rw1r_130w512d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_130w512d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_130w512d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_130w1024d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_130w512d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram130_1rw1r_130w512d_DATA) {
+    type (fakeram_1rw1r_130w1024d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
         bit_width : 130;
@@ -79,20 +79,20 @@ library(fakeram130_1rw1r_130w512d) {
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram130_1rw1r_130w512d_ADDRESS) {
+    type (fakeram_1rw1r_130w1024d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 9;
-        bit_from : 8;
+        bit_width : 10;
+        bit_from : 9;
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram130_1rw1r_130w512d) {
-    area : 2242134.134;
+cell(fakeram_1rw1r_130w1024d_sram) {
+    area : 4483396.182;
     interface_timing : true;
     memory() {
         type : ram;
-        address_width : 9;
+        address_width : 10;
         word_width : 130;
     }
     pin(r0_clk)   {
@@ -101,11 +101,11 @@ cell(fakeram130_1rw1r_130w512d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -118,11 +118,11 @@ cell(fakeram130_1rw1r_130w512d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -130,7 +130,7 @@ cell(fakeram130_1rw1r_130w512d) {
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram130_1rw1r_130w512d_DATA;
+        bus_type : fakeram_1rw1r_130w1024d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,7 +140,7 @@ cell(fakeram130_1rw1r_130w512d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_130w512d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -148,7 +148,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_130w512d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -156,18 +156,18 @@ cell(fakeram130_1rw1r_130w512d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_130w512d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_130w512d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram130_1rw1r_130w512d_DATA;
+        bus_type : fakeram_1rw1r_130w1024d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,7 +177,7 @@ cell(fakeram130_1rw1r_130w512d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_130w512d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -185,7 +185,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_130w512d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w1024d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -193,11 +193,11 @@ cell(fakeram130_1rw1r_130w512d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_130w512d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_130w512d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w1024d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
@@ -209,7 +209,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -247,11 +247,11 @@ cell(fakeram130_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -263,7 +263,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -301,11 +301,11 @@ cell(fakeram130_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -317,7 +317,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram130_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram130_1rw1r_130w512d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w1024d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram130_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram130_1rw1r_130w512d_DATA;
+        bus_type : fakeram_1rw1r_130w1024d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram130_1rw1r_130w512d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram130_1rw1r_130w512d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w1024d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram130_1rw1r_130w512d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram130_1rw1r_130w512d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w512d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w1024d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -536,11 +536,11 @@ cell(fakeram130_1rw1r_130w512d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w512d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w1024d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }

--- a/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_130w128d_sram.lib
+++ b/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_130w128d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram130_1rw1r_130w128d) {
+library(fakeram_1rw1r_130w128d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:51Z";
+    date : "2026-05-19 17:28:17Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,32 +46,32 @@ library(fakeram130_1rw1r_130w128d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram130_1rw1r_130w128d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_130w128d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_130w128d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_130w128d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_130w128d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram130_1rw1r_130w128d_DATA) {
+    type (fakeram_1rw1r_130w128d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
         bit_width : 130;
@@ -79,7 +79,7 @@ library(fakeram130_1rw1r_130w128d) {
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram130_1rw1r_130w128d_ADDRESS) {
+    type (fakeram_1rw1r_130w128d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
         bit_width : 7;
@@ -87,7 +87,7 @@ library(fakeram130_1rw1r_130w128d) {
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram130_1rw1r_130w128d) {
+cell(fakeram_1rw1r_130w128d_sram) {
     area : 561556.077;
     interface_timing : true;
     memory() {
@@ -101,11 +101,11 @@ cell(fakeram130_1rw1r_130w128d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -118,11 +118,11 @@ cell(fakeram130_1rw1r_130w128d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -130,7 +130,7 @@ cell(fakeram130_1rw1r_130w128d) {
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram130_1rw1r_130w128d_DATA;
+        bus_type : fakeram_1rw1r_130w128d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,7 +140,7 @@ cell(fakeram130_1rw1r_130w128d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_130w128d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -148,7 +148,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_130w128d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -156,18 +156,18 @@ cell(fakeram130_1rw1r_130w128d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_130w128d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_130w128d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram130_1rw1r_130w128d_DATA;
+        bus_type : fakeram_1rw1r_130w128d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,7 +177,7 @@ cell(fakeram130_1rw1r_130w128d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_130w128d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -185,7 +185,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_130w128d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w128d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -193,11 +193,11 @@ cell(fakeram130_1rw1r_130w128d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_130w128d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_130w128d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
@@ -209,7 +209,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -247,11 +247,11 @@ cell(fakeram130_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -263,7 +263,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -301,11 +301,11 @@ cell(fakeram130_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -317,7 +317,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram130_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram130_1rw1r_130w128d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w128d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram130_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram130_1rw1r_130w128d_DATA;
+        bus_type : fakeram_1rw1r_130w128d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram130_1rw1r_130w128d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram130_1rw1r_130w128d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w128d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram130_1rw1r_130w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram130_1rw1r_130w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -536,11 +536,11 @@ cell(fakeram130_1rw1r_130w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }

--- a/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_130w512d_sram.lib
+++ b/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_130w512d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram130_1rw1r_92w256d) {
+library(fakeram_1rw1r_130w512d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:51Z";
+    date : "2026-05-19 17:28:17Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,54 +46,54 @@ library(fakeram130_1rw1r_92w256d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram130_1rw1r_92w256d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_92w256d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_92w256d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_130w512d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_92w256d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram130_1rw1r_92w256d_DATA) {
+    type (fakeram_1rw1r_130w512d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 92;
-        bit_from : 91;
+        bit_width : 130;
+        bit_from : 129;
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram130_1rw1r_92w256d_ADDRESS) {
+    type (fakeram_1rw1r_130w512d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 8;
-        bit_from : 7;
+        bit_width : 9;
+        bit_from : 8;
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram130_1rw1r_92w256d) {
-    area : 794737.216;
+cell(fakeram_1rw1r_130w512d_sram) {
+    area : 2242134.134;
     interface_timing : true;
     memory() {
         type : ram;
-        address_width : 8;
-        word_width : 92;
+        address_width : 9;
+        word_width : 130;
     }
     pin(r0_clk)   {
         direction : input;
@@ -101,11 +101,11 @@ cell(fakeram130_1rw1r_92w256d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -118,11 +118,11 @@ cell(fakeram130_1rw1r_92w256d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -130,7 +130,7 @@ cell(fakeram130_1rw1r_92w256d) {
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram130_1rw1r_92w256d_DATA;
+        bus_type : fakeram_1rw1r_130w512d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,7 +140,7 @@ cell(fakeram130_1rw1r_92w256d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_92w256d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -148,7 +148,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_92w256d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -156,18 +156,18 @@ cell(fakeram130_1rw1r_92w256d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_92w256d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_92w256d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram130_1rw1r_92w256d_DATA;
+        bus_type : fakeram_1rw1r_130w512d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,7 +177,7 @@ cell(fakeram130_1rw1r_92w256d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_92w256d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -185,7 +185,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_92w256d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_130w512d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -193,11 +193,11 @@ cell(fakeram130_1rw1r_92w256d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_92w256d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_92w256d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_130w512d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
@@ -209,7 +209,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -247,11 +247,11 @@ cell(fakeram130_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -263,7 +263,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -301,11 +301,11 @@ cell(fakeram130_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -317,7 +317,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram130_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram130_1rw1r_92w256d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w512d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram130_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram130_1rw1r_92w256d_DATA;
+        bus_type : fakeram_1rw1r_130w512d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram130_1rw1r_92w256d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram130_1rw1r_92w256d_ADDRESS;
+        bus_type : fakeram_1rw1r_130w512d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram130_1rw1r_92w256d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram130_1rw1r_92w256d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_92w256d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_130w512d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -536,11 +536,11 @@ cell(fakeram130_1rw1r_92w256d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_92w256d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_130w512d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }

--- a/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_230w128d_sram.lib
+++ b/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_230w128d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram130_1rw1r_230w128d) {
+library(fakeram_1rw1r_230w128d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:51Z";
+    date : "2026-05-19 17:28:17Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,32 +46,32 @@ library(fakeram130_1rw1r_230w128d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram130_1rw1r_230w128d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_230w128d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_230w128d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_230w128d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_230w128d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram130_1rw1r_230w128d_DATA) {
+    type (fakeram_1rw1r_230w128d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
         bit_width : 230;
@@ -79,7 +79,7 @@ library(fakeram130_1rw1r_230w128d) {
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram130_1rw1r_230w128d_ADDRESS) {
+    type (fakeram_1rw1r_230w128d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
         bit_width : 7;
@@ -87,7 +87,7 @@ library(fakeram130_1rw1r_230w128d) {
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram130_1rw1r_230w128d) {
+cell(fakeram_1rw1r_230w128d_sram) {
     area : 992984.851;
     interface_timing : true;
     memory() {
@@ -101,11 +101,11 @@ cell(fakeram130_1rw1r_230w128d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -118,11 +118,11 @@ cell(fakeram130_1rw1r_230w128d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -130,7 +130,7 @@ cell(fakeram130_1rw1r_230w128d) {
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram130_1rw1r_230w128d_DATA;
+        bus_type : fakeram_1rw1r_230w128d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,7 +140,7 @@ cell(fakeram130_1rw1r_230w128d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_230w128d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -148,7 +148,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_230w128d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -156,18 +156,18 @@ cell(fakeram130_1rw1r_230w128d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_230w128d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_230w128d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram130_1rw1r_230w128d_DATA;
+        bus_type : fakeram_1rw1r_230w128d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,7 +177,7 @@ cell(fakeram130_1rw1r_230w128d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_230w128d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -185,7 +185,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_230w128d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_230w128d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -193,11 +193,11 @@ cell(fakeram130_1rw1r_230w128d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_230w128d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_230w128d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_230w128d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
@@ -209,7 +209,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -247,11 +247,11 @@ cell(fakeram130_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -263,7 +263,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -301,11 +301,11 @@ cell(fakeram130_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -317,7 +317,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram130_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram130_1rw1r_230w128d_ADDRESS;
+        bus_type : fakeram_1rw1r_230w128d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram130_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram130_1rw1r_230w128d_DATA;
+        bus_type : fakeram_1rw1r_230w128d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram130_1rw1r_230w128d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram130_1rw1r_230w128d_ADDRESS;
+        bus_type : fakeram_1rw1r_230w128d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram130_1rw1r_230w128d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram130_1rw1r_230w128d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_230w128d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_230w128d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -536,11 +536,11 @@ cell(fakeram130_1rw1r_230w128d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_230w128d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_230w128d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }

--- a/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_92w256d_sram.lib
+++ b/designs/sky130hd/litepci/sram/lib/fakeram_1rw1r_92w256d_sram.lib
@@ -1,8 +1,8 @@
-library(fakeram130_1rw1r_130w1024d) {
+library(fakeram_1rw1r_92w256d_sram) {
     technology (cmos);
     delay_model : table_lookup;
     revision : 1.0;
-    date : "2026-05-15 13:21:51Z";
+    date : "2026-05-19 17:28:17Z";
     comment : "SRAM";
     time_unit : "1ns";
     voltage_unit : "1V";
@@ -46,54 +46,54 @@ library(fakeram130_1rw1r_130w1024d) {
     output_threshold_pct_rise : 50.000;
 
 
-    lu_table_template(fakeram130_1rw1r_130w1024d_mem_out_delay_template) {
+    lu_table_template(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
         variable_1 : input_net_transition;
         variable_2 : total_output_net_capacitance;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_130w1024d_mem_out_slew_template) {
+    lu_table_template(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
         variable_1 : total_output_net_capacitance;
             index_1 ("1000, 1001");
     }
-    lu_table_template(fakeram130_1rw1r_130w1024d_constraint_template) {
+    lu_table_template(fakeram_1rw1r_92w256d_sram_constraint_template) {
         variable_1 : related_pin_transition;
         variable_2 : constrained_pin_transition;
             index_1 ("1000, 1001");
             index_2 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_130w1024d_energy_template_clkslew) {
+    power_lut_template(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
-    power_lut_template(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+    power_lut_template(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
         variable_1 : input_transition_time;
             index_1 ("1000, 1001");
     }
     library_features(report_delay_calculation);
-    type (fakeram130_1rw1r_130w1024d_DATA) {
+    type (fakeram_1rw1r_92w256d_sram_DATA) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 130;
-        bit_from : 129;
+        bit_width : 92;
+        bit_from : 91;
         bit_to : 0 ;
         downto : true ;
     }
-    type (fakeram130_1rw1r_130w1024d_ADDRESS) {
+    type (fakeram_1rw1r_92w256d_sram_ADDRESS) {
         base_type : array ;
         data_type : bit ;
-        bit_width : 10;
-        bit_from : 9;
+        bit_width : 8;
+        bit_from : 7;
         bit_to : 0 ;
         downto : true ;
     }
-cell(fakeram130_1rw1r_130w1024d) {
-    area : 4483396.182;
+cell(fakeram_1rw1r_92w256d_sram) {
+    area : 794737.216;
     interface_timing : true;
     memory() {
         type : ram;
-        address_width : 10;
-        word_width : 130;
+        address_width : 8;
+        word_width : 92;
     }
     pin(r0_clk)   {
         direction : input;
@@ -101,11 +101,11 @@ cell(fakeram130_1rw1r_130w1024d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -118,11 +118,11 @@ cell(fakeram130_1rw1r_130w1024d) {
         clock : true;
         min_period           : 1.000 ;
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_clkslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_clkslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_clkslew) {
                 index_1 ("0.200, 5.000");
                 values ("15.000, 15.000")
             }
@@ -130,7 +130,7 @@ cell(fakeram130_1rw1r_130w1024d) {
     }
 
     bus(rw0_rd_out)   {
-        bus_type : fakeram130_1rw1r_130w1024d_DATA;
+        bus_type : fakeram_1rw1r_92w256d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -140,7 +140,7 @@ cell(fakeram130_1rw1r_130w1024d) {
             related_pin : "rw0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_130w1024d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -148,7 +148,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_130w1024d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -156,18 +156,18 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_130w1024d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_130w1024d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
         }
     }
     bus(r0_rd_out)   {
-        bus_type : fakeram130_1rw1r_130w1024d_DATA;
+        bus_type : fakeram_1rw1r_92w256d_sram_DATA;
         direction : output;
         max_capacitance : 0.500;
         memory_read() {
@@ -177,7 +177,7 @@ cell(fakeram130_1rw1r_130w1024d) {
             related_pin : "r0_clk" ;
             timing_type : rising_edge;
             timing_sense : non_unate;
-            cell_rise(fakeram130_1rw1r_130w1024d_mem_out_delay_template) {
+            cell_rise(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -185,7 +185,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "1.400, 1.400" \
                 )
             }
-            cell_fall(fakeram130_1rw1r_130w1024d_mem_out_delay_template) {
+            cell_fall(fakeram_1rw1r_92w256d_sram_mem_out_delay_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.005, 0.500");
                 values ( \
@@ -193,11 +193,11 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "1.400, 1.400" \
                 )
             }
-            rise_transition(fakeram130_1rw1r_130w1024d_mem_out_slew_template) {
+            rise_transition(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
-            fall_transition(fakeram130_1rw1r_130w1024d_mem_out_slew_template) {
+            fall_transition(fakeram_1rw1r_92w256d_sram_mem_out_slew_template) {
                 index_1 ("0.005, 0.500");
                 values ("0.200, 5.000")
             }
@@ -209,7 +209,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -217,7 +217,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -229,7 +229,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -237,7 +237,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -247,11 +247,11 @@ cell(fakeram130_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -263,7 +263,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -271,7 +271,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -283,7 +283,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -291,7 +291,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -301,11 +301,11 @@ cell(fakeram130_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
@@ -317,7 +317,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -325,7 +325,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -337,7 +337,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -345,7 +345,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -355,24 +355,24 @@ cell(fakeram130_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_addr_in)   {
-        bus_type : fakeram130_1rw1r_130w1024d_ADDRESS;
+        bus_type : fakeram_1rw1r_92w256d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : rw0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -380,7 +380,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -392,7 +392,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin : rw0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -400,7 +400,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -410,18 +410,18 @@ cell(fakeram130_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(rw0_wd_in)   {
-        bus_type : fakeram130_1rw1r_130w1024d_DATA;
+        bus_type : fakeram_1rw1r_92w256d_sram_DATA;
         memory_write() {
             address : rw0_addr_in;
             clocked_on : "rw0_clk";
@@ -431,7 +431,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -439,7 +439,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -451,7 +451,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin     : rw0_clk;
             timing_type     : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -459,7 +459,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -470,35 +470,35 @@ cell(fakeram130_1rw1r_130w1024d) {
         }
         internal_power(){
             when : "(! (rw0_we_in) )";
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
         internal_power(){
             when : "(rw0_we_in)";
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
         }
     }
     bus(r0_addr_in)   {
-        bus_type : fakeram130_1rw1r_130w1024d_ADDRESS;
+        bus_type : fakeram_1rw1r_92w256d_sram_ADDRESS;
         direction : input;
         capacitance : 0.005;
         timing() {
             related_pin : r0_clk;
             timing_type : setup_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -506,7 +506,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -518,7 +518,7 @@ cell(fakeram130_1rw1r_130w1024d) {
         timing() {
             related_pin : r0_clk;
             timing_type : hold_rising ;
-            rise_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            rise_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -526,7 +526,7 @@ cell(fakeram130_1rw1r_130w1024d) {
                   "0.050, 0.050" \
                 )
             }
-            fall_constraint(fakeram130_1rw1r_130w1024d_constraint_template) {
+            fall_constraint(fakeram_1rw1r_92w256d_sram_constraint_template) {
                 index_1 ("0.200, 5.000");
                 index_2 ("0.200, 5.000");
                 values ( \
@@ -536,11 +536,11 @@ cell(fakeram130_1rw1r_130w1024d) {
             }
         }
         internal_power(){
-            rise_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            rise_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }
-            fall_power(fakeram130_1rw1r_130w1024d_energy_template_sigslew) {
+            fall_power(fakeram_1rw1r_92w256d_sram_energy_template_sigslew) {
                 index_1 ("0.200, 5.000");
                 values ("0.150, 0.150")
             }

--- a/designs/src/litepci/dev/generated/fakeram_sky130hd.cfg
+++ b/designs/src/litepci/dev/generated/fakeram_sky130hd.cfg
@@ -11,10 +11,10 @@
   "flipPins": true,
 
   "srams": [
-    { "name": "fakeram130_1rw1r_92w256d",  "width":  92, "depth":  256, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
-    { "name": "fakeram130_1rw1r_130w128d", "width": 130, "depth":  128, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
-    { "name": "fakeram130_1rw1r_130w512d", "width": 130, "depth":  512, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
-    { "name": "fakeram130_1rw1r_130w1024d","width": 130, "depth": 1024, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
-    { "name": "fakeram130_1rw1r_230w128d", "width": 230, "depth":  128, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} }
+    { "name": "fakeram_1rw1r_92w256d_sram",  "width":  92, "depth":  256, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
+    { "name": "fakeram_1rw1r_130w128d_sram", "width": 130, "depth":  128, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
+    { "name": "fakeram_1rw1r_130w512d_sram", "width": 130, "depth":  512, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
+    { "name": "fakeram_1rw1r_130w1024d_sram","width": 130, "depth": 1024, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} },
+    { "name": "fakeram_1rw1r_230w128d_sram", "width": 230, "depth":  128, "banks": 1, "no_wmask": "true", "ports": {"r": 1, "w": 0, "rw": 1} }
   ]
 }


### PR DESCRIPTION
## Summary

Closes sky130hd/litepci, which was previously failing in global routing on main. Same spreading lever as PR #165 (sky130hd NVDLA partitions) and the longstanding sky130hd/cnn config, scaled for litepci's macro-pin density.

## Problem

`sky130hd/litepci` on main fails GRT with:
```
[WARNING GRT-0281] Net rst has a large fanout of 3211 terminals.
Error: detail_route.tcl, 8 Global routing failed
[ERROR GRT-0116] Global routing finished with congestion
```
~460k total overflow, max_v=12 on met2 — local congestion from the 6-FakeRAM-macro + pcie_us-PHY layout, exacerbated by a 3211-terminal reset net. (`PLACE_DENSITY_LB_ADDON` was forcing density above the achieved util, packing std cells against macro pin clusters.)

## Fix

| Knob | Before | After |
|---|---|---|
| `CORE_UTILIZATION` | 55 | **30** |
| `PLACE_DENSITY` | — (LB_ADDON wired) | **0.40** |
| `MACRO_PLACE_HALO` | 20 20 | **100 100** |

Drops the packing forcing function (`PLACE_DENSITY_LB_ADDON`), explicitly sets `PLACE_DENSITY: 0.40` per the new `optimize-ppa 2c'` spread recipe (~10 pp below achieved util), and triples `MACRO_PLACE_HALO` to push std cells off the macro pin edges. This is the same family as sky130hd/cnn's `0.20 + 300` and PR #165's partition configs, scaled for litepci's macro pin density (`partition_p` ≤ 6 macros + central placement = halo 60; litepci 6 SRAM + PHY blackbox + 3211-fanout reset = halo 100).

Also includes the sky130hd portion of c75ea180 (FakeRAM macro rename to unified `_sram` naming, the sister of [PR #162](https://github.com/VLSIDA/HighTide/pull/162) for nangate45) which is required for the design to find its macros.

## Validation on NRP k8s (4h57m, Complete, exit 0)

| Metric | Value |
|---|---|
| Die area | 105.8 mm² |
| Achieved util | 31.4% |
| TNS setup | 0 |
| Hold violations | 0 |
| Cells (seq+comb) | ~41 k |
| Macros | 21 |
| IOs | 875 |

`finish__timing__setup__ws` returns a sentinel value (1e+39) — litepci has no constrained internal setup paths (PHY blackbox handles the timing-critical work). Standard for this design family.

## Known DRVs (not blocking, pre-existing class)

13 028 `max_slew` + 427 `max_cap` violations. The reset net's 3211-terminal fanout is the dominant contributor — it's an RTL property, not introduced by this change. Sky130hd's coarse pitch amplifies the count vs. nangate45. Tracked as a follow-up that would need a `PRE_GRT_TCL` script to buffer the reset tree, or upstream RTL gating (not in scope for HighTide as a benchmark suite).

## Cross-references

- [PR #164](https://github.com/VLSIDA/HighTide/pull/164) — the optimize-ppa skill's new 2c' section that documents this lever
- [PR #165](https://github.com/VLSIDA/HighTide/pull/165) — sister application of 2c' to sky130hd NVDLA partitions
- [PR #162](https://github.com/VLSIDA/HighTide/pull/162) — the matching nangate45/litepci macro rename