### PR TITLE
ternip: port to nangate45 and sky130hd

### DIFF
--- a/designs/nangate45/ternip/BUILD.bazel
+++ b/designs/nangate45/ternip/BUILD.bazel
@@ -1,14 +1,5 @@
 load("//:defs.bzl", "hightide_design")
 
-# Shared FakeRAM wrapper — instantiates fakeram7_512x16 banks. The macro name
-# is identical across platforms (just regenerated with each platform's tech
-# params via tools/regenerate_sram.sh), so nangate45/ternip and sky130hd/ternip
-# reuse this same wrapper via "//designs/asap7/ternip:ternip_pipelined_mem_fakeram7.v".
-exports_files(
-    ["ternip_pipelined_mem_fakeram7.v"],
-    visibility = ["//designs:__subpackages__"],
-)
-
 filegroup(
     name = "sram_lefs",
     srcs = glob(["sram/lef/*.lef"]),
@@ -21,11 +12,14 @@ filegroup(
 
 hightide_design(
     name = "ternip",
-    platform = "asap7",
+    platform = "nangate45",
     top = "ternip_core",
     verilog_files = [
         "//designs/src/ternip:rtl",
-        ":ternip_pipelined_mem_fakeram7.v",
+        # Reuse the asap7 wrapper — fakeram macro name is identical across
+        # platforms (just regenerated with each platform's tech params via
+        # tools/regenerate_sram.sh), so the same wrapper binds correctly.
+        "//designs/asap7/ternip:ternip_pipelined_mem_fakeram7.v",
     ],
     sources = {
         "SDC_FILE": [":constraint.sdc"],
@@ -37,13 +31,11 @@ hightide_design(
         "SYNTH_HIERARCHICAL": "0",
         "VERILOG_INCLUDE_DIRS": "designs/src/ternip designs/src/ternip/dev/rtl designs/src/ternip/dev/bsg/bsg_misc designs/src/ternip/dev/bsg/bsg_dataflow designs/src/ternip/dev/bsg/bsg_mem",
         "VERILOG_DEFINES": "-DCONFIG_FILENAME=\\\"config/hightide.svh\\\" -DSYNTHESIS",
-        "CORE_UTILIZATION": "70",
-        "PLACE_DENSITY": "0.75",
-        "MACRO_PLACE_HALO": "4 4",
+        "CORE_UTILIZATION": "45",
+        "PLACE_DENSITY": "0.55",
+        "MACRO_PLACE_HALO": "6 6",
         "TNS_END_PERCENT": "100",
-        # importvector (16 × 1024 = 16384 bits) is implemented as flip-flops in
-        # the wrapper; ram_style="registers" prevents instantiation but yosys
-        # still emits a $mem cell that trips this threshold without the bump.
+        # See asap7 BUILD.bazel — importvector requires SYNTH_MEMORY_MAX_BITS bump.
         "SYNTH_MEMORY_MAX_BITS": "16384",
     },
     stage_data = {"synth": ["//designs/src/ternip:rtl_data"]},

--- a/designs/nangate45/ternip/constraint.sdc
+++ b/designs/nangate45/ternip/constraint.sdc
@@ -1,0 +1,17 @@
+current_design ternip_core
+
+set clk_name  clk
+set clk_port_name clk_i
+set clk_period 15
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_false_path -from [get_ports rst_ni]

--- a/designs/nangate45/ternip/sram/lef/fakeram7_512x16.lef
+++ b/designs/nangate45/ternip/sram/lef/fakeram7_512x16.lef
@@ -1,0 +1,520 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram7_512x16
+  FOREIGN fakeram7_512x16 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 99.750 BY 128.800 ;
+  CLASS BLOCK ;
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 0.805 0.210 0.875 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.805 0.210 14.875 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.805 0.210 28.875 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.805 0.210 42.875 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.540 0.805 99.750 0.875 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.540 14.805 99.750 14.875 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.540 28.805 99.750 28.875 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.540 42.805 99.750 42.875 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 1.105 0.000 1.175 0.210 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 7.185 0.000 7.255 0.210 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 13.265 0.000 13.335 0.210 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 19.345 0.000 19.415 0.210 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 25.425 0.000 25.495 0.210 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 31.505 0.000 31.575 0.210 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 37.585 0.000 37.655 0.210 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 43.665 0.000 43.735 0.210 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 49.745 0.000 49.815 0.210 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 55.825 0.000 55.895 0.210 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 61.905 0.000 61.975 0.210 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 67.985 0.000 68.055 0.210 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 74.065 0.000 74.135 0.210 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 80.145 0.000 80.215 0.210 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 86.225 0.000 86.295 0.210 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 92.305 0.000 92.375 0.210 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 1.105 128.590 1.175 128.800 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 9.845 128.590 9.915 128.800 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 18.585 128.590 18.655 128.800 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 27.325 128.590 27.395 128.800 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 36.065 128.590 36.135 128.800 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 44.805 128.590 44.875 128.800 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 53.545 128.590 53.615 128.800 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 62.285 128.590 62.355 128.800 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.805 0.210 56.875 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 70.805 0.210 70.875 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 84.805 0.210 84.875 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 98.805 0.210 98.875 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 112.805 0.210 112.875 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.540 56.805 99.750 56.875 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.540 70.805 99.750 70.875 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.540 84.805 99.750 84.875 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 99.540 98.805 99.750 98.875 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 71.025 128.590 71.095 128.800 ;
+    END
+  END rw0_we_in
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 79.765 128.590 79.835 128.800 ;
+    END
+  END rw0_ce_in
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal2 ;
+      RECT 88.505 128.590 88.575 128.800 ;
+    END
+  END rw0_clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER metal4 ;
+      RECT 1.000 0.840 1.280 127.960 ;
+      RECT 3.240 0.840 3.520 127.960 ;
+      RECT 5.480 0.840 5.760 127.960 ;
+      RECT 7.720 0.840 8.000 127.960 ;
+      RECT 9.960 0.840 10.240 127.960 ;
+      RECT 12.200 0.840 12.480 127.960 ;
+      RECT 14.440 0.840 14.720 127.960 ;
+      RECT 16.680 0.840 16.960 127.960 ;
+      RECT 18.920 0.840 19.200 127.960 ;
+      RECT 21.160 0.840 21.440 127.960 ;
+      RECT 23.400 0.840 23.680 127.960 ;
+      RECT 25.640 0.840 25.920 127.960 ;
+      RECT 27.880 0.840 28.160 127.960 ;
+      RECT 30.120 0.840 30.400 127.960 ;
+      RECT 32.360 0.840 32.640 127.960 ;
+      RECT 34.600 0.840 34.880 127.960 ;
+      RECT 36.840 0.840 37.120 127.960 ;
+      RECT 39.080 0.840 39.360 127.960 ;
+      RECT 41.320 0.840 41.600 127.960 ;
+      RECT 43.560 0.840 43.840 127.960 ;
+      RECT 45.800 0.840 46.080 127.960 ;
+      RECT 48.040 0.840 48.320 127.960 ;
+      RECT 50.280 0.840 50.560 127.960 ;
+      RECT 52.520 0.840 52.800 127.960 ;
+      RECT 54.760 0.840 55.040 127.960 ;
+      RECT 57.000 0.840 57.280 127.960 ;
+      RECT 59.240 0.840 59.520 127.960 ;
+      RECT 61.480 0.840 61.760 127.960 ;
+      RECT 63.720 0.840 64.000 127.960 ;
+      RECT 65.960 0.840 66.240 127.960 ;
+      RECT 68.200 0.840 68.480 127.960 ;
+      RECT 70.440 0.840 70.720 127.960 ;
+      RECT 72.680 0.840 72.960 127.960 ;
+      RECT 74.920 0.840 75.200 127.960 ;
+      RECT 77.160 0.840 77.440 127.960 ;
+      RECT 79.400 0.840 79.680 127.960 ;
+      RECT 81.640 0.840 81.920 127.960 ;
+      RECT 83.880 0.840 84.160 127.960 ;
+      RECT 86.120 0.840 86.400 127.960 ;
+      RECT 88.360 0.840 88.640 127.960 ;
+      RECT 90.600 0.840 90.880 127.960 ;
+      RECT 92.840 0.840 93.120 127.960 ;
+      RECT 95.080 0.840 95.360 127.960 ;
+      RECT 97.320 0.840 97.600 127.960 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER metal4 ;
+      RECT 1.000 0.840 1.280 127.960 ;
+      RECT 3.240 0.840 3.520 127.960 ;
+      RECT 5.480 0.840 5.760 127.960 ;
+      RECT 7.720 0.840 8.000 127.960 ;
+      RECT 9.960 0.840 10.240 127.960 ;
+      RECT 12.200 0.840 12.480 127.960 ;
+      RECT 14.440 0.840 14.720 127.960 ;
+      RECT 16.680 0.840 16.960 127.960 ;
+      RECT 18.920 0.840 19.200 127.960 ;
+      RECT 21.160 0.840 21.440 127.960 ;
+      RECT 23.400 0.840 23.680 127.960 ;
+      RECT 25.640 0.840 25.920 127.960 ;
+      RECT 27.880 0.840 28.160 127.960 ;
+      RECT 30.120 0.840 30.400 127.960 ;
+      RECT 32.360 0.840 32.640 127.960 ;
+      RECT 34.600 0.840 34.880 127.960 ;
+      RECT 36.840 0.840 37.120 127.960 ;
+      RECT 39.080 0.840 39.360 127.960 ;
+      RECT 41.320 0.840 41.600 127.960 ;
+      RECT 43.560 0.840 43.840 127.960 ;
+      RECT 45.800 0.840 46.080 127.960 ;
+      RECT 48.040 0.840 48.320 127.960 ;
+      RECT 50.280 0.840 50.560 127.960 ;
+      RECT 52.520 0.840 52.800 127.960 ;
+      RECT 54.760 0.840 55.040 127.960 ;
+      RECT 57.000 0.840 57.280 127.960 ;
+      RECT 59.240 0.840 59.520 127.960 ;
+      RECT 61.480 0.840 61.760 127.960 ;
+      RECT 63.720 0.840 64.000 127.960 ;
+      RECT 65.960 0.840 66.240 127.960 ;
+      RECT 68.200 0.840 68.480 127.960 ;
+      RECT 70.440 0.840 70.720 127.960 ;
+      RECT 72.680 0.840 72.960 127.960 ;
+      RECT 74.920 0.840 75.200 127.960 ;
+      RECT 77.160 0.840 77.440 127.960 ;
+      RECT 79.400 0.840 79.680 127.960 ;
+      RECT 81.640 0.840 81.920 127.960 ;
+      RECT 83.880 0.840 84.160 127.960 ;
+      RECT 86.120 0.840 86.400 127.960 ;
+      RECT 88.360 0.840 88.640 127.960 ;
+      RECT 90.600 0.840 90.880 127.960 ;
+      RECT 92.840 0.840 93.120 127.960 ;
+      RECT 95.080 0.840 95.360 127.960 ;
+      RECT 97.320 0.840 97.600 127.960 ;
+    END
+  END VDD
+  OBS
+    LAYER metal1 ;
+    RECT 0 0 99.750 128.800 ;
+    LAYER metal2 ;
+    RECT 0 0 99.750 128.800 ;
+    LAYER metal3 ;
+    RECT 0 0 99.750 128.800 ;
+    LAYER metal4 ;
+    RECT 0 0 99.750 128.800 ;
+    LAYER OVERLAP ;
+    RECT 0 0 99.750 128.800 ;
+  END
+END fakeram7_512x16
+
+END LIBRARY

--- a/designs/nangate45/ternip/sram/lib/fakeram7_512x16.lib
+++ b/designs/nangate45/ternip/sram/lib/fakeram7_512x16.lib
@@ -1,0 +1,389 @@
+library(fakeram7_512x16) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-05-21 16:28:44Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.1;
+    capacitive_load_unit (1,pf);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.1;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 0.227;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram7_512x16_mem_out_delay_template) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram7_512x16_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram7_512x16_constraint_template) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    power_lut_template(fakeram7_512x16_energy_template_clkslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    power_lut_template(fakeram7_512x16_energy_template_sigslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram7_512x16_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 16;
+        bit_from : 15;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram7_512x16_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 9;
+        bit_from : 8;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram7_512x16) {
+    area : 12847.800;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 9;
+        word_width : 16;
+    }
+    pin(rw0_clk)   {
+        direction : input;
+        capacitance : 0.025;
+        clock : true;
+        min_period           : 0.252 ;
+        internal_power(){
+            rise_power(fakeram7_512x16_energy_template_clkslew) {
+                index_1 ("0.009, 0.227");
+                values ("2.916, 2.916")
+            }
+            fall_power(fakeram7_512x16_energy_template_clkslew) {
+                index_1 ("0.009, 0.227");
+                values ("2.916, 2.916")
+            }
+        }
+    }
+
+    bus(rw0_rd_out)   {
+        bus_type : fakeram7_512x16_DATA;
+        direction : output;
+        max_capacitance : 0.500;
+        memory_read() {
+            address : r0_addr_in;
+        }
+        timing() {
+            related_pin : "rw0_clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(fakeram7_512x16_mem_out_delay_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.309, 0.309", \
+                  "0.309, 0.309" \
+                )
+            }
+            cell_fall(fakeram7_512x16_mem_out_delay_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "0.309, 0.309", \
+                  "0.309, 0.309" \
+                )
+            }
+            rise_transition(fakeram7_512x16_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.009, 0.227")
+            }
+            fall_transition(fakeram7_512x16_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.009, 0.227")
+            }
+        }
+    }
+    pin(rw0_we_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+        }
+    }
+    pin(rw0_ce_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+        }
+    }
+    bus(rw0_addr_in)   {
+        bus_type : fakeram7_512x16_ADDRESS;
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+        }
+    }
+    bus(rw0_wd_in)   {
+        bus_type : fakeram7_512x16_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.009, 0.227");
+                index_2 ("0.009, 0.227");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.009, 0.227");
+                values ("0.029, 0.029")
+            }
+        }
+    }
+    cell_leakage_power : 728.565;
+}
+
+}

--- a/designs/sky130hd/ternip/BUILD.bazel
+++ b/designs/sky130hd/ternip/BUILD.bazel
@@ -1,14 +1,5 @@
 load("//:defs.bzl", "hightide_design")
 
-# Shared FakeRAM wrapper — instantiates fakeram7_512x16 banks. The macro name
-# is identical across platforms (just regenerated with each platform's tech
-# params via tools/regenerate_sram.sh), so nangate45/ternip and sky130hd/ternip
-# reuse this same wrapper via "//designs/asap7/ternip:ternip_pipelined_mem_fakeram7.v".
-exports_files(
-    ["ternip_pipelined_mem_fakeram7.v"],
-    visibility = ["//designs:__subpackages__"],
-)
-
 filegroup(
     name = "sram_lefs",
     srcs = glob(["sram/lef/*.lef"]),
@@ -21,11 +12,11 @@ filegroup(
 
 hightide_design(
     name = "ternip",
-    platform = "asap7",
+    platform = "sky130hd",
     top = "ternip_core",
     verilog_files = [
         "//designs/src/ternip:rtl",
-        ":ternip_pipelined_mem_fakeram7.v",
+        "//designs/asap7/ternip:ternip_pipelined_mem_fakeram7.v",
     ],
     sources = {
         "SDC_FILE": [":constraint.sdc"],
@@ -37,13 +28,10 @@ hightide_design(
         "SYNTH_HIERARCHICAL": "0",
         "VERILOG_INCLUDE_DIRS": "designs/src/ternip designs/src/ternip/dev/rtl designs/src/ternip/dev/bsg/bsg_misc designs/src/ternip/dev/bsg/bsg_dataflow designs/src/ternip/dev/bsg/bsg_mem",
         "VERILOG_DEFINES": "-DCONFIG_FILENAME=\\\"config/hightide.svh\\\" -DSYNTHESIS",
-        "CORE_UTILIZATION": "70",
-        "PLACE_DENSITY": "0.75",
-        "MACRO_PLACE_HALO": "4 4",
+        "CORE_UTILIZATION": "40",
+        "PLACE_DENSITY": "0.50",
+        "MACRO_PLACE_HALO": "10 10",
         "TNS_END_PERCENT": "100",
-        # importvector (16 × 1024 = 16384 bits) is implemented as flip-flops in
-        # the wrapper; ram_style="registers" prevents instantiation but yosys
-        # still emits a $mem cell that trips this threshold without the bump.
         "SYNTH_MEMORY_MAX_BITS": "16384",
     },
     stage_data = {"synth": ["//designs/src/ternip:rtl_data"]},

--- a/designs/sky130hd/ternip/constraint.sdc
+++ b/designs/sky130hd/ternip/constraint.sdc
@@ -1,0 +1,17 @@
+current_design ternip_core
+
+set clk_name  clk
+set clk_port_name clk_i
+set clk_period 50
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_false_path -from [get_ports rst_ni]

--- a/designs/sky130hd/ternip/sram/lef/fakeram7_512x16.lef
+++ b/designs/sky130hd/ternip/sram/lef/fakeram7_512x16.lef
@@ -1,0 +1,494 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram7_512x16
+  FOREIGN fakeram7_512x16 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 342.700 BY 280.160 ;
+  CLASS BLOCK ;
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 3.930 0.900 4.230 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 33.850 0.900 34.150 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 63.770 0.900 64.070 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 93.690 0.900 93.990 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 341.800 3.930 342.700 4.230 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 341.800 33.850 342.700 34.150 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 341.800 63.770 342.700 64.070 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 341.800 93.690 342.700 93.990 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2.690 0.000 2.830 0.420 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 23.390 0.000 23.530 0.420 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 44.090 0.000 44.230 0.420 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 64.790 0.000 64.930 0.420 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 85.490 0.000 85.630 0.420 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 106.190 0.000 106.330 0.420 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 126.890 0.000 127.030 0.420 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 147.590 0.000 147.730 0.420 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 168.290 0.000 168.430 0.420 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 188.990 0.000 189.130 0.420 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 209.690 0.000 209.830 0.420 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 230.390 0.000 230.530 0.420 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 251.090 0.000 251.230 0.420 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 271.790 0.000 271.930 0.420 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 292.490 0.000 292.630 0.420 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 313.190 0.000 313.330 0.420 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 2.690 279.740 2.830 280.160 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 33.050 279.740 33.190 280.160 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 63.410 279.740 63.550 280.160 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 93.770 279.740 93.910 280.160 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 124.130 279.740 124.270 280.160 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 154.490 279.740 154.630 280.160 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 184.850 279.740 184.990 280.160 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 215.210 279.740 215.350 280.160 ;
+    END
+  END rw0_rd_out[15]
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 123.610 0.900 123.910 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 153.530 0.900 153.830 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 183.450 0.900 183.750 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 213.370 0.900 213.670 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 243.290 0.900 243.590 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 341.800 123.610 342.700 123.910 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 341.800 153.530 342.700 153.830 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 341.800 183.450 342.700 183.750 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 341.800 213.370 342.700 213.670 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 245.570 279.740 245.710 280.160 ;
+    END
+  END rw0_we_in
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 275.930 279.740 276.070 280.160 ;
+    END
+  END rw0_ce_in
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met2 ;
+      RECT 306.290 279.740 306.430 280.160 ;
+    END
+  END rw0_clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+      RECT 2.160 4.080 3.360 276.080 ;
+      RECT 13.040 4.080 14.240 276.080 ;
+      RECT 23.920 4.080 25.120 276.080 ;
+      RECT 34.800 4.080 36.000 276.080 ;
+      RECT 45.680 4.080 46.880 276.080 ;
+      RECT 56.560 4.080 57.760 276.080 ;
+      RECT 67.440 4.080 68.640 276.080 ;
+      RECT 78.320 4.080 79.520 276.080 ;
+      RECT 89.200 4.080 90.400 276.080 ;
+      RECT 100.080 4.080 101.280 276.080 ;
+      RECT 110.960 4.080 112.160 276.080 ;
+      RECT 121.840 4.080 123.040 276.080 ;
+      RECT 132.720 4.080 133.920 276.080 ;
+      RECT 143.600 4.080 144.800 276.080 ;
+      RECT 154.480 4.080 155.680 276.080 ;
+      RECT 165.360 4.080 166.560 276.080 ;
+      RECT 176.240 4.080 177.440 276.080 ;
+      RECT 187.120 4.080 188.320 276.080 ;
+      RECT 198.000 4.080 199.200 276.080 ;
+      RECT 208.880 4.080 210.080 276.080 ;
+      RECT 219.760 4.080 220.960 276.080 ;
+      RECT 230.640 4.080 231.840 276.080 ;
+      RECT 241.520 4.080 242.720 276.080 ;
+      RECT 252.400 4.080 253.600 276.080 ;
+      RECT 263.280 4.080 264.480 276.080 ;
+      RECT 274.160 4.080 275.360 276.080 ;
+      RECT 285.040 4.080 286.240 276.080 ;
+      RECT 295.920 4.080 297.120 276.080 ;
+      RECT 306.800 4.080 308.000 276.080 ;
+      RECT 317.680 4.080 318.880 276.080 ;
+      RECT 328.560 4.080 329.760 276.080 ;
+      RECT 339.440 4.080 340.640 276.080 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+      RECT 2.160 4.080 3.360 276.080 ;
+      RECT 13.040 4.080 14.240 276.080 ;
+      RECT 23.920 4.080 25.120 276.080 ;
+      RECT 34.800 4.080 36.000 276.080 ;
+      RECT 45.680 4.080 46.880 276.080 ;
+      RECT 56.560 4.080 57.760 276.080 ;
+      RECT 67.440 4.080 68.640 276.080 ;
+      RECT 78.320 4.080 79.520 276.080 ;
+      RECT 89.200 4.080 90.400 276.080 ;
+      RECT 100.080 4.080 101.280 276.080 ;
+      RECT 110.960 4.080 112.160 276.080 ;
+      RECT 121.840 4.080 123.040 276.080 ;
+      RECT 132.720 4.080 133.920 276.080 ;
+      RECT 143.600 4.080 144.800 276.080 ;
+      RECT 154.480 4.080 155.680 276.080 ;
+      RECT 165.360 4.080 166.560 276.080 ;
+      RECT 176.240 4.080 177.440 276.080 ;
+      RECT 187.120 4.080 188.320 276.080 ;
+      RECT 198.000 4.080 199.200 276.080 ;
+      RECT 208.880 4.080 210.080 276.080 ;
+      RECT 219.760 4.080 220.960 276.080 ;
+      RECT 230.640 4.080 231.840 276.080 ;
+      RECT 241.520 4.080 242.720 276.080 ;
+      RECT 252.400 4.080 253.600 276.080 ;
+      RECT 263.280 4.080 264.480 276.080 ;
+      RECT 274.160 4.080 275.360 276.080 ;
+      RECT 285.040 4.080 286.240 276.080 ;
+      RECT 295.920 4.080 297.120 276.080 ;
+      RECT 306.800 4.080 308.000 276.080 ;
+      RECT 317.680 4.080 318.880 276.080 ;
+      RECT 328.560 4.080 329.760 276.080 ;
+      RECT 339.440 4.080 340.640 276.080 ;
+    END
+  END VDD
+  OBS
+    LAYER met1 ;
+    RECT 0 0 342.700 280.160 ;
+    LAYER met2 ;
+    RECT 0 0 342.700 280.160 ;
+    LAYER met3 ;
+    RECT 0 0 342.700 280.160 ;
+    LAYER met4 ;
+    RECT 0 0 342.700 280.160 ;
+  END
+END fakeram7_512x16
+
+END LIBRARY

--- a/designs/sky130hd/ternip/sram/lib/fakeram7_512x16.lib
+++ b/designs/sky130hd/ternip/sram/lib/fakeram7_512x16.lib
@@ -1,0 +1,389 @@
+library(fakeram7_512x16) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-05-21 16:28:44Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 5.000;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram7_512x16_mem_out_delay_template) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram7_512x16_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram7_512x16_constraint_template) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    power_lut_template(fakeram7_512x16_energy_template_clkslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    power_lut_template(fakeram7_512x16_energy_template_sigslew) {
+        variable_1 : input_transition_time;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram7_512x16_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 16;
+        bit_from : 15;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram7_512x16_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 9;
+        bit_from : 8;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram7_512x16) {
+    area : 96010.832;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 9;
+        word_width : 16;
+    }
+    pin(rw0_clk)   {
+        direction : input;
+        capacitance : 0.025;
+        clock : true;
+        min_period           : 1.000 ;
+        internal_power(){
+            rise_power(fakeram7_512x16_energy_template_clkslew) {
+                index_1 ("0.200, 5.000");
+                values ("15.000, 15.000")
+            }
+            fall_power(fakeram7_512x16_energy_template_clkslew) {
+                index_1 ("0.200, 5.000");
+                values ("15.000, 15.000")
+            }
+        }
+    }
+
+    bus(rw0_rd_out)   {
+        bus_type : fakeram7_512x16_DATA;
+        direction : output;
+        max_capacitance : 0.500;
+        memory_read() {
+            address : r0_addr_in;
+        }
+        timing() {
+            related_pin : "rw0_clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(fakeram7_512x16_mem_out_delay_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "1.400, 1.400", \
+                  "1.400, 1.400" \
+                )
+            }
+            cell_fall(fakeram7_512x16_mem_out_delay_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.005, 0.500");
+                values ( \
+                  "1.400, 1.400", \
+                  "1.400, 1.400" \
+                )
+            }
+            rise_transition(fakeram7_512x16_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.200, 5.000")
+            }
+            fall_transition(fakeram7_512x16_mem_out_slew_template) {
+                index_1 ("0.005, 0.500");
+                values ("0.200, 5.000")
+            }
+        }
+    }
+    pin(rw0_we_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+        }
+    }
+    pin(rw0_ce_in)   {
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+        }
+    }
+    bus(rw0_addr_in)   {
+        bus_type : fakeram7_512x16_ADDRESS;
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : setup_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin : rw0_clk;
+            timing_type : hold_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+        }
+    }
+    bus(rw0_wd_in)   {
+        bus_type : fakeram7_512x16_DATA;
+        memory_write() {
+            address : rw0_addr_in;
+            clocked_on : "rw0_clk";
+        }
+        direction : input;
+        capacitance : 0.005;
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : setup_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        } 
+        timing() {
+            related_pin     : rw0_clk;
+            timing_type     : hold_rising ;
+            rise_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+            fall_constraint(fakeram7_512x16_constraint_template) {
+                index_1 ("0.200, 5.000");
+                index_2 ("0.200, 5.000");
+                values ( \
+                  "0.050, 0.050", \
+                  "0.050, 0.050" \
+                )
+            }
+        }
+        internal_power(){
+            when : "(! (rw0_we_in) )";
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+        }
+        internal_power(){
+            when : "(rw0_we_in)";
+            rise_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+            fall_power(fakeram7_512x16_energy_template_sigslew) {
+                index_1 ("0.200, 5.000");
+                values ("0.150, 0.150")
+            }
+        }
+    }
+    cell_leakage_power : 50.000;
+}
+
+}

--- a/designs/src/ternip/dev/generated/fakeram_nangate45.cfg
+++ b/designs/src/ternip/dev/generated/fakeram_nangate45.cfg
@@ -1,0 +1,16 @@
+{
+  "tech_nm": 45,
+  "voltage": 1.1,
+  "metalPrefix": "metal",
+  "LRpinWidth_nm": 70,
+  "LRpinPitch_nm": 140,
+  "TBpinWidth_nm": 70,
+  "TBpinPitch_nm": 190,
+  "snapWidth_nm":  190,
+  "snapHeight_nm": 1400,
+  "flipPins": true,
+
+  "srams": [
+    { "name": "fakeram7_512x16", "width": 16, "depth": 512, "banks": 1, "no_wmask": "true", "ports": {"r": 0, "w": 0, "rw": 1} }
+  ]
+}

--- a/designs/src/ternip/dev/generated/fakeram_sky130hd.cfg
+++ b/designs/src/ternip/dev/generated/fakeram_sky130hd.cfg
@@ -1,0 +1,16 @@
+{
+  "tech_nm": 130,
+  "voltage": 1.8,
+  "metalPrefix": "met",
+  "LRpinWidth_nm": 300,
+  "LRpinPitch_nm": 680,
+  "TBpinWidth_nm": 140,
+  "TBpinPitch_nm": 460,
+  "snapWidth_nm":   460,
+  "snapHeight_nm": 2720,
+  "flipPins": true,
+
+  "srams": [
+    { "name": "fakeram7_512x16", "width": 16, "depth": 512, "banks": 1, "no_wmask": "true", "ports": {"r": 0, "w": 0, "rw": 1} }
+  ]
+}

--- a/k8s/design_resources.conf
+++ b/k8s/design_resources.conf
@@ -79,3 +79,5 @@ sky130hd/partition_c  eph_lim=150Gi
 # Ternip 'Ethan' config (D=2560, Tmatmul=256, Vector=8, Lut=1, MUL_BSG, DIV_BSG):
 # default 32/128Gi OOM'd at exit 137 during synth on 2026-05-19.
 asap7/ternip          mem_req=64Gi mem_lim=192Gi eph_lim=150Gi
+nangate45/ternip      mem_req=64Gi mem_lim=192Gi eph_lim=150Gi
+sky130hd/ternip       mem_req=64Gi mem_lim=192Gi eph_lim=150Gi


### PR DESCRIPTION
## Summary

Ports the `ternip` ternary NPU benchmark from asap7-only to all three HighTide platforms (asap7, nangate45, sky130hd), matching the multi-platform structure of gemmini/coralnpu/sha3/etc.

## Changes

| File | Purpose |
|---|---|
| `designs/nangate45/ternip/BUILD.bazel` | new — util 45 / density 0.55 / halo 6 / clk-from-SDC |
| `designs/nangate45/ternip/constraint.sdc` | new — clk_period **15 ns** (conservative 3× asap7's 5 ns, well within nangate45's 2-10 ns typical range per CLAUDE.md guidance) |
| `designs/nangate45/ternip/sram/{lef,lib}/fakeram7_512x16.{lef,lib}` | regenerated via `tools/regenerate_sram.sh ternip nangate45`; 99.75 × 128.80 µm |
| `designs/sky130hd/ternip/BUILD.bazel` | new — util 40 / density 0.50 / halo 10 (looser for sky130hd's coarse pitch) |
| `designs/sky130hd/ternip/constraint.sdc` | new — clk_period **50 ns** (10× asap7, at the high end of sky130hd's 10-50 ns range) |
| `designs/sky130hd/ternip/sram/{lef,lib}/fakeram7_512x16.{lef,lib}` | regenerated; 342.70 × 280.16 µm |
| `designs/src/ternip/dev/generated/fakeram_{nangate45,sky130hd}.cfg` | new cfgs (platform-tech headers; same single-entry `fakeram7_512x16` 16×512×1) |
| `designs/asap7/ternip/BUILD.bazel` | adds `exports_files` on `ternip_pipelined_mem_fakeram7.v` so the n45+sky cards can reference the same wrapper file |
| `k8s/design_resources.conf` | adds per-platform overrides `mem_req=64Gi mem_lim=192Gi eph_lim=150Gi` (the Ethan ternip config OOMs at default 128 Gi during synth — same family as the asap7/ternip override added in PR #160) |

## Key design choice: shared wrapper, regenerated macros

The FakeRAM macro name (`fakeram7_512x16`) is intentionally identical across all three platforms. The wrapper file (`designs/asap7/ternip/ternip_pipelined_mem_fakeram7.v`, which hard-binds to that macro name) is *exported* via `exports_files` and reused by all three platform BUILD.bazel files. Per-platform regeneration via `tools/regenerate_sram.sh` produces tech-correct LEF/LIBs with that same name but the right cell sizes for each technology.

Alternative considered: per-platform wrapper file (`ternip_pipelined_mem_fakeram45.v` etc.). Rejected — it would mean 3× wrapper duplication for zero functional gain. The macro name is arbitrary; the wrapper is what defines the interface, and it doesn't change.

## Validation

Both new platforms submitted to NRP k8s on this branch; results to follow as the jobs land. Note that this brings ternip's gallery card up from 1 platform badge to 3, with the corresponding new rows on results.html once cached.