### PR TITLE
Port ternip to nangate45 and sky130hd

### DIFF
--- a/designs/nangate45/ternip/BUILD.bazel
+++ b/designs/nangate45/ternip/BUILD.bazel
@@ -1,0 +1,46 @@
+load("//:defs.bzl", "hightide_design")
+
+filegroup(
+    name = "sram_lefs",
+    srcs = glob(["sram/lef/*.lef"]),
+)
+
+filegroup(
+    name = "sram_libs",
+    srcs = glob(["sram/lib/*.lib"]),
+)
+
+# Ternip on nangate45 — same RTL as asap7 / sky130hd, but the
+# ternip_pipelined_mem wrapper instantiates fakeram45_512x16 macros
+# (regenerated via designs/src/ternip/dev/gen_fakeram.py --platform
+# nangate45).  Each 512×16 macro is 249.660 × 126.000 µm (~7× asap7
+# area), so the floorplan needs to be ~10× larger than asap7 ternip.
+hightide_design(
+    name = "ternip",
+    platform = "nangate45",
+    top = "ternip_core",
+    verilog_files = [
+        "//designs/src/ternip:rtl",
+        ":ternip_pipelined_mem_fakeram45.v",
+    ],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": [":sram_lefs"],
+        "ADDITIONAL_LIBS": [":sram_libs"],
+    },
+    arguments = {
+        "SYNTH_HDL_FRONTEND": "slang",
+        "SYNTH_HIERARCHICAL": "0",
+        "VERILOG_INCLUDE_DIRS": "designs/src/ternip designs/src/ternip/dev/repo/rtl designs/src/ternip/dev/basejump_stl/bsg_misc designs/src/ternip/dev/basejump_stl/bsg_dataflow designs/src/ternip/dev/basejump_stl/bsg_mem",
+        "VERILOG_DEFINES": "-DCONFIG_FILENAME=\\\"config/hightide.svh\\\" -DSYNTHESIS",
+        "CORE_UTILIZATION": "35",
+        "PLACE_DENSITY_LB_ADDON": "0.15",
+        "MACRO_PLACE_HALO": "15 15",
+        "TNS_END_PERCENT": "100",
+        # importvector (16 × 1024 = 16384 bits) is implemented as flip-flops in
+        # the wrapper; ram_style="registers" prevents instantiation but yosys
+        # still emits a $mem cell that trips this threshold without the bump.
+        "SYNTH_MEMORY_MAX_BITS": "16384",
+    },
+    stage_data = {"synth": ["//designs/src/ternip:rtl_data"]},
+)

--- a/designs/nangate45/ternip/constraint.sdc
+++ b/designs/nangate45/ternip/constraint.sdc
@@ -1,0 +1,17 @@
+current_design ternip_core
+
+set clk_name  clk
+set clk_port_name clk_i
+set clk_period 5
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_false_path -from [get_ports rst_ni]

--- a/designs/nangate45/ternip/sram/lef/fakeram45_512x16.lef
+++ b/designs/nangate45/ternip/sram/lef/fakeram45_512x16.lef
@@ -1,0 +1,415 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram45_512x16
+  FOREIGN fakeram45_512x16 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 249.660 BY 126.000 ;
+  CLASS BLOCK ;
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 1.330 0.140 1.470 ;
+    END
+  END rw0_clk
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 1.330 249.660 1.470 ;
+    END
+  END rw0_ce_in
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 2.730 0.140 2.870 ;
+    END
+  END rw0_we_in
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 2.730 249.660 2.870 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.130 0.140 4.270 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 4.130 249.660 4.270 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.530 0.140 5.670 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 5.530 249.660 5.670 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.930 0.140 7.070 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 6.930 249.660 7.070 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.330 0.140 8.470 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 8.330 249.660 8.470 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.730 0.140 9.870 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 9.730 249.660 9.870 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.130 0.140 11.270 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 11.130 249.660 11.270 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.530 0.140 12.670 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 12.530 249.660 12.670 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.930 0.140 14.070 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 13.930 249.660 14.070 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.330 0.140 15.470 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 15.330 249.660 15.470 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.730 0.140 16.870 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 16.730 249.660 16.870 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.130 0.140 18.270 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 18.130 249.660 18.270 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.530 0.140 19.670 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 19.530 249.660 19.670 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 20.930 0.140 21.070 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 20.930 249.660 21.070 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.330 0.140 22.470 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 22.330 249.660 22.470 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.730 0.140 23.870 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 23.730 249.660 23.870 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.130 0.140 25.270 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 25.130 249.660 25.270 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.530 0.140 26.670 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 26.530 249.660 26.670 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.930 0.140 28.070 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 27.930 249.660 28.070 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.330 0.140 29.470 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 29.330 249.660 29.470 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.730 0.140 30.870 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 249.520 30.730 249.660 30.870 ;
+    END
+  END rw0_rd_out[15]
+  OBS
+    LAYER metal1 ;
+      RECT 0.000 0.000 249.660 126.000 ;
+    LAYER metal2 ;
+      RECT 0.000 0.000 249.660 126.000 ;
+    LAYER metal3 ;
+      RECT 0.000 0.000 249.660 126.000 ;
+    LAYER metal4 ;
+      RECT 0.000 0.000 249.660 126.000 ;
+  END
+END fakeram45_512x16
+END LIBRARY

--- a/designs/nangate45/ternip/sram/lib/fakeram45_512x16.lib
+++ b/designs/nangate45/ternip/sram/lib/fakeram45_512x16.lib
@@ -1,0 +1,211 @@
+library(fakeram45_512x16) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.1;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.1;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram45_512x16_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram45_512x16_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram45_512x16_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram45_512x16_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 16; bit_from : 15; bit_to : 0; downto : true;
+    }
+    type (fakeram45_512x16_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 9; bit_from : 8; bit_to : 0; downto : true;
+    }
+    cell(fakeram45_512x16) {
+        area : 31457.160;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(rw0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_addr_in) {
+            bus_type : fakeram45_512x16_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_wd_in) {
+            bus_type : fakeram45_512x16_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw0_addr_in; clocked_on : "rw0_clk"; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram45_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_rd_out) {
+            bus_type : fakeram45_512x16_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw0_addr_in; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram45_512x16_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram45_512x16_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram45_512x16_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram45_512x16_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/nangate45/ternip/ternip_pipelined_mem_fakeram45.v
+++ b/designs/nangate45/ternip/ternip_pipelined_mem_fakeram45.v
@@ -1,0 +1,227 @@
+// ternip_pipelined_mem — FakeRAM replacement for HighTide ASIC synthesis (nangate45).
+//
+// Drop-in replacement for the behavioral ternip_pipelined_mem module.
+// Replaces the internal reg array with a FakeRAM SRAM macro and removes the
+// redundant read_data_q2 register (the FakeRAM output is already registered).
+
+`define SAFE_CLOG2(x) ( (((x)==1) || ((x)==0)) ? 1 : $clog2(x) )
+
+module ternip_pipelined_mem #(
+    parameter int DATA_WIDTH      = 8,
+    parameter int NUM_ENTRIES     = 256,
+    parameter bit DECOUPLED_READY = 0
+) (
+    input  logic                                clk_i,
+    input  logic                                rst_ni,
+
+    output logic                                request_ready_o,
+    input  logic                                request_valid_i,
+    input  logic                                request_write_not_read_i,
+    input  logic [`SAFE_CLOG2(NUM_ENTRIES)-1:0] request_addr_i,
+    input  logic [DATA_WIDTH-1:0]               request_w_data_i,
+
+    input  logic                                read_ready_i,
+    output logic                                read_valid_o,
+    output logic [`SAFE_CLOG2(NUM_ENTRIES)-1:0] read_addr_o,
+    output logic [DATA_WIDTH-1:0]               read_data_o
+);
+
+localparam int ADDR_WIDTH = `SAFE_CLOG2(NUM_ENTRIES);
+
+// Pipeline registers (unchanged from original)
+logic read_valid_d;
+logic read_valid_q1;
+logic read_valid_q2;
+
+logic write_valid_d;
+logic write_valid_q1;
+logic write_valid_q2;
+
+logic [ADDR_WIDTH-1:0] request_addr_q1;
+logic [ADDR_WIDTH-1:0] request_addr_q2;
+logic [DATA_WIDTH-1:0] request_w_data_q1;
+logic [DATA_WIDTH-1:0] read_data_q2;
+
+logic                                         buffer_in_ready;
+logic                                         buffer_in_valid;
+logic [$bits({read_addr_o, read_data_o})-1:0] buffer_in_data;
+
+logic                                         buffer_out_ready;
+logic                                         buffer_out_valid;
+logic [$bits({read_addr_o, read_data_o})-1:0] buffer_out_data;
+
+assign read_valid_d = (request_valid_i && !request_write_not_read_i);
+assign write_valid_d = (request_valid_i && request_write_not_read_i);
+
+logic stall1, stall2, stall3;
+
+if (DECOUPLED_READY) begin
+    assign stall2 = !buffer_in_ready && read_valid_q2;
+end else begin
+    assign stall3 = !read_ready_i && read_valid_o;
+    assign stall2 = stall3 && (read_valid_q2 || write_valid_q2);
+end
+
+assign stall1 = stall2 && (read_valid_q1 || write_valid_q1);
+assign request_ready_o = !stall1;
+
+// Stage 1 pipeline registers
+always_ff @(posedge clk_i) begin
+    if (!rst_ni) begin
+        read_valid_q1 <= 0;
+        write_valid_q1 <= 0;
+    end else if (!stall1) begin
+        read_valid_q1 <= read_valid_d;
+        write_valid_q1 <= write_valid_d;
+    end
+end
+always_ff @(posedge clk_i) begin
+    if (!stall1) begin
+        request_addr_q1 <= request_addr_i;
+        request_w_data_q1 <= request_w_data_i;
+    end
+end
+
+// Stage 2 pipeline registers
+always_ff @(posedge clk_i) begin
+    if (!rst_ni) begin
+        read_valid_q2 <= 0;
+        write_valid_q2 <= 0;
+    end else if (!stall2) begin
+        read_valid_q2   <= read_valid_q1;
+        write_valid_q2  <= write_valid_q1;
+    end
+end
+always_ff @(posedge clk_i) begin
+    if (!stall2) begin
+        request_addr_q2 <= request_addr_q1;
+    end
+end
+
+// Banked FakeRAM SRAM macros — replace the behavioral reg array.
+// The FakeRAMs have a synchronous registered output, which replaces read_data_q2.
+//
+//   (16, 4096) → 8 × fakeram45_512x16  (depth-banked, 8 Kb per bank)
+//   (16, 1024) → 2 × fakeram45_512x16  (depth-banked, 8 Kb per bank)
+//   (1024, 16) → flip-flop register file (16 entries is too small for a macro)
+//
+// Depth banking: addr[high] selects which bank's ce_in fires; the bank's
+// rd_out is muxed back into read_data_q2 using request_addr_q2 (the
+// SRAM's read latency is 1 cycle, so by the time the data arrives,
+// addr_q2 holds the address that was driven into the SRAM last cycle).
+//
+// Width banking: every bank gets the same address/ce/we, and the data
+// bus is sliced/concatenated into BANK_WIDTH-bit groups across banks.
+
+wire fakeram_ce = !stall2 && (write_valid_q1 || read_valid_q1);
+wire fakeram_we = write_valid_q1;
+
+generate
+    if (DATA_WIDTH == 16 && NUM_ENTRIES == 4096) begin : gen_sram
+        localparam int BANK_DEPTH      = 512;
+        localparam int NUM_BANKS       = 8;
+        localparam int BANK_ADDR_BITS  = 9;  // log2(512)
+        localparam int BANK_SEL_BITS   = 3;  // log2(8)
+
+        wire [BANK_SEL_BITS-1:0]  bank_sel  = request_addr_q1[ADDR_WIDTH-1 -: BANK_SEL_BITS];
+        wire [BANK_ADDR_BITS-1:0] bank_addr = request_addr_q1[BANK_ADDR_BITS-1:0];
+        wire [BANK_SEL_BITS-1:0]  bank_sel_q2 = request_addr_q2[ADDR_WIDTH-1 -: BANK_SEL_BITS];
+
+        logic [DATA_WIDTH-1:0] bank_rd_out [NUM_BANKS-1:0];
+
+        for (genvar b = 0; b < NUM_BANKS; b++) begin : gen_bank
+            wire bank_ce = fakeram_ce && (bank_sel == BANK_SEL_BITS'(b));
+            fakeram45_512x16 sram (
+                .rw0_clk(clk_i),
+                .rw0_ce_in(bank_ce),
+                .rw0_we_in(fakeram_we),
+                .rw0_addr_in(bank_addr),
+                .rw0_wd_in(request_w_data_q1),
+                .rw0_rd_out(bank_rd_out[b])
+            );
+        end
+        assign read_data_q2 = bank_rd_out[bank_sel_q2];
+    end else if (DATA_WIDTH == 16 && NUM_ENTRIES == 1024) begin : gen_sram
+        localparam int BANK_DEPTH      = 512;
+        localparam int NUM_BANKS       = 2;
+        localparam int BANK_ADDR_BITS  = 9;  // log2(512)
+        localparam int BANK_SEL_BITS   = 1;  // log2(2)
+
+        wire [BANK_SEL_BITS-1:0]  bank_sel  = request_addr_q1[ADDR_WIDTH-1 -: BANK_SEL_BITS];
+        wire [BANK_ADDR_BITS-1:0] bank_addr = request_addr_q1[BANK_ADDR_BITS-1:0];
+        wire [BANK_SEL_BITS-1:0]  bank_sel_q2 = request_addr_q2[ADDR_WIDTH-1 -: BANK_SEL_BITS];
+
+        logic [DATA_WIDTH-1:0] bank_rd_out [NUM_BANKS-1:0];
+
+        for (genvar b = 0; b < NUM_BANKS; b++) begin : gen_bank
+            wire bank_ce = fakeram_ce && (bank_sel == BANK_SEL_BITS'(b));
+            fakeram45_512x16 sram (
+                .rw0_clk(clk_i),
+                .rw0_ce_in(bank_ce),
+                .rw0_we_in(fakeram_we),
+                .rw0_addr_in(bank_addr),
+                .rw0_wd_in(request_w_data_q1),
+                .rw0_rd_out(bank_rd_out[b])
+            );
+        end
+        assign read_data_q2 = bank_rd_out[bank_sel_q2];
+    end else if (DATA_WIDTH == 1024 && NUM_ENTRIES == 16) begin : gen_sram
+        // 16 entries is too small for a macro; use flip-flops with the same
+        // 1-cycle read latency so the pipeline timing is unchanged.
+        // ram_style="registers" tells yosys not to infer this as RAM.
+        (* ram_style = "registers" *)
+        reg [DATA_WIDTH-1:0] mem_ff [0:NUM_ENTRIES-1];
+        always_ff @(posedge clk_i) begin
+            if (!stall2 && write_valid_q1)
+                mem_ff[request_addr_q1] <= request_w_data_q1;
+        end
+        always_ff @(posedge clk_i) begin
+            if (!stall2 && read_valid_q1)
+                read_data_q2 <= mem_ff[request_addr_q1];
+        end
+    end
+endgenerate
+
+// Output stage (unchanged from original)
+if (DECOUPLED_READY) begin : decoupled_ready
+    assign buffer_in_valid = read_valid_q2;
+    assign buffer_in_data = {request_addr_q2, read_data_q2};
+
+    assign buffer_out_ready = read_ready_i;
+    assign read_valid_o = buffer_out_valid;
+    assign {read_addr_o, read_data_o} = buffer_out_data;
+
+    ternip_pipelined_interconnect #(
+        .DataWidth($bits(buffer_in_data)),
+        .NumStages(1)
+    ) buffer (
+        .clk_i,
+        .rst_ni,
+
+        .in_ready_o(buffer_in_ready),
+        .in_valid_i(buffer_in_valid),
+        .in_data_i(buffer_in_data),
+
+        .out_ready_i(buffer_out_ready),
+        .out_valid_o(buffer_out_valid),
+        .out_data_o(buffer_out_data)
+    );
+end else begin : coupled_ready
+    always_ff @(posedge clk_i) begin
+        if (!rst_ni) begin
+            read_valid_o <= 1'b0;
+        end else if (!stall3) begin
+            read_valid_o <= read_valid_q2;
+        end
+    end
+    always_ff @(posedge clk_i) begin
+        if (!stall3) begin
+            read_addr_o  <= read_valid_q2 ? request_addr_q2 : 'x;
+            read_data_o  <= read_valid_q2 ? read_data_q2    : 'x;
+        end
+    end
+end
+
+endmodule
+
+`undef SAFE_CLOG2

--- a/designs/sky130hd/ternip/BUILD.bazel
+++ b/designs/sky130hd/ternip/BUILD.bazel
@@ -1,0 +1,46 @@
+load("//:defs.bzl", "hightide_design")
+
+filegroup(
+    name = "sram_lefs",
+    srcs = glob(["sram/lef/*.lef"]),
+)
+
+filegroup(
+    name = "sram_libs",
+    srcs = glob(["sram/lib/*.lib"]),
+)
+
+# Ternip on sky130hd — same RTL as asap7 / nangate45, but the
+# ternip_pipelined_mem wrapper instantiates fakeram130_512x16 macros
+# (regenerated via designs/src/ternip/dev/gen_fakeram.py --platform
+# sky130hd).  Each 512×16 macro is 256.220 × 130.560 µm (~8× asap7
+# area), so the floorplan needs to be ~10× larger than asap7 ternip.
+hightide_design(
+    name = "ternip",
+    platform = "sky130hd",
+    top = "ternip_core",
+    verilog_files = [
+        "//designs/src/ternip:rtl",
+        ":ternip_pipelined_mem_fakeram130.v",
+    ],
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+        "ADDITIONAL_LEFS": [":sram_lefs"],
+        "ADDITIONAL_LIBS": [":sram_libs"],
+    },
+    arguments = {
+        "SYNTH_HDL_FRONTEND": "slang",
+        "SYNTH_HIERARCHICAL": "0",
+        "VERILOG_INCLUDE_DIRS": "designs/src/ternip designs/src/ternip/dev/repo/rtl designs/src/ternip/dev/basejump_stl/bsg_misc designs/src/ternip/dev/basejump_stl/bsg_dataflow designs/src/ternip/dev/basejump_stl/bsg_mem",
+        "VERILOG_DEFINES": "-DCONFIG_FILENAME=\\\"config/hightide.svh\\\" -DSYNTHESIS",
+        "CORE_UTILIZATION": "25",
+        "PLACE_DENSITY_LB_ADDON": "0.15",
+        "MACRO_PLACE_HALO": "30 30",
+        "TNS_END_PERCENT": "100",
+        # importvector (16 × 1024 = 16384 bits) is implemented as flip-flops in
+        # the wrapper; ram_style="registers" prevents instantiation but yosys
+        # still emits a $mem cell that trips this threshold without the bump.
+        "SYNTH_MEMORY_MAX_BITS": "16384",
+    },
+    stage_data = {"synth": ["//designs/src/ternip:rtl_data"]},
+)

--- a/designs/sky130hd/ternip/constraint.sdc
+++ b/designs/sky130hd/ternip/constraint.sdc
@@ -1,0 +1,17 @@
+current_design ternip_core
+
+set clk_name  clk
+set clk_port_name clk_i
+set clk_period 25
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_false_path -from [get_ports rst_ni]

--- a/designs/sky130hd/ternip/sram/lef/fakeram130_512x16.lef
+++ b/designs/sky130hd/ternip/sram/lef/fakeram130_512x16.lef
@@ -1,0 +1,417 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram130_512x16
+  FOREIGN fakeram130_512x16 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 256.220 BY 130.560 ;
+  CLASS BLOCK ;
+  PIN rw0_clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 2.570 0.300 2.870 ;
+    END
+  END rw0_clk
+  PIN rw0_ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 2.570 256.220 2.870 ;
+    END
+  END rw0_ce_in
+  PIN rw0_we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 5.290 0.300 5.590 ;
+    END
+  END rw0_we_in
+  PIN rw0_addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 5.290 256.220 5.590 ;
+    END
+  END rw0_addr_in[0]
+  PIN rw0_addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 8.010 0.300 8.310 ;
+    END
+  END rw0_addr_in[1]
+  PIN rw0_addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 8.010 256.220 8.310 ;
+    END
+  END rw0_addr_in[2]
+  PIN rw0_addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 10.730 0.300 11.030 ;
+    END
+  END rw0_addr_in[3]
+  PIN rw0_addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 10.730 256.220 11.030 ;
+    END
+  END rw0_addr_in[4]
+  PIN rw0_addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 13.450 0.300 13.750 ;
+    END
+  END rw0_addr_in[5]
+  PIN rw0_addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 13.450 256.220 13.750 ;
+    END
+  END rw0_addr_in[6]
+  PIN rw0_addr_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 16.170 0.300 16.470 ;
+    END
+  END rw0_addr_in[7]
+  PIN rw0_addr_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 16.170 256.220 16.470 ;
+    END
+  END rw0_addr_in[8]
+  PIN rw0_wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 18.890 0.300 19.190 ;
+    END
+  END rw0_wd_in[0]
+  PIN rw0_wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 18.890 256.220 19.190 ;
+    END
+  END rw0_wd_in[1]
+  PIN rw0_wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 21.610 0.300 21.910 ;
+    END
+  END rw0_wd_in[2]
+  PIN rw0_wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 21.610 256.220 21.910 ;
+    END
+  END rw0_wd_in[3]
+  PIN rw0_wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 24.330 0.300 24.630 ;
+    END
+  END rw0_wd_in[4]
+  PIN rw0_wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 24.330 256.220 24.630 ;
+    END
+  END rw0_wd_in[5]
+  PIN rw0_wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 27.050 0.300 27.350 ;
+    END
+  END rw0_wd_in[6]
+  PIN rw0_wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 27.050 256.220 27.350 ;
+    END
+  END rw0_wd_in[7]
+  PIN rw0_wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 29.770 0.300 30.070 ;
+    END
+  END rw0_wd_in[8]
+  PIN rw0_wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 29.770 256.220 30.070 ;
+    END
+  END rw0_wd_in[9]
+  PIN rw0_wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 32.490 0.300 32.790 ;
+    END
+  END rw0_wd_in[10]
+  PIN rw0_wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 32.490 256.220 32.790 ;
+    END
+  END rw0_wd_in[11]
+  PIN rw0_wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 35.210 0.300 35.510 ;
+    END
+  END rw0_wd_in[12]
+  PIN rw0_wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 35.210 256.220 35.510 ;
+    END
+  END rw0_wd_in[13]
+  PIN rw0_wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 37.930 0.300 38.230 ;
+    END
+  END rw0_wd_in[14]
+  PIN rw0_wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 37.930 256.220 38.230 ;
+    END
+  END rw0_wd_in[15]
+  PIN rw0_rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 40.650 0.300 40.950 ;
+    END
+  END rw0_rd_out[0]
+  PIN rw0_rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 40.650 256.220 40.950 ;
+    END
+  END rw0_rd_out[1]
+  PIN rw0_rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 43.370 0.300 43.670 ;
+    END
+  END rw0_rd_out[2]
+  PIN rw0_rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 43.370 256.220 43.670 ;
+    END
+  END rw0_rd_out[3]
+  PIN rw0_rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 46.090 0.300 46.390 ;
+    END
+  END rw0_rd_out[4]
+  PIN rw0_rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 46.090 256.220 46.390 ;
+    END
+  END rw0_rd_out[5]
+  PIN rw0_rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 48.810 0.300 49.110 ;
+    END
+  END rw0_rd_out[6]
+  PIN rw0_rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 48.810 256.220 49.110 ;
+    END
+  END rw0_rd_out[7]
+  PIN rw0_rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 51.530 0.300 51.830 ;
+    END
+  END rw0_rd_out[8]
+  PIN rw0_rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 51.530 256.220 51.830 ;
+    END
+  END rw0_rd_out[9]
+  PIN rw0_rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 54.250 0.300 54.550 ;
+    END
+  END rw0_rd_out[10]
+  PIN rw0_rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 54.250 256.220 54.550 ;
+    END
+  END rw0_rd_out[11]
+  PIN rw0_rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 56.970 0.300 57.270 ;
+    END
+  END rw0_rd_out[12]
+  PIN rw0_rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 56.970 256.220 57.270 ;
+    END
+  END rw0_rd_out[13]
+  PIN rw0_rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 0.000 59.690 0.300 59.990 ;
+    END
+  END rw0_rd_out[14]
+  PIN rw0_rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER met3 ;
+      RECT 255.920 59.690 256.220 59.990 ;
+    END
+  END rw0_rd_out[15]
+  OBS
+    LAYER li1 ;
+      RECT 0.000 0.000 256.220 130.560 ;
+    LAYER met1 ;
+      RECT 0.000 0.000 256.220 130.560 ;
+    LAYER met2 ;
+      RECT 0.000 0.000 256.220 130.560 ;
+    LAYER met3 ;
+      RECT 0.000 0.000 256.220 130.560 ;
+    LAYER met4 ;
+      RECT 0.000 0.000 256.220 130.560 ;
+  END
+END fakeram130_512x16
+END LIBRARY

--- a/designs/sky130hd/ternip/sram/lib/fakeram130_512x16.lib
+++ b/designs/sky130hd/ternip/sram/lib/fakeram130_512x16.lib
@@ -1,0 +1,211 @@
+library(fakeram130_512x16) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-01-01 00:00:00Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1uW";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.8;
+    capacitive_load_unit (1,pf);
+    pulling_resistance_unit : "1kohm";
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.8;
+        tree_type : balanced_tree;
+    }
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_max_transition : 0.227;
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+    lu_table_template(fakeram130_512x16_delay) {
+        variable_1 : input_net_transition;
+        variable_2 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    lu_table_template(fakeram130_512x16_slew) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    lu_table_template(fakeram130_512x16_constraint) {
+        variable_1 : related_pin_transition;
+        variable_2 : constrained_pin_transition;
+            index_1 ("1000, 1001");
+            index_2 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram130_512x16_DATA) {
+        base_type : array; data_type : bit;
+        bit_width : 16; bit_from : 15; bit_to : 0; downto : true;
+    }
+    type (fakeram130_512x16_ADDR) {
+        base_type : array; data_type : bit;
+        bit_width : 9; bit_from : 8; bit_to : 0; downto : true;
+    }
+    cell(fakeram130_512x16) {
+        area : 33452.083;
+        interface_timing : true;
+        dont_use : true;
+        dont_touch : true;
+        pin(rw0_clk) { direction : input; capacitance : 0.0214; clock : true; }
+        pin(rw0_ce_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        pin(rw0_we_in) {
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_addr_in) {
+            bus_type : fakeram130_512x16_ADDR;
+            direction : input;
+            capacitance : 0.0035;
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_wd_in) {
+            bus_type : fakeram130_512x16_DATA;
+            direction : input;
+            capacitance : 0.0035;
+            memory_write() { address : rw0_addr_in; clocked_on : "rw0_clk"; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : setup_rising;
+                rise_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+                fall_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.050, 0.050", "0.050, 0.050");
+                }
+            }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : hold_rising;
+                rise_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+                fall_constraint(fakeram130_512x16_constraint) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.010, 0.100");
+                    values("0.005, 0.005", "0.005, 0.005");
+                }
+            }
+        }
+        bus(rw0_rd_out) {
+            bus_type : fakeram130_512x16_DATA;
+            direction : output;
+            max_capacitance : 0.500;
+            memory_read() { address : rw0_addr_in; }
+            timing() {
+                related_pin : "rw0_clk";
+                timing_type : rising_edge;
+                timing_sense : non_unate;
+                cell_rise(fakeram130_512x16_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                cell_fall(fakeram130_512x16_delay) {
+                    index_1 ("0.010, 0.100"); index_2 ("0.0005, 0.500");
+                    values("0.200, 0.800", "0.250, 0.850");
+                }
+                rise_transition(fakeram130_512x16_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+                fall_transition(fakeram130_512x16_slew) {
+                    index_1 ("0.0005, 0.500"); values("0.015, 0.300");
+                }
+            }
+        }
+    }
+}

--- a/designs/sky130hd/ternip/ternip_pipelined_mem_fakeram130.v
+++ b/designs/sky130hd/ternip/ternip_pipelined_mem_fakeram130.v
@@ -1,0 +1,227 @@
+// ternip_pipelined_mem — FakeRAM replacement for HighTide ASIC synthesis (sky130hd).
+//
+// Drop-in replacement for the behavioral ternip_pipelined_mem module.
+// Replaces the internal reg array with a FakeRAM SRAM macro and removes the
+// redundant read_data_q2 register (the FakeRAM output is already registered).
+
+`define SAFE_CLOG2(x) ( (((x)==1) || ((x)==0)) ? 1 : $clog2(x) )
+
+module ternip_pipelined_mem #(
+    parameter int DATA_WIDTH      = 8,
+    parameter int NUM_ENTRIES     = 256,
+    parameter bit DECOUPLED_READY = 0
+) (
+    input  logic                                clk_i,
+    input  logic                                rst_ni,
+
+    output logic                                request_ready_o,
+    input  logic                                request_valid_i,
+    input  logic                                request_write_not_read_i,
+    input  logic [`SAFE_CLOG2(NUM_ENTRIES)-1:0] request_addr_i,
+    input  logic [DATA_WIDTH-1:0]               request_w_data_i,
+
+    input  logic                                read_ready_i,
+    output logic                                read_valid_o,
+    output logic [`SAFE_CLOG2(NUM_ENTRIES)-1:0] read_addr_o,
+    output logic [DATA_WIDTH-1:0]               read_data_o
+);
+
+localparam int ADDR_WIDTH = `SAFE_CLOG2(NUM_ENTRIES);
+
+// Pipeline registers (unchanged from original)
+logic read_valid_d;
+logic read_valid_q1;
+logic read_valid_q2;
+
+logic write_valid_d;
+logic write_valid_q1;
+logic write_valid_q2;
+
+logic [ADDR_WIDTH-1:0] request_addr_q1;
+logic [ADDR_WIDTH-1:0] request_addr_q2;
+logic [DATA_WIDTH-1:0] request_w_data_q1;
+logic [DATA_WIDTH-1:0] read_data_q2;
+
+logic                                         buffer_in_ready;
+logic                                         buffer_in_valid;
+logic [$bits({read_addr_o, read_data_o})-1:0] buffer_in_data;
+
+logic                                         buffer_out_ready;
+logic                                         buffer_out_valid;
+logic [$bits({read_addr_o, read_data_o})-1:0] buffer_out_data;
+
+assign read_valid_d = (request_valid_i && !request_write_not_read_i);
+assign write_valid_d = (request_valid_i && request_write_not_read_i);
+
+logic stall1, stall2, stall3;
+
+if (DECOUPLED_READY) begin
+    assign stall2 = !buffer_in_ready && read_valid_q2;
+end else begin
+    assign stall3 = !read_ready_i && read_valid_o;
+    assign stall2 = stall3 && (read_valid_q2 || write_valid_q2);
+end
+
+assign stall1 = stall2 && (read_valid_q1 || write_valid_q1);
+assign request_ready_o = !stall1;
+
+// Stage 1 pipeline registers
+always_ff @(posedge clk_i) begin
+    if (!rst_ni) begin
+        read_valid_q1 <= 0;
+        write_valid_q1 <= 0;
+    end else if (!stall1) begin
+        read_valid_q1 <= read_valid_d;
+        write_valid_q1 <= write_valid_d;
+    end
+end
+always_ff @(posedge clk_i) begin
+    if (!stall1) begin
+        request_addr_q1 <= request_addr_i;
+        request_w_data_q1 <= request_w_data_i;
+    end
+end
+
+// Stage 2 pipeline registers
+always_ff @(posedge clk_i) begin
+    if (!rst_ni) begin
+        read_valid_q2 <= 0;
+        write_valid_q2 <= 0;
+    end else if (!stall2) begin
+        read_valid_q2   <= read_valid_q1;
+        write_valid_q2  <= write_valid_q1;
+    end
+end
+always_ff @(posedge clk_i) begin
+    if (!stall2) begin
+        request_addr_q2 <= request_addr_q1;
+    end
+end
+
+// Banked FakeRAM SRAM macros — replace the behavioral reg array.
+// The FakeRAMs have a synchronous registered output, which replaces read_data_q2.
+//
+//   (16, 4096) → 8 × fakeram130_512x16  (depth-banked, 8 Kb per bank)
+//   (16, 1024) → 2 × fakeram130_512x16  (depth-banked, 8 Kb per bank)
+//   (1024, 16) → flip-flop register file (16 entries is too small for a macro)
+//
+// Depth banking: addr[high] selects which bank's ce_in fires; the bank's
+// rd_out is muxed back into read_data_q2 using request_addr_q2 (the
+// SRAM's read latency is 1 cycle, so by the time the data arrives,
+// addr_q2 holds the address that was driven into the SRAM last cycle).
+//
+// Width banking: every bank gets the same address/ce/we, and the data
+// bus is sliced/concatenated into BANK_WIDTH-bit groups across banks.
+
+wire fakeram_ce = !stall2 && (write_valid_q1 || read_valid_q1);
+wire fakeram_we = write_valid_q1;
+
+generate
+    if (DATA_WIDTH == 16 && NUM_ENTRIES == 4096) begin : gen_sram
+        localparam int BANK_DEPTH      = 512;
+        localparam int NUM_BANKS       = 8;
+        localparam int BANK_ADDR_BITS  = 9;  // log2(512)
+        localparam int BANK_SEL_BITS   = 3;  // log2(8)
+
+        wire [BANK_SEL_BITS-1:0]  bank_sel  = request_addr_q1[ADDR_WIDTH-1 -: BANK_SEL_BITS];
+        wire [BANK_ADDR_BITS-1:0] bank_addr = request_addr_q1[BANK_ADDR_BITS-1:0];
+        wire [BANK_SEL_BITS-1:0]  bank_sel_q2 = request_addr_q2[ADDR_WIDTH-1 -: BANK_SEL_BITS];
+
+        logic [DATA_WIDTH-1:0] bank_rd_out [NUM_BANKS-1:0];
+
+        for (genvar b = 0; b < NUM_BANKS; b++) begin : gen_bank
+            wire bank_ce = fakeram_ce && (bank_sel == BANK_SEL_BITS'(b));
+            fakeram130_512x16 sram (
+                .rw0_clk(clk_i),
+                .rw0_ce_in(bank_ce),
+                .rw0_we_in(fakeram_we),
+                .rw0_addr_in(bank_addr),
+                .rw0_wd_in(request_w_data_q1),
+                .rw0_rd_out(bank_rd_out[b])
+            );
+        end
+        assign read_data_q2 = bank_rd_out[bank_sel_q2];
+    end else if (DATA_WIDTH == 16 && NUM_ENTRIES == 1024) begin : gen_sram
+        localparam int BANK_DEPTH      = 512;
+        localparam int NUM_BANKS       = 2;
+        localparam int BANK_ADDR_BITS  = 9;  // log2(512)
+        localparam int BANK_SEL_BITS   = 1;  // log2(2)
+
+        wire [BANK_SEL_BITS-1:0]  bank_sel  = request_addr_q1[ADDR_WIDTH-1 -: BANK_SEL_BITS];
+        wire [BANK_ADDR_BITS-1:0] bank_addr = request_addr_q1[BANK_ADDR_BITS-1:0];
+        wire [BANK_SEL_BITS-1:0]  bank_sel_q2 = request_addr_q2[ADDR_WIDTH-1 -: BANK_SEL_BITS];
+
+        logic [DATA_WIDTH-1:0] bank_rd_out [NUM_BANKS-1:0];
+
+        for (genvar b = 0; b < NUM_BANKS; b++) begin : gen_bank
+            wire bank_ce = fakeram_ce && (bank_sel == BANK_SEL_BITS'(b));
+            fakeram130_512x16 sram (
+                .rw0_clk(clk_i),
+                .rw0_ce_in(bank_ce),
+                .rw0_we_in(fakeram_we),
+                .rw0_addr_in(bank_addr),
+                .rw0_wd_in(request_w_data_q1),
+                .rw0_rd_out(bank_rd_out[b])
+            );
+        end
+        assign read_data_q2 = bank_rd_out[bank_sel_q2];
+    end else if (DATA_WIDTH == 1024 && NUM_ENTRIES == 16) begin : gen_sram
+        // 16 entries is too small for a macro; use flip-flops with the same
+        // 1-cycle read latency so the pipeline timing is unchanged.
+        // ram_style="registers" tells yosys not to infer this as RAM.
+        (* ram_style = "registers" *)
+        reg [DATA_WIDTH-1:0] mem_ff [0:NUM_ENTRIES-1];
+        always_ff @(posedge clk_i) begin
+            if (!stall2 && write_valid_q1)
+                mem_ff[request_addr_q1] <= request_w_data_q1;
+        end
+        always_ff @(posedge clk_i) begin
+            if (!stall2 && read_valid_q1)
+                read_data_q2 <= mem_ff[request_addr_q1];
+        end
+    end
+endgenerate
+
+// Output stage (unchanged from original)
+if (DECOUPLED_READY) begin : decoupled_ready
+    assign buffer_in_valid = read_valid_q2;
+    assign buffer_in_data = {request_addr_q2, read_data_q2};
+
+    assign buffer_out_ready = read_ready_i;
+    assign read_valid_o = buffer_out_valid;
+    assign {read_addr_o, read_data_o} = buffer_out_data;
+
+    ternip_pipelined_interconnect #(
+        .DataWidth($bits(buffer_in_data)),
+        .NumStages(1)
+    ) buffer (
+        .clk_i,
+        .rst_ni,
+
+        .in_ready_o(buffer_in_ready),
+        .in_valid_i(buffer_in_valid),
+        .in_data_i(buffer_in_data),
+
+        .out_ready_i(buffer_out_ready),
+        .out_valid_o(buffer_out_valid),
+        .out_data_o(buffer_out_data)
+    );
+end else begin : coupled_ready
+    always_ff @(posedge clk_i) begin
+        if (!rst_ni) begin
+            read_valid_o <= 1'b0;
+        end else if (!stall3) begin
+            read_valid_o <= read_valid_q2;
+        end
+    end
+    always_ff @(posedge clk_i) begin
+        if (!stall3) begin
+            read_addr_o  <= read_valid_q2 ? request_addr_q2 : 'x;
+            read_data_o  <= read_valid_q2 ? read_data_q2    : 'x;
+        end
+    end
+end
+
+endmodule
+
+`undef SAFE_CLOG2

--- a/designs/src/ternip/BUILD.bazel
+++ b/designs/src/ternip/BUILD.bazel
@@ -12,7 +12,8 @@ _TERNIP_FILES = [
     "common/ternip_gearbox_fifo.sv",
     "common/ternip_multioperand_accumulator.sv",
     "common/ternip_pipelined_interconnect.sv",
-    # common/ternip_pipelined_mem.sv replaced by ternip_pipelined_mem_fakeram7.v (FakeRAM, asap7)
+    # common/ternip_pipelined_mem.sv replaced per-platform by a FakeRAM
+    # wrapper at designs/<platform>/ternip/ternip_pipelined_mem_fakeram*.v.
     "math/ternip_add.sv",
     "math/ternip_sub.sv",
     "math/ternip_mul.sv",

--- a/designs/src/ternip/dev/gen_fakeram.py
+++ b/designs/src/ternip/dev/gen_fakeram.py
@@ -56,6 +56,44 @@ PLATFORM_PARAMS = {
         "nom_voltage": 0.7,
         "op_cond_name": "tt_1.0_25.0",
     },
+    "nangate45": {
+        # Pin grid matches designs/src/cnn/dev/gen_fakeram_nangate45.py: metal3
+        # track pitch 0.14 µm, one pin per stdcell row (snap_h = 1.4 µm).  No
+        # VDD/VSS pins emitted — like cnn, rely on PDN-over-macro on metal4+.
+        "pin_w": 0.140,
+        "pin_protrusion": 0.140,
+        "lr_pitch": 0.140,
+        "pin_track_count": 10,    # 10 × 0.14 = 1.40 µm pin spacing (= snap_h)
+        "pin_start_tracks": 10,   # first pin at y = 1.40 µm
+        "snap_w": 0.190,
+        "snap_h": 1.400,
+        "area_per_bit": 3.8,
+        "min_area": 800,
+        "pin_layer": "metal3",
+        "obs_layers": ["metal1", "metal2", "metal3", "metal4"],
+        "emit_supply_pins": False,
+        "nom_voltage": 1.1,
+        "op_cond_name": "tt_1.0_25.0",
+    },
+    "sky130hd": {
+        # Pin grid matches designs/src/cnn/dev/gen_fakeram_sky130hd.py: met3
+        # track pitch 0.68 µm, one pin per stdcell row (snap_h = 2.72 µm).
+        # unithd site: 0.46 × 2.72.
+        "pin_w": 0.300,
+        "pin_protrusion": 0.300,
+        "lr_pitch": 0.680,
+        "pin_track_count": 4,     # 4 × 0.68 = 2.72 µm pin spacing (= snap_h)
+        "pin_start_tracks": 4,    # first pin at y = 2.72 µm
+        "snap_w": 0.460,
+        "snap_h": 2.720,
+        "area_per_bit": 4.0,
+        "min_area": 800,
+        "pin_layer": "met3",
+        "obs_layers": ["li1", "met1", "met2", "met3", "met4"],
+        "emit_supply_pins": False,
+        "nom_voltage": 1.8,
+        "op_cond_name": "tt_1.0_25.0",
+    },
 }
 
 
@@ -139,53 +177,55 @@ def gen_lef(name, width, depth, outdir, platform):
     for i in range(width):
         add_pin(f"rw0_rd_out[{i}]", "OUTPUT")
 
-    # VDD / VSS supply rails
-    track_off = p["supply_track_offset"]
-    track_pitch = p["supply_track_pitch"]
-    rail_w = p.get("supply_rail_w", p["pin_w"])
-    direction = p.get("supply_direction", "horizontal")
-    span_axis = h if direction == "horizontal" else w
-    track_centers = []
-    n = 0
-    while True:
-        c = track_off + n * track_pitch
-        if c + rail_w / 2 > span_axis:
-            break
-        if c - rail_w / 2 >= 0:
-            track_centers.append(c)
-        n += 1
-    vdd_centers = track_centers[0::2]
-    vss_centers = track_centers[1::2]
+    # VDD / VSS supply rails.  Skipped on platforms (cnn-style) that route
+    # PDN over the macro on an upper metal not touched by the signal pins.
+    if p.get("emit_supply_pins", True):
+        track_off = p["supply_track_offset"]
+        track_pitch = p["supply_track_pitch"]
+        rail_w = p.get("supply_rail_w", p["pin_w"])
+        direction = p.get("supply_direction", "horizontal")
+        span_axis = h if direction == "horizontal" else w
+        track_centers = []
+        n = 0
+        while True:
+            c = track_off + n * track_pitch
+            if c + rail_w / 2 > span_axis:
+                break
+            if c - rail_w / 2 >= 0:
+                track_centers.append(c)
+            n += 1
+        vdd_centers = track_centers[0::2]
+        vss_centers = track_centers[1::2]
 
-    # Supply rails must keep clear of the signal-pin protrusions at the macro
-    # edges — they're on the same layer, so any overlap is a short.  Use a
-    # one-track gap after the pin tip (matches liteeth: pin protrusion 0.048,
-    # rail margin 0.096 → 0.048 µm gap).
-    supply_margin_xy = p["pin_protrusion"] + p["lr_pitch"]
+        # Supply rails must keep clear of the signal-pin protrusions at the
+        # macro edges — they're on the same layer, so any overlap is a short.
+        # Use a one-track gap after the pin tip (matches liteeth: pin
+        # protrusion 0.048, rail margin 0.096 → 0.048 µm gap).
+        supply_margin_xy = p["pin_protrusion"] + p["lr_pitch"]
 
-    def add_supply(net, use, centers):
-        lines.extend([
-            f"  PIN {net}",
-            "    DIRECTION INOUT ;",
-            f"    USE {use} ;",
-            "    PORT",
-            f"      LAYER {p['supply_layer']} ;",
-        ])
-        for c in sorted(centers):
-            if direction == "horizontal":
-                x0, x1 = supply_margin_xy, w - supply_margin_xy
-                y0, y1 = c - rail_w / 2, c + rail_w / 2
-            else:
-                x0, x1 = c - rail_w / 2, c + rail_w / 2
-                y0, y1 = supply_margin_xy, h - supply_margin_xy
-            lines.append(f"      RECT {x0:.3f} {y0:.3f} {x1:.3f} {y1:.3f} ;")
-        lines.extend([
-            "    END",
-            f"  END {net}",
-        ])
+        def add_supply(net, use, centers):
+            lines.extend([
+                f"  PIN {net}",
+                "    DIRECTION INOUT ;",
+                f"    USE {use} ;",
+                "    PORT",
+                f"      LAYER {p['supply_layer']} ;",
+            ])
+            for c in sorted(centers):
+                if direction == "horizontal":
+                    x0, x1 = supply_margin_xy, w - supply_margin_xy
+                    y0, y1 = c - rail_w / 2, c + rail_w / 2
+                else:
+                    x0, x1 = c - rail_w / 2, c + rail_w / 2
+                    y0, y1 = supply_margin_xy, h - supply_margin_xy
+                lines.append(f"      RECT {x0:.3f} {y0:.3f} {x1:.3f} {y1:.3f} ;")
+            lines.extend([
+                "    END",
+                f"  END {net}",
+            ])
 
-    add_supply("VDD", "POWER", vdd_centers)
-    add_supply("VSS", "GROUND", vss_centers)
+        add_supply("VDD", "POWER", vdd_centers)
+        add_supply("VSS", "GROUND", vss_centers)
 
     lines.append("  OBS")
     for layer in p["obs_layers"]:


### PR DESCRIPTION
Extends ternip from asap7-only to all three HighTide platforms.

## Changes

* `designs/src/ternip/dev/gen_fakeram.py` — adds `nangate45` and
  `sky130hd` `PLATFORM_PARAMS` entries (cnn-style metal3/met3 pin
  grid, no VDD/VSS pins — PDN routes over-macro). Made supply-pin
  emission optional via a new `emit_supply_pins` flag.
* `designs/{nangate45,sky130hd}/ternip/sram/{lef,lib}/` —
  generated `fakeram45_512x16` (249.66 × 126.00 µm) and
  `fakeram130_512x16` (256.22 × 130.56 µm). For reference, the asap7
  cell is 90.56 × 45.36 µm — so ~15–16× the asap7 area, as expected
  for 45 nm / 130 nm vs. 7 nm.
* `designs/{nangate45,sky130hd}/ternip/ternip_pipelined_mem_fakeram{45,130}.v`
  — per-platform wrappers, identical to the asap7 wrapper except for
  the macro module name. The depth-banking logic (vector_registers:
  8 × 512×16; exportvector: 2 × 512×16; importvector: flip-flops) is
  platform-agnostic.
* `designs/{nangate45,sky130hd}/ternip/BUILD.bazel` + `constraint.sdc`:
    * nangate45: util 35, halo 15 15, clock 5 ns
    * sky130hd:  util 25, halo 30 30, clock 25 ns
* No `MACRO_PLACEMENT_TCL` — RTLMP handles 10 macros fine; revisit
  if MPL-0040 hits.

## Status

Configurations established. PPA tuning will continue in a separate
worktree.