### PR TITLE
ternip: bump upstream to 187957b

### DIFF
--- a/designs/src/ternip/DECISIONS.md
+++ b/designs/src/ternip/DECISIONS.md
@@ -22,7 +22,10 @@ None — ternip closes with RTLMP placement.
 ## asap7
 
 **Status**: finishing
-**Last updated**: 2026-05-13 (FakeRAM regen).
+**Last updated**: 2026-05-28 (upstream bump to `187957b5`).
+
+### Decisions
+- **2026-05-28 `187957b5`**: bumped `dev/repo` to upstream `187957b5` — single commit, improves rowwise multioperand combinational operations in `rtl/fus/ternip_rowwise_operation.sv`. Closes #148.
 
 ### Configuration
 

--- a/designs/src/ternip/dev/rtl/fus/ternip_rowwise_operation.sv
+++ b/designs/src/ternip/dev/rtl/fus/ternip_rowwise_operation.sv
@@ -272,16 +272,20 @@ always_comb begin
                 read_response_counter_d++;
                 if (read_response_counter_q % 2 == 0) begin // received vec1 read
                     vector1_r_data_d = vector_read_data_i;
-                end else if (read_response_counter_q % 2 == 1) begin // received vec2 read
-                    vector_request_valid_o = 1;
-                    vector_request_write_not_read_o = 1;
-                    vector_request_vector_select_o = vector3_select_q;
-                    vector_request_vector_addr_o = write_request_counter_q;
-                    if (vector_request_ready_i) begin
-                        write_request_counter_d++;
-                        if (write_request_counter_q >= NumChunksPerVector-1) begin
-                            state_d = WAITING_FOR_IN;
-                        end
+                end
+            end
+
+            // Request issuance: write takes priority over read on the cycle
+            // an odd response arrives; otherwise issue the next read.
+            if (vector_read_valid_i && (read_response_counter_q % 2 == 1)) begin // received vec2 read -> write
+                vector_request_valid_o = 1;
+                vector_request_write_not_read_o = 1;
+                vector_request_vector_select_o = vector3_select_q;
+                vector_request_vector_addr_o = write_request_counter_q;
+                if (vector_request_ready_i) begin
+                    write_request_counter_d++;
+                    if (write_request_counter_q >= NumChunksPerVector-1) begin
+                        state_d = WAITING_FOR_IN;
                     end
                 end
             end else if (read_request_counter_q < 2*NumChunksPerVector) begin


### PR DESCRIPTION
## Summary
- Bump `designs/src/ternip/dev/repo` `7573c17d` → `187957b5` (1 commit).
- Single upstream change: improved rowwise multioperand combinational operations (`rtl/fus/ternip_rowwise_operation.sv`).
- Regenerated `dev/rtl/` via `designs/src/ternip/dev/setup.sh`.

## Test plan
- [x] `bazel build //designs/asap7/ternip:ternip_final` (passes locally, 941s; mostly cache hits — 9 sandboxed actions for the affected stages).

Closes #148.