### PR TITLE
ternip: bump basejump_stl to b48037e2

### DIFF
--- a/designs/src/ternip/DECISIONS.md
+++ b/designs/src/ternip/DECISIONS.md
@@ -22,10 +22,11 @@ None — ternip closes with RTLMP placement.
 ## asap7
 
 **Status**: finishing
-**Last updated**: 2026-05-28 (upstream bump to `187957b5`).
+**Last updated**: 2026-05-28 (basejump_stl bump to `b48037e2`).
 
 ### Decisions
 - **2026-05-28 `187957b5`**: bumped `dev/repo` to upstream `187957b5` — single commit, improves rowwise multioperand combinational operations in `rtl/fus/ternip_rowwise_operation.sv`. Closes #148.
+- **2026-05-28 `b48037e2`**: bumped `dev/basejump_stl` to `b48037e2` (3 commits: rp_groups `.v` extensions, `bsg_fifo_1r1w_narrowed.sv` update, `bsg_reduce balanced_p` param). None touch files in `_BSG_FILES` — regenerated `dev/bsg/` is bit-identical, build is pure cache hit. Closes #149.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary
- Bump `designs/src/ternip/dev/basejump_stl` `a43571d2` → `b48037e2` (3 commits).
- None of the upstream commits (rp_groups `.v` extensions, `bsg_fifo_1r1w_narrowed.sv` update, `bsg_reduce balanced_p` param) touch any file in `BUILD.bazel`'s `_BSG_FILES` list, so the regenerated `dev/bsg/` is bit-identical and the synthesized RTL is unchanged.

## Test plan
- [x] `bazel build //designs/asap7/ternip:ternip_final` (passes locally, 12s; all cache hits — only the submodule pin changed).

Closes #149.