### PR TITLE
CLAUDE.md → per-design DECISIONS.md migration (reduce hotspot conflicts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,27 +75,26 @@ Dev mode requires: `git submodule update --init designs/src/<design>/dev/repo` b
 | nangate45 | 45nm | coralnpu, gemmini, lfsr, litedram, minimax, NyuziProcessor, sha3, liteeth, bp_processor (bp_uno, bp_quad), cnn |
 | sky130hd | 130nm open | gemmini, lfsr, litedram, minimax, sha3, liteeth, cnn, bp_processor (bp_uno) |
 
-#### Build status (as of 2026-05-11)
+#### Build status
 
-Designs reaching `_final` (cached on remote build cache):
-- **asap7**: coralnpu, gemmini, lfsr, litedram, minimax, sha3, vortex, liteeth, NVDLA partitions a/m/o
+Per-design close history, knobs, QoR, and known issues live in **`designs/src/<design>/DECISIONS.md`**, with one `## <platform>` section per technology. Update there, not here — this index just tracks which (design, platform) pairs are reaching `_final`.
+
+Reaching `_final` (cached on remote build cache):
+- **asap7**: coralnpu, gemmini, lfsr, litedram, minimax, sha3, vortex, liteeth, NVDLA partitions a/m/o, NyuziProcessor
 - **nangate45**: coralnpu, gemmini, lfsr, litedram, minimax, NyuziProcessor, sha3, liteeth
 - **sky130hd**: gemmini, lfsr, litedram, minimax, sha3, liteeth, NVDLA partitions a/m/o/p
 
-Newly finishing after the wd_in-fix recovery (verified locally, 2026-05-16):
-- **sky130hd**: `cnn` (fixed-grid `macro_placement.tcl` + `PLACE_DENSITY=0.20` + halo 300 — full GDS, 0 route DRC)
-- **nangate45**: `cnn`; **asap7/nangate45**: NVDLA `partition_c` (local sweep `6_final`)
-- **sky130hd**: `bp_uno` (2026-05-26 — fixed-grid `macro_placement.tcl` at DIE=8000×8000, 140 macros R0+FIRM; WNS +4.4 ns, 0 DRC). `6_final.odb` is 2.9 GB — Cloudflare-local-build only.
-- **asap7**: `NyuziProcessor` (2026-05-27) — added custom `pdn.tcl` (copy of gemmini's) to fix PSM-0069 VDD connectivity; default platform PDN was too sparse to survive macro-pin obstructions (983 PDN-0195 via-removals → 18k unconnected fillers). PPA-tuned to `CORE_UTILIZATION=65` / `clk_period=3000 ps` (Fmax 274 MHz, core 1170k µm² — −15% area and +27% Fmax vs initial close). At util 65 the denser place exposed ODB-0445 in post-GRT `repair_timing`, worked around with `SKIP_INCREMENTAL_REPAIR=1`
+Reaching `_final` locally only (over the Cloudflare-tunnel 100 MB cache-upload ceiling — see the local-build list below):
+- **asap7**: NVDLA partition_c
+- **nangate45**: cnn, NVDLA partition_c
+- **sky130hd**: cnn, bp_uno
 
-Not yet finishing (not cached):
-- **asap7**: floonoc, snitch_cluster, bp_processor (bp_uno, bp_quad), NVDLA partition p
+Not yet finishing:
+- **asap7**: floonoc, snitch_cluster, bp_processor (bp_uno, bp_quad), NVDLA partition_p
 - **nangate45**: bp_processor (bp_uno, bp_quad)
-- **sky130hd**: NVDLA partition c — global-placement plateau (~18 h on `3_place`, the documented GP overflow plateau); needs the same manual-grid `macro_placement.tcl` treatment cnn-sky130hd just got
+- **sky130hd**: NVDLA partition_c (global-placement plateau — see `designs/src/NVDLA/DECISIONS.md`)
 
-`sky130hd/NVDLA/partition_c` global placement plateaus at overflow ~0.31 (target 0.10) — 84 macros at sky130hd's coarse pitches create local density hot spots near macro pin clusters that the placer can't smooth out. Loosening `CORE_UTILIZATION` / `PLACE_DENSITY_LB_ADDON` / `MACRO_PLACE_HALO` to match working partitions doesn't fix it. Likely needs a manual `macros.tcl` to spread the 84 SRAMs into a regular grid.
-
-Use `tools/fetch_cache.sh` to pull cached `_final` results from the remote cache; designs marked NOT CACHED there are the not-yet-finishing set above.
+Use `tools/fetch_cache.sh` to pull cached `_final` results from the remote cache; designs in the local-only / not-finishing lists above aren't on it.
 
 ### Output Directories
 

--- a/designs/src/NVDLA/DECISIONS.md
+++ b/designs/src/NVDLA/DECISIONS.md
@@ -42,3 +42,21 @@ The FF stubs are emitted by `designs/src/NVDLA/dev/gen_ff_rams.py` into `designs
 | m | – | – |
 | o | 18x128, 8x256, 4x256, 7x256, 66x64, 15x80, 22x60, 32x128 | 9x80 |
 | p | 16x160, 65x160, 14x80, 66x80 | – |
+
+## asap7
+
+**Status**: partitions `a`, `m`, `o` cached on remote build cache; partition `c` finishing locally (local sweep `6_final`, 2026-05-16); partition `p` not yet finishing.
+
+## nangate45
+
+**Status**: same shape as asap7 — partitions `a`, `m`, `o` cached; partition `c` finishing locally (2026-05-16); partition `p` not yet finishing.
+
+## sky130hd
+
+**Status**: partitions `a`, `m`, `o`, `p` cached on remote build cache; **partition `c` does not finish** — global-placement plateau.
+
+### partition_c plateau
+
+Global placement plateaus at overflow ~0.31 (target 0.10). 84 macros at sky130hd's coarse pitches create local density hot spots near macro pin clusters that the placer can't smooth out. Loosening `CORE_UTILIZATION` / `PLACE_DENSITY_LB_ADDON` / `MACRO_PLACE_HALO` to match the other partitions doesn't fix it; ~18 h on `3_place` is the documented GP overflow plateau.
+
+Likely fix: a manual `macros.tcl` to spread the 84 SRAMs into a regular grid — same treatment that cnn-sky130hd ([[../cnn/DECISIONS.md]]) and bp_uno-sky130hd ([[../bp_processor/DECISIONS.md]]) needed.

--- a/designs/src/NyuziProcessor/DECISIONS.md
+++ b/designs/src/NyuziProcessor/DECISIONS.md
@@ -1,0 +1,85 @@
+# NyuziProcessor Design Decisions
+
+Per-platform notes for `NyuziProcessor` (Jeff Bush) — an open-source GPGPU written in SystemVerilog, with a 4-thread × 16-lane vector ISA. The HighTide port uses 8 vector lanes (halved from upstream 16 to reach a tractable cache-line width) and 2 L2 cache ways (halved from upstream 4) to fit asap7/nangate45/sky130hd floorplans.
+
+FakeRAM macros live at `designs/<platform>/NyuziProcessor/sram/{lef,lib}/` and are wrapped by `designs/src/NyuziProcessor/macros.v`.
+
+## asap7
+
+**Status**: finishing (PR #185, 2026-05-30)
+
+### Configuration
+
+| Knob | Value | Notes |
+|---|---|---|
+| `CORE_UTILIZATION` | 65 | PPA sweep raised 55 → 65; 55 macros are 52% of core, std cells pack the rest. GRT peak 32% on M2 — wide open. |
+| `PLACE_DENSITY_LB_ADDON` | 0.22 | Spread cells slightly given the large macro count. |
+| `MACRO_PLACE_HALO` | `6 6` | Aggressive (cells are small on asap7). |
+| `clk_period` | 3000 ps | Tighter target pushes synth/repair; Fmax = 273.76 MHz (period_min = 3653 ps). WNS reported negative against target — see "Reported WNS" below. |
+| `SKIP_CTS_REPAIR_TIMING` | 1 | ODB-1200 workaround — see [CLAUDE.md](../../../CLAUDE.md) bug table. |
+| `SKIP_INCREMENTAL_REPAIR` | 1 | ODB-0445 workaround — see CLAUDE.md bug table. |
+| `PDN_TCL` | `pdn.tcl` (copy of gemmini's) | Required; default platform PDN was too sparse — see PSM-0069 note below. |
+| `PRE_CTS_TCL` | `pre_cts.tcl` | CTS-0105 workaround — see CLAUDE.md bug table. |
+
+### QoR (cached on remote build cache, 2026-05-27)
+
+| Metric | Value |
+|---|---|
+| Fmax | 273.76 MHz |
+| period_min | 3652.77 ps |
+| Core area | 1170 k µm² (1084 × 1084 µm) |
+| Route DRC | 0 |
+| PSM connectivity | 0 warnings |
+| IR-drop violations | 0 |
+| Macros / sequential / combinational | 55 / 40 906 / 209 621 |
+| Power | 162 mW |
+
+### Decisions
+
+- **2026-05-25 (PR #185)** — initial close after the long-running port effort failed at PSM-0069 with 18 000+ unconnected filler VDD pins. Root cause: default asap7 platform PDN was too sparse for this design's macro density; PDN-gen removed 983 M2→M5 vias near macro pin obstructions, leaving M1 followpin shapes disconnected. Fix: copied `designs/asap7/gemmini/pdn.tcl` as a denser starting grid (M1/M2 followpins + M5/M6/M7 cross-stripes + macro grids).
+
+- **2026-05-27 (PR #185, second commit)** — 3-step disciplined PPA sweep from the post-PDN-fix baseline:
+
+  | iter | util | SDC (ps) | Fmax (MHz) | core (µm²) | DRC/PSM/IR |
+  |---|---:|---:|---:|---:|---|
+  | baseline | 55 | 3800 | 215.67 | 1383 k | 0 / 0 / 0 |
+  | iter 1 | 65 | 3800 | 241.41 | 1170 k | 0 / 0 / 0 |
+  | **iter 2 (landed)** | **65** | **3000** | **273.76** | **1170 k** | **0 / 0 / 0** |
+  | iter 3 abort | 65 | 2500 | — | — | host died mid-build |
+
+  Net vs baseline: **+27% Fmax, −15% area**, all checks clean.
+
+  - **Util 55 → 65**: at baseline, std-cell utilization in the available (non-macro) space was only 7.9% — massive packing headroom. Die shrunk without hitting routing or congestion limits. Macros are now 52% of core; that's the floor without repacking the macros themselves.
+  - **SDC 3800 → 3000 ps**: looser 3800 ps targets left synth/repair_timing under-motivated; tightening pushed both to pick faster cells and to optimize the wire-bound L2-cache critical path (`sram_l2_data → l2_response[307]`) harder.
+
+- **2026-05-27** — at util 65 the denser placement exposed **ODB-0445** in post-GRT `repair_timing` (`[CRITICAL] No undo_updateField support for type dbTechNonDefaultRule`). The resizer's `Journal::undo` can't unroll changes to non-default routing rules made during repair, so the slack-spiral retry on a single endpoint crashes out. Same workaround family as snitch_cluster/litedram: `SKIP_INCREMENTAL_REPAIR = 1`. Detailed-route hold-repair still runs and DRC stays clean. Documented in CLAUDE.md's bug-workaround table.
+
+### Reported WNS vs achievable Fmax
+
+The flow reports WNS = −653 ps at the 3000 ps target. That's not a real timing failure: it's the gap between the SDC target and the design's achievable period (3653 ps). Setting SDC to 3653 ps would zero the WNS but synth would slack off, increasing the period — a known ORFS pitfall (the [[#sdc-tightness-coupling]] note below). The reported `period_min`/`fmax` from `report_clock_min_period` are the truth: 273.76 MHz.
+
+### Known issues / open questions
+
+- **CTS-0105 false skip** — yosys hierarchical synthesis output port buffers arrive in ODB with `dbSourceType::TIMING`; `PRE_CTS_TCL` resets them to `NETLIST` before CTS runs ([OpenROAD #10177](https://github.com/The-OpenROAD-Project/OpenROAD/issues/10177)).
+- **ODB-1200** in CTS repair_timing — the gemmini-style targeted fix (drop `split_load` from `SETUP_MOVE_SEQUENCE`) didn't clear it for this design; escalated to `SKIP_CTS_REPAIR_TIMING = 1` ([HighTide #75](https://github.com/VLSIDA/HighTide/issues/75)).
+- **ODB-0445** in post-GRT repair_timing — only surfaces at util ≥ 65 here; no upstream issue filed yet.
+
+## nangate45
+
+**Status**: finishing (long-running baseline)
+
+### Configuration
+
+| Knob | Value | Notes |
+|---|---|---|
+| `CORE_UTILIZATION` | 57 | |
+| `PLACE_DENSITY_LB_ADDON` | 0.1 | |
+| `MACRO_PLACE_HALO` | `40 40` | Larger metal pitch needs more keep-out. |
+| `clk_period` | 4.5 ns (4500 ps) | |
+| `ABC_AREA` | 1 | |
+| `FASTROUTE_TCL` | `fastroute.tcl` | Per-layer routing adjustments. |
+| `PRE_CTS_TCL` | `pre_cts.tcl` | CTS-0105 workaround. |
+
+### Known issues / open questions
+
+- None active. Same CTS-0105 workaround applies (yosys-hierarchical port-buffer ODB metadata).

--- a/designs/src/cnn/DECISIONS.md
+++ b/designs/src/cnn/DECISIONS.md
@@ -35,3 +35,45 @@ sky130hd grew ~10× because:
 CACTI's optimizer minimises cycle time for an L3-cache-like target; with cnn's 16-bit-wide × 32K-deep memory and sky130hd's bitcell geometry, that lands at column-mux=1 and a 21 mm × 0.7 mm macro (30:1 aspect) — usable for area-estimate cells in a research context, not a real floorplan. The bsg_fakeram fork's analytical formula uses dynamic column muxing to land near 1.5:1 aspect and matches the same overhead model used for asap7.
 
 nangate45 stays on CACTI; its aspects come out 1.2–1.6 for cnn's four sizes.
+
+## asap7
+
+**Status**: finishing.
+
+`hightide_design()` with `CORE_UTILIZATION=60`, `PLACE_DENSITY=0.40`. Default RTLMP places the four `fakeram_w16_l32768` macros. **MPL-0040** workaround required — see CLAUDE.md bug table: `macros.tcl` pre-places the fakeram macros (FIRM) before RTLMP runs.
+
+## nangate45
+
+**Status**: finishing (2026-05-16).
+
+Fixed `DIE_AREA = 0 0 4502 4277` (auto-sizing didn't leave enough room for the 4 large macros). All 367 IO pins force-placed onto the bottom edge with `PLACE_PINS_ARGS` to avoid clustering and shorten routes to the stdcell band below the four `w16_l32768` macros at the top of the die. Default RTLMP for macro placement.
+
+## sky130hd
+
+**Status**: finishing (2026-05-16, with R4 banks experiment 2026-05-20).
+
+This was the hardest port — full RTL→GDS only landed after a stack of three independent fixes:
+
+1. **`wd_in` LEF direction fix** (bsg_fakeram `c83ecb4` / HighTide `044c02b9`) — killed the "net1337 1964-fanout" short, a LEF bug masquerading as real fanout.
+2. **Fixed-grid `MACRO_PLACEMENT_TCL`** (all macros R0, channel below every row) — every fakeram puts all signal pins on its bottom met2 edge; RTLMP was pin-edge-blind and clustered them so escape lanes collided. The hand grid faces every pin edge onto a clear channel.
+3. **`PLACE_DENSITY=0.20` + `MACRO_PLACE_HALO=300`** — spread the 28.6% std-cell utilization across the near-empty die instead of clumping them onto the macro pin edges.
+
+### R4 banks experiment (2026-05-20)
+
+After the close, the four 32K macros were sub-banked via cfg (`w16_l32768 banks=16`, `w16_l8192 banks=4`) — `4.93 × 4.01 mm → 1.23 × 1.00 mm` per macro (**−94% macro area**). With tiny macros the floorplan was retuned:
+
+| Knob | Before | After (current) |
+|---|---|---|
+| `DIE_AREA` | `0 0 20000 20000` (400 mm²) | `0 0 7000 7000` (49 mm²) |
+| `PLACE_DENSITY` | 0.20 | 0.40 |
+| `MACRO_PLACE_HALO` | 300 | 50 |
+| `MACRO_PLACEMENT_TCL` | hand grid (still required pre-R4) | dropped — RTLMP re-derives |
+
+The hand-placed coordinates from #2 above were valid for the old enormous macros and are obsolete now. Inline rationale lives in `designs/sky130hd/cnn/BUILD.bazel`.
+
+### Decisions
+
+- **2026-05-16**: full RTL→GDS, 0 GRT overflow on every layer (met2 1.46% usage), detail route 100% with 0 violations.
+- **2026-05-20** (R4): banks experiment shrunk macros 94% — die from 400 mm² to 49 mm².
+
+cnn-asap7 and cnn-nangate45 pass with RTLMP; only sky130's coarse pitch needed the hand grid + spread.


### PR DESCRIPTION
## Summary
- Move the "Newly finishing" narrative section and the NVDLA partition_c plateau paragraph out of `CLAUDE.md` into per-design `designs/src/<design>/DECISIONS.md` files.
- Reshape `CLAUDE.md`'s "Build status" into a pure status index: which (design, platform) pairs are remote-cached vs local-only (Cloudflare 100 MB ceiling) vs not-yet-finishing. No narrative, no dates.
- Create `designs/src/NyuziProcessor/DECISIONS.md` (the only design from the migrated content that didn't have one).
- Extend `cnn` and `NVDLA` DECISIONS.md with per-platform port sections for the previously-CLAUDE.md-resident close stories.

Cross-cutting bug-workaround table stays in `CLAUDE.md` — one bug spans multiple designs, the centralized lookup is the value.

## Why
`CLAUDE.md`'s "Newly finishing" block had become a merge-conflict hotspot — every per-design close PR (`bp_uno-sky130hd`, `nyuzi-asap7-ppa`, etc.) edited it in roughly the same place. Distributing the per-design content to the existing `DECISIONS.md` pattern (gemmini, coralnpu, liteeth, … all already have one) localizes future writes.

## What moved where
| Source line in old CLAUDE.md | New home |
|---|---|
| sky130hd cnn / nangate45 cnn close bullet | `designs/src/cnn/DECISIONS.md` (new `## asap7` / `## nangate45` / `## sky130hd` sections, plus R4 banks-experiment subsection) |
| asap7/nangate45 NVDLA partition_c local sweep | `designs/src/NVDLA/DECISIONS.md` (new `## asap7` / `## nangate45` partition-status sections) |
| sky130hd NVDLA partition_c plateau paragraph | `designs/src/NVDLA/DECISIONS.md` (new `## sky130hd` section with the "partition_c plateau" subsection) |
| sky130hd bp_uno close bullet | Already in `designs/src/bp_processor/DECISIONS.md` — no change |
| asap7 NyuziProcessor close + PPA-sweep bullet (added in #185) | `designs/src/NyuziProcessor/DECISIONS.md` (new file with full asap7 section + brief nangate45 baseline) |

## Test plan
- [x] `grep -c "<<<<<<<" CLAUDE.md` → 0 (no stray conflict markers).
- [x] Every (design, platform) pair previously in the "Newly finishing" bullets now appears in the relevant `DECISIONS.md`.
- [x] `CLAUDE.md`'s new "Build status" lists cover the same pairs (cached / local-only / not-finishing) as the old structure.
- [x] Reviewer sanity-check: read the new `NyuziProcessor` DECISIONS.md and confirm it captures the PR #185 story faithfully.