### PR TITLE
Skills: instruct DECISIONS.md as the per-design notes home (follow-up to #186)

### DIFF
--- a/.claude/skills/debug-design/SKILL.md
+++ b/.claude/skills/debug-design/SKILL.md
@@ -268,3 +268,15 @@ bazel build //designs/<platform>/<design>:<design>_final
 Compare metrics before and after (WNS, TNS, Fmax, DRC count, cell count) to verify the fix improved the situation.
 
 Once the design is passing cleanly, suggest that the user run `/optimize-ppa` to maximize utilization and clock frequency.
+
+## Step 7: Record the fix in DECISIONS.md
+
+After the fix lands, append a dated bullet to `designs/src/<design>/DECISIONS.md` under the `## <platform>` section (create the section, or the whole file, if missing — use `designs/src/gemmini/DECISIONS.md` as the canonical template). Capture:
+- **What surfaced** — the error code or symptom (stage, log marker).
+- **Root cause** — what you traced it back to (e.g. PDN-0195 via-removal near macros, MPL-0040 annealing failure, RTL-bounded path).
+- **Fix applied** — the BUILD.bazel argument, the new tcl file, the SDC tweak, with commit hash.
+- **Which prior design's experience you reused** — credit the DECISIONS.md / bug-table row you pulled the workaround from (the Step 0 prior-art search).
+
+If the fix is a workaround for a new upstream bug, also run `/track-bug` so the cross-cutting CLAUDE.md table gets a row pointing at the upstream issue.
+
+**Do not** add the debug story to `CLAUDE.md`. CLAUDE.md's "Build status" is a pure index; per-design narrative belongs in DECISIONS.md. Only update CLAUDE.md if the (design, platform) pair changed status (moved between cached / local-only / not-finishing).

--- a/.claude/skills/new-design/SKILL.md
+++ b/.claude/skills/new-design/SKILL.md
@@ -224,3 +224,17 @@ Repeat step 6 for nangate45 and sky130hd as needed. Each platform needs its own:
 - `BUILD.bazel` (adjust utilization/density for the technology)
 - `constraint.sdc` (adjust clock period for the technology)
 - `sram/` directory with platform-specific FakeRAM files (if applicable)
+
+### 11. Create DECISIONS.md
+
+Create `designs/src/$0/DECISIONS.md` with one `## <platform>` section per technology this design targets. Use `designs/src/gemmini/DECISIONS.md` as the canonical template (header + per-variant table + per-platform sections).
+
+Each platform section should capture:
+- **Status**: `finishing` or `not yet finishing`
+- **Configuration**: a table of every non-default `BUILD.bazel` `arguments` knob, the SDC clock period, and which `pdn.tcl` / `io.tcl` / `pre_cts.tcl` files are wired in.
+- **Decisions**: dated bullet list of the non-obvious calls made (why this utilization, why this SDC, what congestion / IR / timing surfaces you fought), with commit hashes.
+- **Known issues / open questions**: active workarounds, anything pending.
+
+For pre-existing designs that need a DECISIONS.md retroactively, the `update-design --init-decisions <design>` skill bootstraps a starter file from git history + BUILD.bazel + SDC.
+
+**Do not** add the new design's narrative to `CLAUDE.md`. CLAUDE.md's "Build status" is a pure index of which (design, platform) pairs reach `_final`; per-design narrative belongs in DECISIONS.md. Update CLAUDE.md only to add the design to the Platforms table and to the appropriate status list (cached / local-only / not-finishing).

--- a/.claude/skills/optimize-ppa/SKILL.md
+++ b/.claude/skills/optimize-ppa/SKILL.md
@@ -254,3 +254,14 @@ Continue iterating until either:
 - Further utilization increases cause unresolvable congestion/DRC
 - Further clock tightening causes timing violations that cannot be closed
 - The user is satisfied with the achieved PPA
+
+### 6a. Record the sweep in DECISIONS.md
+
+Once the user accepts a result, append the outcome to `designs/src/<design>/DECISIONS.md` under the `## <platform>` section (create the section if it's missing). Capture:
+- **An updated Configuration table** reflecting the new knobs that landed.
+- **A new dated "Decisions" bullet** describing the sweep — what changed, the per-iteration table (util / SDC / Fmax / area / DRC / runtime) including any failed iterations and why, which Step 0 prior-art DECISIONS.md informed the choices, and the commit hash once you commit.
+- **Any new "Known issues / open questions"** discovered along the way (bug workarounds added, plateaus hit, hold-skew limits, etc.). If a new upstream bug was found, also run `/track-bug` to add it to CLAUDE.md's centralized bug table.
+
+The per-iteration table from Step 6's comparison output transplants directly — keep it. Future readers (including the next invocation of this skill) will rely on it as prior art.
+
+**Do not** add the PPA narrative to `CLAUDE.md`. CLAUDE.md's "Build status" is a pure index; per-design narrative lives in DECISIONS.md. Update CLAUDE.md only if a (design, platform) pair moved between the cached / local-only / not-finishing lists.

--- a/.claude/skills/port-design/SKILL.md
+++ b/.claude/skills/port-design/SKILL.md
@@ -157,3 +157,15 @@ After a successful build, check:
 - `bazel-bin/designs/$2/$0/reports/$2/$0/base/` for QoR reports
 - No DRC violations in the final report
 - Timing meets the target clock period (some slack is expected for initial ports)
+
+### 13. Record the port in DECISIONS.md
+
+Append a new `## $2` section to `designs/src/$0/DECISIONS.md`. If the file doesn't exist yet, create it using `designs/src/gemmini/DECISIONS.md` as the canonical template (header + per-variant table + per-platform sections).
+
+Each platform section should capture:
+- **Status**: `finishing` or `not yet finishing`
+- **Configuration**: a table of every non-default `BUILD.bazel` `arguments` knob, the SDC clock period, and which `pdn.tcl` / `io.tcl` / `pre_cts.tcl` files are wired in. For workaround knobs, point at the CLAUDE.md bug-table row rather than repeating the rationale.
+- **Decisions**: dated bullet list of non-obvious calls made during the port (why this utilization, what congestion you hit, why a custom PDN was needed, which prior design's experience you reused), with commit hashes once you commit.
+- **Known issues / open questions**: active workarounds, anything pending.
+
+**Do not** add the port summary to `CLAUDE.md`. CLAUDE.md's "Build status" section is a pure index of which (design, platform) pairs reach `_final`; per-design narrative belongs in DECISIONS.md. Update CLAUDE.md only to move the new (design, platform) row between the cached / local-only / not-finishing lists.


### PR DESCRIPTION
## Summary
Without these skill updates, the next invocation of `/port-design`, `/new-design`, `/optimize-ppa`, or `/debug-design` would tell the user to update `CLAUDE.md` and re-create the hotspot resolved in #186.

| Skill | Change |
|---|---|
| **port-design** | New final step "13. Record the port in DECISIONS.md" — points at `designs/src/gemmini/DECISIONS.md` as the canonical template; explicit "do not add to CLAUDE.md". |
| **new-design** | New final step "11. Create DECISIONS.md" — same template pointer; also references `update-design --init-decisions` for retroactive cases. |
| **optimize-ppa** | Step 0 already promised a Step 6 DECISIONS.md write-back, but Step 6 never delivered. Adds Step 6a with what to record (updated config table, dated decisions bullet with the per-iteration sweep table, new known issues). Notes that new upstream bugs should also trigger `/track-bug`. |
| **debug-design** | New "Step 7: Record the fix in DECISIONS.md" — standard sections (symptom, root cause, fix, prior-art credit) plus `/track-bug` pointer for upstream-bug workarounds. |
| **track-bug** | No change — correctly writes to CLAUDE.md's centralized table; cross-cutting bugs stay there per the #186 migration. |
| **update-design** | No change — already documents DECISIONS.md as the per-design home. |

## Test plan
- [x] `git diff --stat` shows only the 4 skill files touched.
- [x] Each skill's new section consistently says "do not add to CLAUDE.md" and routes new bug findings through `/track-bug`.
- [ ] Reviewer sanity-check: skim the new sections and confirm the template pointer (`gemmini/DECISIONS.md`) and the CLAUDE.md/DECISIONS.md split match the convention from #186.