### PR TITLE
vortex: bump upstream to d425a56 (v2.3+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 sv2v
 **/dev/liteeth_builds
 designs/src/liteeth/dev/*_build_*/
+**/vortex/dev/gen/
 **/dev/litedram_build_*
 **/litedram_core.v.orig
 **/dev/bender

--- a/designs/src/vortex/rtl/libs/VX_axi_adapter.sv
+++ b/designs/src/vortex/rtl/libs/VX_axi_adapter.sv
@@ -261,7 +261,7 @@ module VX_axi_adapter #(
         assign m_axi_awid[i]    = TAG_WIDTH_OUT'(xbar_tag_out);
         assign m_axi_awlen[i]   = 8'b00000000;
         assign m_axi_awsize[i]  = 3'(LOG2_DATA_SIZE);
-        assign m_axi_awburst[i] = 2'b00;
+        assign m_axi_awburst[i] = 2'b01;
         assign m_axi_awlock[i]  = 2'b00;
         assign m_axi_awcache[i] = 4'b0000;
         assign m_axi_awprot[i]  = 3'b000;
@@ -296,7 +296,7 @@ module VX_axi_adapter #(
         assign m_axi_arid[i]    = TAG_WIDTH_OUT'(xbar_tag_r_out);
         assign m_axi_arlen[i]   = 8'b00000000;
         assign m_axi_arsize[i]  = 3'(LOG2_DATA_SIZE);
-        assign m_axi_arburst[i] = 2'b00;
+        assign m_axi_arburst[i] = 2'b01;
         assign m_axi_arlock[i]  = 2'b00;
         assign m_axi_arcache[i] = 4'b0000;
         assign m_axi_arprot[i]  = 3'b000;


### PR DESCRIPTION
## Summary
- Bump `designs/src/vortex/dev/repo` `31e4765d` → `d425a56e` (86 upstream commits).
- After applying our `srcs.bzl` exclusions (alternate tops / FPGA AFU / TCU), only **one** synthesizable RTL file actually changes: `libs/VX_axi_adapter.sv` flips both `AWBURST` and `ARBURST` from `2'b00` (FIXED) to `2'b01` (INCR). It's a release-tree file but **not** in `VORTEX_FILES` — we use the inner `Vortex.sv` top, not the AXI-wrapped `Vortex_axi.sv`. Committed for tree-sync, no synth impact.
- Upstream added two new top-level dirs (`afu/`, `tcu/` — TensorCoreUnit). Both explicitly excluded by `srcs.bzl` and not promoted into `rtl/`.

Also gitignore `**/vortex/dev/gen/` — setup.sh's rsync staging area, never meant to be committed.

## Test plan
- [x] `dev/setup.sh` runs clean.
- [x] `bazel build //designs/asap7/vortex:vortex_gallery` — **passes locally, 6603s**.
- [x] `bazel build //designs/nangate45/vortex:vortex_gallery` — **passes locally, 4246s**.
- [x] `bazel build //designs/sky130hd/vortex:vortex_gallery` — **passes locally, 6349s**.

Closes #82.