### PR TITLE
freq-push: raise Fmax to reg2reg floor + 10% guardband across 23 designs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,12 @@ When reporting or comparing cell counts across designs or platforms, **exclude f
 
 Use the per-class fields in `6_report.json` (e.g. `class:sequential_cell`, `class:multi_input_combinational_cell`, `class:inverter`, `class:clock_buffer`, `class:timing_repair_buffer`) — not the top-level `instance__count` — when comparing designs.
 
+## Pushing clock frequency (and the io-feedthrough WNS trap)
+
+When tightening a design's clock period to raise Fmax, **do not use `finish__timing__setup__ws` (reported WNS) as the limiter.** For LiteX/protocol/NVDLA designs (litedram, liteeth, litepci, floonoc, NVDLA, bp_uno) the worst setup path is often a pure input→output *combinational feedthrough* constrained only by `set_input_delay + set_output_delay = clk_io_pct*period`, so its slack is `~0.6*period` and shows a permanent huge "margin" no matter how tight the clock — it tracks the constraint, not silicon, and masks the real register-to-register path (some designs were reg2reg-*violated* at baseline while reported WNS stayed positive). `6_finish.rpt`'s setup section only prints the worst path per group (= this io path), so it can't reveal reg2reg slack either.
+
+**Use `report_clock_min_period` instead** — the `period_min` field in `6_finish.rpt` is the achievable minimum period from the routed netlist and is reg2reg-dominated. ORFS synthesis optimizes *to the target clock*, so `period_min` keeps dropping as you tighten (litedram-asap7 floor fell 2373→1217→902 ps as the target tightened); iterate `clk_period = period_min * 1.10`, rebuild, re-read, until `set/period_min ≈ 1.10` (converged). Some designs hit a **routability** floor first (P&R fails before timing runs out — back off to the tightest that routes). Retrieve `period_min` for large designs via `k8s/run.sh --upload-artifacts` (PVC); their stage ODBs bust the Cloudflare cache cap.
+
 ## Known OpenROAD / yosys-slang bug workarounds
 
 Designs in this repo carry workarounds for upstream tool bugs. Update this table whenever a new workaround lands, and remove rows once the upstream bug is fixed and the workaround can be reverted.

--- a/designs/asap7/NyuziProcessor/constraint.sdc
+++ b/designs/asap7/NyuziProcessor/constraint.sdc
@@ -1,6 +1,6 @@
 current_design NyuziProcessor
 
-set clk_period 3000
+set clk_period 2850
 set clk_io_pct 0.2
 
 create_clock -name clk -period $clk_period [get_ports clk]

--- a/designs/asap7/NyuziProcessor/constraint.sdc
+++ b/designs/asap7/NyuziProcessor/constraint.sdc
@@ -1,6 +1,6 @@
 current_design NyuziProcessor
 
-set clk_period 3000
+set clk_period 2841
 set clk_io_pct 0.2
 
 create_clock -name clk -period $clk_period [get_ports clk]

--- a/designs/asap7/NyuziProcessor/constraint.sdc
+++ b/designs/asap7/NyuziProcessor/constraint.sdc
@@ -1,6 +1,6 @@
 current_design NyuziProcessor
 
-set clk_period 2850
+set clk_period 3000
 set clk_io_pct 0.2
 
 create_clock -name clk -period $clk_period [get_ports clk]

--- a/designs/asap7/floonoc/constraint.sdc
+++ b/designs/asap7/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 2000
+set clk_period 975
 
 set clk_port [get_ports $clk_port_name]
 

--- a/designs/asap7/floonoc/constraint.sdc
+++ b/designs/asap7/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 1040
+set clk_period 884
 
 set clk_port [get_ports $clk_port_name]
 

--- a/designs/asap7/floonoc/constraint.sdc
+++ b/designs/asap7/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 884
+set clk_period 821
 
 set clk_port [get_ports $clk_port_name]
 

--- a/designs/asap7/floonoc/constraint.sdc
+++ b/designs/asap7/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 975
+set clk_period 1040
 
 set clk_port [get_ports $clk_port_name]
 

--- a/designs/asap7/litedram/constraint.sdc
+++ b/designs/asap7/litedram/constraint.sdc
@@ -13,7 +13,7 @@ set clk_port    [get_ports clk]
 # is comfortably absorbed; this is the slowest clock that still beats
 # the sky130hd target (36 ns at 130 nm) and the nangate45 target
 # (12 ns at 45 nm) on a relative-process-speed basis.
-set clk_period  25000
+set clk_period  11150
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/asap7/litedram/constraint.sdc
+++ b/designs/asap7/litedram/constraint.sdc
@@ -13,7 +13,7 @@ set clk_port    [get_ports clk]
 # is comfortably absorbed; this is the slowest clock that still beats
 # the sky130hd target (36 ns at 130 nm) and the nangate45 target
 # (12 ns at 45 nm) on a relative-process-speed basis.
-set clk_period  11150
+set clk_period  5100
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/asap7/litedram/constraint.sdc
+++ b/designs/asap7/litedram/constraint.sdc
@@ -13,7 +13,7 @@ set clk_port    [get_ports clk]
 # is comfortably absorbed; this is the slowest clock that still beats
 # the sky130hd target (36 ns at 130 nm) and the nangate45 target
 # (12 ns at 45 nm) on a relative-process-speed basis.
-set clk_period  2610
+set clk_period  1338
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/asap7/litedram/constraint.sdc
+++ b/designs/asap7/litedram/constraint.sdc
@@ -13,7 +13,7 @@ set clk_port    [get_ports clk]
 # is comfortably absorbed; this is the slowest clock that still beats
 # the sky130hd target (36 ns at 130 nm) and the nangate45 target
 # (12 ns at 45 nm) on a relative-process-speed basis.
-set clk_period  5100
+set clk_period  5600
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/asap7/litedram/constraint.sdc
+++ b/designs/asap7/litedram/constraint.sdc
@@ -13,7 +13,7 @@ set clk_port    [get_ports clk]
 # is comfortably absorbed; this is the slowest clock that still beats
 # the sky130hd target (36 ns at 130 nm) and the nangate45 target
 # (12 ns at 45 nm) on a relative-process-speed basis.
-set clk_period  1338
+set clk_period  1047
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/asap7/litedram/constraint.sdc
+++ b/designs/asap7/litedram/constraint.sdc
@@ -13,7 +13,7 @@ set clk_port    [get_ports clk]
 # is comfortably absorbed; this is the slowest clock that still beats
 # the sky130hd target (36 ns at 130 nm) and the nangate45 target
 # (12 ns at 45 nm) on a relative-process-speed basis.
-set clk_period  5600
+set clk_period  2610
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/asap7/liteeth/constraint.sdc
+++ b/designs/asap7/liteeth/constraint.sdc
@@ -2,7 +2,7 @@ current_design liteeth_udp_usp_gth_sgmii
 
 set clk_name clk
 set clk_port_name sys_clock
-set clk_period 920
+set clk_period 900
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/asap7/liteeth/constraint.sdc
+++ b/designs/asap7/liteeth/constraint.sdc
@@ -2,7 +2,7 @@ current_design liteeth_udp_usp_gth_sgmii
 
 set clk_name clk
 set clk_port_name sys_clock
-set clk_period 1000
+set clk_period 1022
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/asap7/liteeth/constraint.sdc
+++ b/designs/asap7/liteeth/constraint.sdc
@@ -2,7 +2,7 @@ current_design liteeth_udp_usp_gth_sgmii
 
 set clk_name clk
 set clk_port_name sys_clock
-set clk_period 900
+set clk_period 1000
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/asap7/sha3/constraint.sdc
+++ b/designs/asap7/sha3/constraint.sdc
@@ -2,7 +2,7 @@ current_design sha3
 
 set clk_name  clk
 set clk_port_name clock
-set clk_period 1000
+set clk_period 950
 
 set clk_port [get_ports $clk_port_name]
 

--- a/designs/asap7/sha3/constraint.sdc
+++ b/designs/asap7/sha3/constraint.sdc
@@ -2,7 +2,7 @@ current_design sha3
 
 set clk_name  clk
 set clk_port_name clock
-set clk_period 950
+set clk_period 929
 
 set clk_port [get_ports $clk_port_name]
 

--- a/designs/asap7/ternip/constraint.sdc
+++ b/designs/asap7/ternip/constraint.sdc
@@ -2,7 +2,7 @@ current_design ternip_core
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 1715
+set clk_period 975
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/asap7/ternip/constraint.sdc
+++ b/designs/asap7/ternip/constraint.sdc
@@ -2,7 +2,7 @@ current_design ternip_core
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 975
+set clk_period 953
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/NVDLA/partition_a/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_a/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 4.5
+set clk_period 3.28
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_a/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_a/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 3.28
+set clk_period 2.63
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_a/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_a/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 2.90
+set clk_period 1.93
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_a/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_a/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 1.93
+set clk_period 1.71
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_a/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_a/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 2.63
+set clk_period 2.90
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_c/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_c/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_c
 
 set clk_name nvdla_core_clk
-set clk_period 4.07
+set clk_period 3.63
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_c/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_c/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_c
 
 set clk_name nvdla_core_clk
-set clk_period 4.5
+set clk_period 4.07
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_c/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_c/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_c
 
 set clk_name nvdla_core_clk
-set clk_period 3.54
+set clk_period 3.90
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_c/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_c/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_c
 
 set clk_name nvdla_core_clk
-set clk_period 4.06
+set clk_period 3.54
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_c/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_c/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_c
 
 set clk_name nvdla_core_clk
-set clk_period 3.63
+set clk_period 4.06
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_m/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_m/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_m
 
 set clk_name nvdla_core_clk
-set clk_period 2.93
+set clk_period 2.20
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_m/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_m/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_m
 
 set clk_name nvdla_core_clk
-set clk_period 4.5
+set clk_period 2.93
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_m/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_m/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_m
 
 set clk_name nvdla_core_clk
-set clk_period 2.20
+set clk_period 2.33
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_m/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_m/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_m
 
 set clk_name nvdla_core_clk
-set clk_period 2.33
+set clk_period 2.21
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_o/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_o/constraint.sdc
@@ -6,7 +6,7 @@ current_design NV_NVDLA_partition_o
 
 set clk_name nvdla_core_clk
 set clk_falcon_name nvdla_falcon_clk
-set clk_period 6.0
+set clk_period 5.37
 set clk_falcon_period 7.5
 set clk_io_pct 0.2
 

--- a/designs/nangate45/NVDLA/partition_o/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_o/constraint.sdc
@@ -6,7 +6,7 @@ current_design NV_NVDLA_partition_o
 
 set clk_name nvdla_core_clk
 set clk_falcon_name nvdla_falcon_clk
-set clk_period 5.37
+set clk_period 5.92
 set clk_falcon_period 7.5
 set clk_io_pct 0.2
 

--- a/designs/nangate45/NVDLA/partition_o/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_o/constraint.sdc
@@ -6,7 +6,7 @@ current_design NV_NVDLA_partition_o
 
 set clk_name nvdla_core_clk
 set clk_falcon_name nvdla_falcon_clk
-set clk_period 4.11
+set clk_period 3.62
 set clk_falcon_period 7.5
 set clk_io_pct 0.2
 

--- a/designs/nangate45/NVDLA/partition_o/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_o/constraint.sdc
@@ -6,7 +6,7 @@ current_design NV_NVDLA_partition_o
 
 set clk_name nvdla_core_clk
 set clk_falcon_name nvdla_falcon_clk
-set clk_period 5.92
+set clk_period 4.11
 set clk_falcon_period 7.5
 set clk_io_pct 0.2
 

--- a/designs/nangate45/NVDLA/partition_p/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_p/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_p
 
 set clk_name nvdla_core_clk
-set clk_period 4.5
+set clk_period 3.97
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_p/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_p/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_p
 
 set clk_name nvdla_core_clk
-set clk_period 4.35
+set clk_period 2.18
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_p/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_p/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_p
 
 set clk_name nvdla_core_clk
-set clk_period 2.18
+set clk_period 2.08
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/NVDLA/partition_p/constraint.sdc
+++ b/designs/nangate45/NVDLA/partition_p/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_p
 
 set clk_name nvdla_core_clk
-set clk_period 3.97
+set clk_period 4.35
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/bp_processor/bp_uno/constraint.sdc
+++ b/designs/nangate45/bp_processor/bp_uno/constraint.sdc
@@ -2,7 +2,7 @@ current_design bp_processor
 
 set clk_name  CLK
 set clk_port_name clk_i
-set clk_period 9.0
+set clk_period 7.77
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/bp_processor/bp_uno/constraint.sdc
+++ b/designs/nangate45/bp_processor/bp_uno/constraint.sdc
@@ -2,7 +2,7 @@ current_design bp_processor
 
 set clk_name  CLK
 set clk_port_name clk_i
-set clk_period 7.77
+set clk_period 8.53
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/bp_processor/bp_uno/constraint.sdc
+++ b/designs/nangate45/bp_processor/bp_uno/constraint.sdc
@@ -2,7 +2,7 @@ current_design bp_processor
 
 set clk_name  CLK
 set clk_port_name clk_i
-set clk_period 5.70
+set clk_period 5.29
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/bp_processor/bp_uno/constraint.sdc
+++ b/designs/nangate45/bp_processor/bp_uno/constraint.sdc
@@ -2,7 +2,7 @@ current_design bp_processor
 
 set clk_name  CLK
 set clk_port_name clk_i
-set clk_period 8.53
+set clk_period 5.70
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/floonoc/constraint.sdc
+++ b/designs/nangate45/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 5.0
+set clk_period 3.48
 set clk_io_pct 0.25
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/floonoc/constraint.sdc
+++ b/designs/nangate45/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 3.48
+set clk_period 3.75
 set clk_io_pct 0.25
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/floonoc/constraint.sdc
+++ b/designs/nangate45/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 2.27
+set clk_period 1.98
 set clk_io_pct 0.25
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/floonoc/constraint.sdc
+++ b/designs/nangate45/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 3.75
+set clk_period 2.79
 set clk_io_pct 0.25
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/floonoc/constraint.sdc
+++ b/designs/nangate45/floonoc/constraint.sdc
@@ -2,7 +2,7 @@ current_design floonoc_mesh_top
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 2.79
+set clk_period 2.27
 set clk_io_pct 0.25
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/lfsr/constraint.sdc
+++ b/designs/nangate45/lfsr/constraint.sdc
@@ -2,7 +2,7 @@ current_design lfsr_prbs_gen
 
 set clk_name  core_clock
 set clk_port_name clk
-set clk_period 0.46 
+set clk_period 0.37 
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/lfsr/constraint.sdc
+++ b/designs/nangate45/lfsr/constraint.sdc
@@ -2,7 +2,7 @@ current_design lfsr_prbs_gen
 
 set clk_name  core_clock
 set clk_port_name clk
-set clk_period 0.37 
+set clk_period 0.35 
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/litedram/constraint.sdc
+++ b/designs/nangate45/litedram/constraint.sdc
@@ -5,7 +5,7 @@ current_design litedram_core
 # liteeth variants — start at 12 ns (~83 MHz) and tighten later.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  5.6
+set clk_period  2.82
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/nangate45/litedram/constraint.sdc
+++ b/designs/nangate45/litedram/constraint.sdc
@@ -5,7 +5,7 @@ current_design litedram_core
 # liteeth variants — start at 12 ns (~83 MHz) and tighten later.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  12
+set clk_period  5.6
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/nangate45/litedram/constraint.sdc
+++ b/designs/nangate45/litedram/constraint.sdc
@@ -5,7 +5,7 @@ current_design litedram_core
 # liteeth variants — start at 12 ns (~83 MHz) and tighten later.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  2.96
+set clk_period  2.15
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/nangate45/litedram/constraint.sdc
+++ b/designs/nangate45/litedram/constraint.sdc
@@ -5,7 +5,7 @@ current_design litedram_core
 # liteeth variants — start at 12 ns (~83 MHz) and tighten later.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  6.0
+set clk_period  2.96
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/nangate45/litedram/constraint.sdc
+++ b/designs/nangate45/litedram/constraint.sdc
@@ -5,7 +5,7 @@ current_design litedram_core
 # liteeth variants — start at 12 ns (~83 MHz) and tighten later.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  2.82
+set clk_period  6.0
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/nangate45/litedram/constraint.sdc
+++ b/designs/nangate45/litedram/constraint.sdc
@@ -5,7 +5,7 @@ current_design litedram_core
 # liteeth variants — start at 12 ns (~83 MHz) and tighten later.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  2.15
+set clk_period  1.98
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/nangate45/liteeth/constraint.sdc
+++ b/designs/nangate45/liteeth/constraint.sdc
@@ -2,7 +2,7 @@ current_design liteeth_udp_usp_gth_sgmii
 
 set clk_name clk
 set clk_port_name sys_clock
-set clk_period 4.46
+set clk_period 2.34
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/liteeth/constraint.sdc
+++ b/designs/nangate45/liteeth/constraint.sdc
@@ -2,7 +2,7 @@ current_design liteeth_udp_usp_gth_sgmii
 
 set clk_name clk
 set clk_port_name sys_clock
-set clk_period 10
+set clk_period 4.46
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/liteeth/constraint.sdc
+++ b/designs/nangate45/liteeth/constraint.sdc
@@ -2,7 +2,7 @@ current_design liteeth_udp_usp_gth_sgmii
 
 set clk_name clk
 set clk_port_name sys_clock
-set clk_period 2.51
+set clk_period 1.78
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/liteeth/constraint.sdc
+++ b/designs/nangate45/liteeth/constraint.sdc
@@ -2,7 +2,7 @@ current_design liteeth_udp_usp_gth_sgmii
 
 set clk_name clk
 set clk_port_name sys_clock
-set clk_period 1.78
+set clk_period 1.66
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/liteeth/constraint.sdc
+++ b/designs/nangate45/liteeth/constraint.sdc
@@ -2,7 +2,7 @@ current_design liteeth_udp_usp_gth_sgmii
 
 set clk_name clk
 set clk_port_name sys_clock
-set clk_period 2.34
+set clk_period 2.51
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/litepci/constraint.sdc
+++ b/designs/nangate45/litepci/constraint.sdc
@@ -8,14 +8,18 @@ current_design litepcie_core
 # a data path under `set_output_delay`.
 
 set clk_name      sys_clk
-# 4 ns / 250 MHz — nangate45 baseline.  Real critical path is FakeRAM
-# clk-to-Q + DMA datapath; SDC target left above the FakeRAM-bounded
-# typical worst-case to allow clean closure (analogous to asap7's 3.6 ns).
-set clk_period    4000
+# nangate45 (SDC unit = ns).  Real critical path is FakeRAM clk-to-Q + DMA
+# datapath; nangate45 (45 nm) is far slower than asap7 (7 nm), so the closing
+# period is well above asap7's 3.6 ns.  Probe at 10 ns, then tighten to the
+# measured critical path + 10% guardband.
+# NOTE: previously `set clk_period 4000` and refclk `-period 10000` — those were
+# ps-magnitude values in an ns-unit file (1000x unit error), making STA report
+# a meaningless +3197 ns WNS / 0.00 GHz Fmax.
+set clk_period    10
 set clk_io_pct    0.2
 
 create_clock -name $clk_name -period $clk_period [get_pins pcie_us/user_clk]
-create_clock -name pcie_refclk -period 10000 [get_ports pcie_clk_p]
+create_clock -name pcie_refclk -period 10 [get_ports pcie_clk_p]
 set_clock_groups -asynchronous \
     -group [get_clocks $clk_name] \
     -group [get_clocks pcie_refclk]

--- a/designs/nangate45/sha3/constraint.sdc
+++ b/designs/nangate45/sha3/constraint.sdc
@@ -2,7 +2,7 @@ current_design sha3
 
 set clk_name  clk
 set clk_port_name clock
-set clk_period 2.5
+set clk_period 2.22
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/sha3/constraint.sdc
+++ b/designs/nangate45/sha3/constraint.sdc
@@ -2,7 +2,7 @@ current_design sha3
 
 set clk_name  clk
 set clk_port_name clock
-set clk_period 2.22
+set clk_period 2.09
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/ternip/constraint.sdc
+++ b/designs/nangate45/ternip/constraint.sdc
@@ -2,7 +2,7 @@ current_design ternip_core
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 5.15
+set clk_period 1.92
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/ternip/constraint.sdc
+++ b/designs/nangate45/ternip/constraint.sdc
@@ -2,7 +2,7 @@ current_design ternip_core
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 1.92
+set clk_period 1.86
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/nangate45/vortex/constraint.sdc
+++ b/designs/nangate45/vortex/constraint.sdc
@@ -2,7 +2,7 @@ current_design Vortex
 
 set clk_name clk
 set clk_port_name clk
-set clk_period 3.0
+set clk_period 2.62
 set clk_io_pct 0.1
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/vortex/constraint.sdc
+++ b/designs/nangate45/vortex/constraint.sdc
@@ -2,7 +2,7 @@ current_design Vortex
 
 set clk_name clk
 set clk_port_name clk
-set clk_period 2.85
+set clk_period 2.65
 set clk_io_pct 0.1
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/vortex/constraint.sdc
+++ b/designs/nangate45/vortex/constraint.sdc
@@ -2,7 +2,7 @@ current_design Vortex
 
 set clk_name clk
 set clk_port_name clk
-set clk_period 2.65
+set clk_period 2.46
 set clk_io_pct 0.1
 
 set clk_port [get_ports $clk_name]

--- a/designs/nangate45/vortex/constraint.sdc
+++ b/designs/nangate45/vortex/constraint.sdc
@@ -2,7 +2,7 @@ current_design Vortex
 
 set clk_name clk
 set clk_port_name clk
-set clk_period 2.62
+set clk_period 2.85
 set clk_io_pct 0.1
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/NVDLA/partition_a/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_a/constraint.sdc
@@ -2,7 +2,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 11.88
+set clk_period 10.15
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/NVDLA/partition_a/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_a/constraint.sdc
@@ -2,7 +2,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 15.0
+set clk_period 11.88
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/NVDLA/partition_a/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_a/constraint.sdc
@@ -2,7 +2,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 10.15
+set clk_period 7.89
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/NVDLA/partition_a/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_a/constraint.sdc
@@ -2,7 +2,7 @@
 current_design NV_NVDLA_partition_a
 
 set clk_name nvdla_core_clk
-set clk_period 7.89
+set clk_period 7.61
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/NVDLA/partition_m/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_m/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_m
 
 set clk_name nvdla_core_clk
-set clk_period 12.6
+set clk_period 10.21
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/NVDLA/partition_m/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_m/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_m
 
 set clk_name nvdla_core_clk
-set clk_period 10.21
+set clk_period 11.0
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/NVDLA/partition_m/constraint.sdc
+++ b/designs/sky130hd/NVDLA/partition_m/constraint.sdc
@@ -5,7 +5,7 @@
 current_design NV_NVDLA_partition_m
 
 set clk_name nvdla_core_clk
-set clk_period 11.0
+set clk_period 10.18
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_name]

--- a/designs/sky130hd/litedram/constraint.sdc
+++ b/designs/sky130hd/litedram/constraint.sdc
@@ -4,7 +4,7 @@ current_design litedram_core
 # delay of nangate45, so scale the starter target accordingly.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  19.16
+set clk_period  11.66
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/sky130hd/litedram/constraint.sdc
+++ b/designs/sky130hd/litedram/constraint.sdc
@@ -4,7 +4,7 @@ current_design litedram_core
 # delay of nangate45, so scale the starter target accordingly.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  36
+set clk_period  19.16
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/sky130hd/litedram/constraint.sdc
+++ b/designs/sky130hd/litedram/constraint.sdc
@@ -4,7 +4,7 @@ current_design litedram_core
 # delay of nangate45, so scale the starter target accordingly.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  12.43
+set clk_period  10.10
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/sky130hd/litedram/constraint.sdc
+++ b/designs/sky130hd/litedram/constraint.sdc
@@ -4,7 +4,7 @@ current_design litedram_core
 # delay of nangate45, so scale the starter target accordingly.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  10.10
+set clk_period  9.59
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/sky130hd/litedram/constraint.sdc
+++ b/designs/sky130hd/litedram/constraint.sdc
@@ -4,7 +4,7 @@ current_design litedram_core
 # delay of nangate45, so scale the starter target accordingly.
 set clk_name    clk
 set clk_port    [get_ports clk]
-set clk_period  11.66
+set clk_period  12.43
 set clk_io_pct  0.2
 
 create_clock -name $clk_name -period $clk_period $clk_port

--- a/designs/sky130hd/litepci/constraint.sdc
+++ b/designs/sky130hd/litepci/constraint.sdc
@@ -7,13 +7,16 @@ current_design litepcie_core
 
 set clk_name      sys_clk
 # 20 ns / 50 MHz — sky130hd baseline.  Real critical path is FakeRAM
-# clk-to-Q + DMA datapath; SDC target left above the FakeRAM-bounded
-# typical worst-case to allow clean closure (analogous to asap7's 3.6 ns).
-set clk_period    20000
+# clk-to-Q + DMA datapath.
+# NOTE: previously `set clk_period 20000` and refclk `-period 10000` — those
+# were ps-magnitude values in an ns-unit file (1000x unit error). Corrected to
+# 20 ns (sys_clk) / 10 ns (100 MHz PCIe refclk). This design still does not
+# route on the new GRT (issue #204), independent of the clock.
+set clk_period    20
 set clk_io_pct    0.2
 
 create_clock -name $clk_name -period $clk_period [get_pins pcie_us/user_clk]
-create_clock -name pcie_refclk -period 10000 [get_ports pcie_clk_p]
+create_clock -name pcie_refclk -period 10 [get_ports pcie_clk_p]
 set_clock_groups -asynchronous \
     -group [get_clocks $clk_name] \
     -group [get_clocks pcie_refclk]

--- a/designs/sky130hd/ternip/constraint.sdc
+++ b/designs/sky130hd/ternip/constraint.sdc
@@ -2,7 +2,7 @@ current_design ternip_core
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 17.15
+set clk_period 8.66
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/designs/sky130hd/ternip/constraint.sdc
+++ b/designs/sky130hd/ternip/constraint.sdc
@@ -2,7 +2,7 @@ current_design ternip_core
 
 set clk_name  clk
 set clk_port_name clk_i
-set clk_period 8.66
+set clk_period 8.43
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]


### PR DESCRIPTION
## Summary

Pushes the clock frequency of every over-provisioned design to its **true register-to-register timing floor + 10% guardband**, found via `report_clock_min_period`. Net result: large Fmax gains, all designs closing on real silicon timing (not the misleading reported WNS).

## The key finding (why this took care)

The reported setup WNS (`finish__timing__setup__ws`) is **not** the frequency limiter for the LiteX/protocol/NVDLA designs. Their worst setup path is a pure **input→output combinational feedthrough** (e.g. litedram `cmd_addr[9]`→`cmd_ready`) constrained only by `set_input/output_delay = clk_io_pct*period`, so its slack is `~0.6*period` and shows a permanent ~57% "margin" no matter how tight the clock — it tracks the constraint, not the design. This masked real reg2reg violations (e.g. **liteeth-asap7 never actually met reg2reg at its 920 ps baseline**).

The fix: drive the clock from **`report_clock_min_period`** (`period_min` — reg2reg-dominated, read from the routed netlist). Because ORFS synthesis optimizes *to the target*, `period_min` keeps dropping as the target tightens, so I iterated `clk_period = period_min * 1.10` until `set/period_min ≈ 1.10` (5-6 build rounds for the deepest designs; litedram-asap7's floor fell 5600→2373→1217→902 ps). `partition_c-n45` hit a **routability** floor (P&R failed to route at 3.54 ns before timing ran out) and is pinned at the tightest routable period.

## Results (baseline → final clk_period, Fmax)

| design | plat | baseline → final | Fmax | gain |
|---|---|---|---|---|
| litedram | asap7 | 25000 → 1047 ps | 40 → 955 MHz | 24× |
| litedram | nangate45 | 12 → 1.98 ns | 83 → 505 MHz | 6.1× |
| liteeth | nangate45 | 10 → 1.66 ns | 100 → 602 MHz | 6.0× |
| litedram | sky130hd | 36 → 9.59 ns | 28 → 104 MHz | 3.8× |
| ternip | nangate45 | 5.15 → 1.86 ns | 194 → 538 MHz | 2.8× |
| partition_a | nangate45 | 4.5 → 1.71 ns | 222 → 585 MHz | 2.6× |
| floonoc | nangate45 | 5 → 1.98 ns | 200 → 505 MHz | 2.5× |
| floonoc | asap7 | 2000 → 821 ps | 500 → 1218 MHz | 2.4× |
| partition_p | nangate45 | 4.5 → 2.08 ns | 222 → 481 MHz | 2.2× |
| partition_m | nangate45 | 4.5 → 2.21 ns | 222 → 452 MHz | 2.0× |
| ternip | sky130hd | 17.15 → 8.43 ns | 58 → 119 MHz | 2.0× |
| partition_a | sky130hd | 15 → 7.61 ns | 67 → 131 MHz | 2.0× |
| ternip | asap7 | 1715 → 953 ps | 583 → 1049 MHz | 1.8× |
| bp_uno | nangate45 | 9 → 5.29 ns | 111 → 189 MHz | 1.7× |
| partition_o | nangate45 | 6 → 3.62 ns | 167 → 276 MHz | 1.7× |
| lfsr | nangate45 | 0.46 → 0.35 ns | 2174 → 2857 MHz | 1.3× |
| partition_m | sky130hd | 12.6 → 10.18 ns | 79 → 98 MHz | 1.2× |
| vortex | nangate45 | 3 → 2.46 ns | 333 → 407 MHz | 1.2× |
| sha3 | nangate45 | 2.5 → 2.09 ns | 400 → 478 MHz | 1.2× |
| partition_c | nangate45 | 4.5 → 3.90 ns | 222 → 256 MHz | 1.15× (routability floor) |
| sha3 | asap7 | 1000 → 929 ps | 1000 → 1076 MHz | 1.08× |
| NyuziProcessor | asap7 | 3000 → 2841 ps | 333 → 352 MHz | 1.06× |
| liteeth | asap7 | 920 → 1022 ps | 1087 → 978 MHz | **0.90× (correction)** |

**liteeth-asap7 is the one "regression"** — but its 920 ps baseline was *below* its reg2reg floor (929 ps), i.e. it never actually met register-to-register timing; the io feedthrough hid the violation. 1022 ps is the correct closing period.

## Scope notes

- Only `constraint.sdc` `clk_period` values changed (no RTL, no other constraints).
- Designs already at their floor were left at baseline; reg2reg-clean compute designs (sha3, lfsr, ternip) needed little change.
- **litepci** is handled separately — its nangate45/sky130hd SDCs additionally had a **ns/ps unit bug** (4000/20000 in ns-unit files); those are corrected on this branch, but its forwarded-clock model needs the same `period_min` treatment to finish (follow-up).

## Follow-ups (not in this PR)
- Final **local builds** to populate the bazel cache (k8s `--upload-artifacts` writes the PVC, not the cache).
- `update-results` page refresh once merged.