### PR TITLE
Add plain-ORFS run path for OpenROAD researchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ google-cloud-sdk/
 google-cloud-cli-*.tar.gz
 audit_upstream_items.ndjson
 tmp/
+.run_orfs/
 
 # bsg_fakeram intermediate outputs — re-generated locally by
 # tools/regenerate_sram.sh; the .lef/.lib that matter are copied into

--- a/README.md
+++ b/README.md
@@ -2,22 +2,7 @@
 
 A VLSI design benchmark suite that runs open-source hardware designs through the [OpenROAD](https://github.com/The-OpenROAD-Project/OpenROAD) RTL-to-GDSII flow on academic and open-source technology nodes (ASAP7 7nm, NanGate 45nm, SkyWater 130nm).
 
-**New here?** See the **[Quick Start Guide](docs/quickstart.md)** to build your first design in 5 minutes.
-
-## Designs
-
-8 designs across 3 technology platforms, ranging from a small LFSR to a quad-core RISC-V processor:
-
-| Design | Type | asap7 | nangate45 | sky130hd |
-|--------|------|:-----:|:---------:|:--------:|
-| lfsr | LFSR/PRBS generator | x | x | x |
-| minimax | RISC-V RV32I core | x | x | x |
-| liteeth | Ethernet MAC (6 variants) | x | x | x |
-| NyuziProcessor | Multi-threaded GPGPU | x | x | |
-| bp_processor | Black-Parrot RISC-V (2 variants) | x | x | |
-| gemmini | ML systolic array | x | x | |
-| cnn | CNN accelerator | x | x | |
-| sha3 | SHA3 hash | x | x | |
+**New here?** See the **[Quick Start Guide](docs/quickstart.md)** to build your first design in 5 minutes. For the full, up-to-date list of designs and the platforms each one closes on, see the **[Design Catalog](docs/designs.md)**.
 
 ## How It Works
 
@@ -31,20 +16,82 @@ bazel build --define update_rtl=true //designs/asap7/lfsr:lfsr_final
 
 The release RTL is then run through the [OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts) RTL-to-GDSII flow: synthesis (Yosys) → floorplan → placement → clock tree synthesis → routing → GDSII output. Each design has per-platform configuration (clock constraints, utilization targets, pin placement) tuned for the target technology node.
 
-## Running a design in upstream ORFS
+## Running a design in upstream ORFS (for OpenROAD researchers)
 
-The Bazel flow is the supported entry point, but every design's
-parameters can be extracted into an ORFS-compatible `config.mk` for
-use with vanilla `OpenROAD-flow-scripts`:
+The Bazel (`bazel-orfs`) flow is HighTide's golden, supported entry
+point. But if you want to experiment with **a custom OpenROAD build**,
+**modified flow Tcl scripts**, or **added/changed flow steps**, plain
+`OpenROAD-flow-scripts` (a single `config.mk` + the standard `Makefile`)
+is the easier interface. Two tools bridge the gap.
+
+### One command: `tools/run_orfs.sh`
 
 ```bash
-tools/bazel_to_config_mk.sh designs/asap7/lfsr > /tmp/lfsr.config.mk
-make -C OpenROAD-flow-scripts/flow DESIGN_CONFIG=$(pwd)/tmp/lfsr.config.mk
+# Golden flow + bazel-built openroad, full place-and-route:
+tools/run_orfs.sh designs/asap7/lfsr
+
+# Your own OpenROAD build, only through placement:
+tools/run_orfs.sh --openroad ~/OpenROAD/build/src/openroad \
+                  designs/asap7/lfsr floorplan place
+
+# Your modified flow scripts:
+tools/run_orfs.sh --flow-home ~/OpenROAD-flow-scripts designs/sky130hd/eyeriss
+```
+
+It extracts the design's resolved `config.mk`, **reuses the golden
+synthesized netlist** bazel-orfs already produced
+(`results/.../1_synth.{odb,sdc}`), and runs the standard ORFS `Makefile`
+from floorplan onward against the OpenROAD binary (`--openroad`, sets
+`OPENROAD_EXE`) and flow (`--flow-home`) you choose. Reusing the netlist
+means **no yosys / yosys-slang toolchain is needed** and the P&R starting
+point is identical to HighTide's published QoR. (Synthesis is therefore
+not re-run here; use the bazel flow to re-synthesize.)
+
+To **edit flow scripts**, clone ORFS and point `--flow-home` at it:
+
+```bash
+git clone https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
+# Check out the commit run_orfs.sh prints ("golden ORFS commit ...") for a
+# comparable baseline — or stay on HEAD if matching HighTide's numbers
+# doesn't matter. Then edit flow/scripts/*.tcl and:
+tools/run_orfs.sh --flow-home ./OpenROAD-flow-scripts designs/asap7/lfsr
+```
+
+**QoR caveat:** HighTide's published numbers come from the bazel-orfs
+build, which pins specific tool commits (bazel-orfs, OpenROAD, and the
+ORFS commit it resolves). Pointing `--flow-home` at a *newer* ORFS shifts
+the baseline, and some extracted `config.mk` workaround variables (e.g.
+`SKIP_CTS_REPAIR_TIMING`, `SETUP_MOVE_SEQUENCE`, `write_sdc` async-reset
+edits) may be unnecessary or stale — review them against your ORFS.
+
+### Just the config.mk: `tools/bazel_to_config_mk.sh`
+
+To drive ORFS yourself, extract an ORFS-compatible `config.mk` (with
+`--abs`, absolute paths that run from any directory):
+
+```bash
+tools/bazel_to_config_mk.sh --abs designs/asap7/lfsr /tmp/lfsr.config.mk
+make -C OpenROAD-flow-scripts/flow DESIGN_CONFIG=/tmp/lfsr.config.mk
 ```
 
 The script builds the design through `bazel-orfs` (cached after the
 first run), then unions the per-stage `*.short.mk` files Bazel writes
 and strips Bazel-internal vars.
+
+### Alternative: a custom OpenROAD inside bazel-orfs (binary swap only)
+
+If you only need a different OpenROAD binary and want to keep bazel's
+caching, override the `openroad` label instead of leaving bazel — per
+design via `openroad = "//path/to:my_openroad"` on the
+`hightide_design()`/`orfs_flow()` call, or globally in `MODULE.bazel`:
+
+```starlark
+orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
+orfs.default(openroad = "@my_openroad//:openroad")
+```
+
+This cannot modify flow Tcl scripts (`FLOW_HOME` is pinned) — use the
+`config.mk` path above for flow-script or flow-step changes.
 
 ## Documentation
 

--- a/tools/bazel_to_config_mk.sh
+++ b/tools/bazel_to_config_mk.sh
@@ -13,16 +13,24 @@
 # OpenROAD-flow-scripts (`make DESIGN_CONFIG=<this-file> ...`).
 #
 # Usage:
-#   tools/bazel_to_config_mk.sh <design-dir-or-label> [output-file]
+#   tools/bazel_to_config_mk.sh [--abs] <design-dir-or-label> [output-file]
+#
+# Options:
+#   --abs   Emit absolute paths (rooted at the repo) for the path-bearing
+#           vars (VERILOG_FILES, SDC_FILE, ADDITIONAL_LEFS/LIBS/GDS,
+#           PDN_TCL, IO_CONSTRAINTS, FOOTPRINT_TCL, MACRO_PLACEMENT_TCL,
+#           VERILOG_INCLUDE_DIRS) so the config.mk runs from any CWD and
+#           against any ORFS clone. Default keeps workspace-relative paths.
 #
 # Examples:
 #   tools/bazel_to_config_mk.sh designs/asap7/lfsr
+#   tools/bazel_to_config_mk.sh --abs designs/asap7/lfsr   ./lfsr.config.mk
 #   tools/bazel_to_config_mk.sh //designs/asap7/lfsr:lfsr   ./lfsr.config.mk
 #   tools/bazel_to_config_mk.sh designs/asap7/liteeth/liteeth_mac_axi_mii
 #
 # Caveats:
-# - VERILOG_FILES / SDC_FILE paths are workspace-relative. Run upstream
-#   ORFS Make from the HighTide repo root (or symlink the paths in).
+# - Without --abs, VERILOG_FILES / SDC_FILE paths are workspace-relative;
+#   run upstream ORFS Make from the HighTide repo root (or use --abs).
 # - For designs that synthesize from dev-generated RTL (genrules), the
 #   resolved paths point into bazel-out/. Use --define update_rtl=true
 #   before extraction if you want fresh generated sources, or rely on
@@ -37,10 +45,24 @@ usage() {
     exit 1
 }
 
-[ $# -ge 1 ] && [ $# -le 2 ] || usage
+abs=0
+positional=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --abs)      abs=1; shift ;;
+        -h|--help)  usage ;;
+        --)         shift; while [ $# -gt 0 ]; do positional+=("$1"); shift; done ;;
+        -*)         echo "ERROR: unknown option: $1" >&2; usage ;;
+        *)          positional+=("$1"); shift ;;
+    esac
+done
 
-input=$1
-output=${2:-}
+[ "${#positional[@]}" -ge 1 ] && [ "${#positional[@]}" -le 2 ] || usage
+
+input=${positional[0]}
+output=${positional[1]:-}
+
+repo_root=$(git rev-parse --show-toplevel)
 
 # --- Normalize the input to package + target name -------------------
 case "$input" in
@@ -117,15 +139,41 @@ emit() {
 EOF
 
     # `export VAR?=VALUE` → keep the first occurrence of each VAR.
+    # With --abs, prefix each repo-relative token of the path-bearing
+    # vars with the repo root so the config.mk runs from any CWD.
     grep -h '^export ' "${shortmks[@]}" \
-        | awk -F'?=' -v skip="$SKIP_VARS" '
+        | awk -v skip="$SKIP_VARS" -v abs="$abs" -v root="$repo_root" '
+            # Vars whose value is one or more file/dir paths.
+            function is_pathvar(k) {
+                return (k ~ /^(VERILOG_FILES|SDC_FILE|ADDITIONAL_LEFS|ADDITIONAL_LIBS|ADDITIONAL_GDS|IO_CONSTRAINTS|FOOTPRINT_TCL|MACRO_PLACEMENT_TCL|VERILOG_INCLUDE_DIRS|PDN_TCL)$/) || (k ~ /_TCL$/)
+            }
             {
-                key = $1
+                pos = index($0, "?=")
+                if (pos == 0) next
+                lhs = substr($0, 1, pos + 1)   # includes "?="
+                val = substr($0, pos + 2)
+                key = lhs
                 sub(/^export /, "", key)
+                sub(/\?=$/, "", key)
                 sub(/[[:space:]]+$/, "", key)
                 if (key ~ skip)   next
                 if (seen[key]++)  next
-                print
+
+                if (abs == "1" && is_pathvar(key)) {
+                    n = split(val, toks, /[[:space:]]+/)
+                    out = ""
+                    for (i = 1; i <= n; i++) {
+                        t = toks[i]
+                        if (t == "") continue
+                        # Absolutize relative paths; leave abs paths and
+                        # make/flag tokens (-, $) untouched.
+                        if (t !~ /^\// && t !~ /^-/ && t !~ /^\$/)
+                            t = root "/" t
+                        out = (out == "" ? t : out " " t)
+                    }
+                    val = out
+                }
+                print lhs val
             }' \
         | sort
 }

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+#
+# Run a HighTide design in upstream OpenROAD-flow-scripts (plain ORFS),
+# so OpenROAD researchers can experiment with a custom OpenROAD binary,
+# modified flow Tcl scripts, or added/changed flow steps — without
+# leaving HighTide's golden bazel-orfs configuration behind.
+#
+# It (1) extracts the design's resolved ORFS config.mk via
+# tools/bazel_to_config_mk.sh --abs, (2) reuses the golden synthesized
+# netlist bazel-orfs already produced (results/.../1_synth.{odb,sdc}) so
+# no yosys / yosys-slang plugin is needed and the P&R starting point is
+# identical to HighTide's published QoR, and (3) runs the standard ORFS
+# Makefile from floorplan onward against the OpenROAD binary and flow
+# you choose.
+#
+# Usage:
+#   tools/run_orfs.sh [options] <design-dir-or-label> [make-target...]
+#
+# Options:
+#   --flow-home DIR  ORFS checkout to run (its `flow/` dir or the dir
+#                    itself). Default: the exact ORFS bazel-orfs resolved
+#                    (read-only) — i.e. HighTide's golden flow. To edit
+#                    flow scripts, clone ORFS at the commit printed below,
+#                    edit flow/scripts/*.tcl, and pass --flow-home <clone>.
+#   --openroad BIN   openroad executable (sets OPENROAD_EXE). Default: the
+#                    bazel-built @openroad//:openroad. Point this at your
+#                    own build to test a custom OpenROAD.
+#   --work-dir DIR   Run/output directory (becomes ORFS WORK_HOME).
+#                    Default: <repo>/.run_orfs/<platform>/<design>.
+#   --config FILE    Use this config.mk instead of extracting one.
+#   --no-build       Don't (re)build in bazel; assume stages + config exist.
+#   -h, --help       Print this help and exit.
+#
+# make-target defaults to: floorplan place cts route finish
+#
+# Examples:
+#   # Out-of-box: golden flow + bazel openroad, full P&R.
+#   tools/run_orfs.sh designs/asap7/lfsr
+#   # My OpenROAD build, only through placement.
+#   tools/run_orfs.sh --openroad ~/OpenROAD/build/src/openroad \
+#                     designs/asap7/lfsr floorplan place
+#   # My modified ORFS flow scripts.
+#   tools/run_orfs.sh --flow-home ~/OpenROAD-flow-scripts designs/sky130hd/eyeriss
+#
+# Note: synthesis is reused from the golden bazel build, not re-run here
+# (that keeps every design buildable without the yosys-slang toolchain and
+# holds the netlist fixed). To re-synthesize, use the bazel flow.
+
+set -euo pipefail
+
+usage() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//' >&2
+    exit 1
+}
+
+flow_home=""
+openroad=""
+work_dir=""
+config=""
+no_build=0
+positional=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --flow-home) flow_home=$2; shift 2 ;;
+        --openroad)  openroad=$2;  shift 2 ;;
+        --work-dir)  work_dir=$2;  shift 2 ;;
+        --config)    config=$2;    shift 2 ;;
+        --no-build)  no_build=1;   shift ;;
+        -h|--help)   usage ;;
+        --)          shift; while [ $# -gt 0 ]; do positional+=("$1"); shift; done ;;
+        -*)          echo "ERROR: unknown option: $1" >&2; usage ;;
+        *)           positional+=("$1"); shift ;;
+    esac
+done
+
+[ "${#positional[@]}" -ge 1 ] || usage
+input=${positional[0]}
+targets=("${positional[@]:1}")
+[ "${#targets[@]}" -gt 0 ] || targets=(floorplan place cts route finish)
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# --- Normalize the design input to a bazel package (designs/<plat>/<d>) ---
+case "$input" in
+    //*:*) pkg=${input#//}; pkg=${pkg%:*} ;;
+    //*)   pkg=${input#//} ;;
+    *)     pkg=${input%/} ;;
+esac
+[ -f "$pkg/BUILD.bazel" ] || { echo "ERROR: no $pkg/BUILD.bazel" >&2; exit 1; }
+
+# Design target base name (first quoted value after `name =` in the
+# hightide_design()/orfs_flow() call).
+name=$(awk -F'"' '
+    /hightide_design\(|orfs_flow\(/ { in_call = 1 }
+    in_call && /name[[:space:]]*=/  { print $2; exit }' "$pkg/BUILD.bazel")
+[ -n "$name" ] || { echo "ERROR: could not find name in $pkg/BUILD.bazel" >&2; exit 1; }
+
+# --- Build stages + extract config.mk (cached after first run) ------------
+if [ -z "$work_dir" ]; then
+    # platform = first path component under designs/; leaf = last.
+    rel=${pkg#designs/}
+    work_dir="$repo_root/.run_orfs/${rel%%/*}/${rel##*/}"
+fi
+mkdir -p "$work_dir"
+
+if [ -z "$config" ]; then
+    config="$work_dir/config.mk"
+    echo ">> Extracting config.mk -> $config" >&2
+    tools/bazel_to_config_mk.sh --abs "$pkg" "$config"
+elif [ "$no_build" = 0 ]; then
+    echo ">> Building all stages of //$pkg (for the synth netlist) ..." >&2
+    stage_targets=()
+    for s in synth floorplan place cts grt route final; do
+        stage_targets+=("//$pkg:${name}_$s")
+    done
+    bazel build "${stage_targets[@]}" >&2
+fi
+config=$(realpath "$config")
+
+# --- Locate the golden synthesized netlist from the bazel build -----------
+results_root="bazel-bin/$pkg/results"
+synth_odb=$(find "$results_root" -name '1_synth.odb' -type f 2>/dev/null | head -1)
+[ -n "$synth_odb" ] || {
+    echo "ERROR: no 1_synth.odb under $results_root — did the bazel build run?" >&2
+    exit 1
+}
+synth_dir=$(dirname "$synth_odb")
+# results/<platform>/<design>/<variant>/1_synth.odb
+relres=${synth_odb#*/results/}
+IFS=/ read -r platform design variant _ <<<"$relres"
+
+# --- Resolve the ORFS flow dir (FLOW_HOME) --------------------------------
+if [ -z "$flow_home" ]; then
+    ob=$(bazel info output_base 2>/dev/null)
+    flow_home="$ob/external/orfs+"
+fi
+if   [ -f "$flow_home/flow/Makefile" ]; then flow_dir="$flow_home/flow"
+elif [ -f "$flow_home/Makefile" ];      then flow_dir="$flow_home"
+else echo "ERROR: no ORFS Makefile under --flow-home $flow_home" >&2; exit 1
+fi
+orfs_commit=$(grep -oP 'OpenROAD-flow-scripts-\K[0-9a-f]{40}' MODULE.bazel | head -1)
+
+# --- Resolve the OpenROAD (+ matching sta) binary -------------------------
+opensta=""
+if [ -z "$openroad" ]; then
+    echo ">> Resolving bazel-built openroad ..." >&2
+    bazel build @openroad//:openroad >&2
+    openroad=$(realpath "$(bazel cquery --output=files @openroad//:openroad 2>/dev/null | head -1)")
+    if bazel cquery @openroad//src/sta:opensta >/dev/null 2>&1; then
+        bazel build @openroad//src/sta:opensta >&2 || true
+        opensta=$(realpath "$(bazel cquery --output=files @openroad//src/sta:opensta 2>/dev/null | head -1)" 2>/dev/null || true)
+    fi
+fi
+[ -x "$openroad" ] || { echo "ERROR: openroad not executable: $openroad" >&2; exit 1; }
+
+# --- Seed WORK_HOME with the golden synth artifacts so synth is skipped ---
+# Copy every 1_* / mem* artifact bazel produced (the whole yosys chain:
+# *.rtlil, 1_2_yosys.{v,sdc}, 1_synth.{odb,sdc}, mem*.json) so upstream
+# Make sees the synth prerequisites present, then touch them in dependency
+# order — newer than the (old, committed) RTL/LEF/LIB sources — so Make
+# treats synthesis as up-to-date and never invokes yosys.
+work_results="$work_dir/results/$platform/$design/$variant"
+mkdir -p "$work_results"
+chmod -R u+w "$work_results" 2>/dev/null || true
+cp -f --no-preserve=mode "$synth_dir"/1_* "$work_results"/ 2>/dev/null || true
+cp -f --no-preserve=mode "$synth_dir"/mem*.json "$work_results"/ 2>/dev/null || true
+
+# clock_period.txt is a yosys prerequisite Make would otherwise regenerate
+# (then rebuild the netlist). Its content is irrelevant once synth is
+# skipped — create it only if bazel didn't emit one.
+[ -f "$work_results/clock_period.txt" ] || echo 0 > "$work_results/clock_period.txt"
+
+# Anchor slightly in the past so the ordered touches stay <= now (avoids
+# Make's "modification time in the future" warning) yet newer than the
+# day-old committed sources.
+base=$(( $(date +%s) - 60 ))
+i=0
+for f in clock_period.txt 1_1_yosys_canonicalize.rtlil 1_2_yosys.sdc \
+         1_2_yosys.v 1_synth.odb 1_synth.sdc; do
+    [ -e "$work_results/$f" ] && touch -d "@$((base + i * 2))" "$work_results/$f"
+    i=$((i + 1))
+done
+
+# --- Run upstream ORFS ----------------------------------------------------
+cat >&2 <<EOF
+>> Running upstream ORFS
+   design     : $platform / $design
+   flow_home  : $flow_dir
+   (golden ORFS commit bazel resolves: $orfs_commit — clone this to edit flow scripts)
+   openroad   : $openroad
+   work_home  : $work_dir
+   targets    : ${targets[*]}
+EOF
+
+exec make -C "$flow_dir" \
+    DESIGN_CONFIG="$config" \
+    WORK_HOME="$work_dir" \
+    FLOW_HOME="$flow_dir" \
+    OPENROAD_EXE="$openroad" \
+    ${opensta:+OPENSTA_EXE="$opensta"} \
+    "${targets[@]}"


### PR DESCRIPTION
## What & why

Make it easy for **OpenROAD researchers** to run any HighTide design in plain upstream **OpenROAD-flow-scripts** (a single `config.mk` + the standard `Makefile`) so they can experiment with a **custom OpenROAD build**, **modified flow Tcl**, or **added/changed flow steps** — while the `bazel-orfs` config stays the golden source of truth.

`bazel-orfs` deliberately makes flow-script edits hard (`FLOW_HOME` is pinned), so the natural research interface is plain ORFS. This PR adds a one-command bridge.

## Changes

- **`tools/bazel_to_config_mk.sh`**: add `--abs` — rewrite the path-bearing ORFS vars (`VERILOG_FILES`, `SDC_FILE`, `ADDITIONAL_LEFS/LIBS`, `*_TCL`, `VERILOG_INCLUDE_DIRS`, …) to absolute paths so the extracted `config.mk` runs from any directory / any ORFS clone. Default (workspace-relative) behavior unchanged.

- **`tools/run_orfs.sh`** (new): one-command wrapper.
  - Extracts the `config.mk`, resolves the bazel-built `openroad`/`opensta` (or your `--openroad`), and runs upstream ORFS `make` against the ORFS you choose (`--flow-home`; default = the exact commit bazel resolves, which it prints so you know what to clone for flow-script edits).
  - **Reuses the golden `1_synth` netlist** rather than re-synthesizing — no yosys / yosys-slang toolchain needed (works for every design, incl. SystemVerilog ones), and the P&R starting point is identical to HighTide's published QoR.

- **README**: rewrite "Running a design in upstream ORFS" as a researcher workflow (usage, editing flow scripts, QoR caveat for newer ORFS, and the bazel-native binary-swap alternative). Also drop the stale hardcoded "Designs" table (claimed 8 designs, missing most of the suite) in favor of the maintained Design Catalog link.

- **`.gitignore`**: ignore the generated `.run_orfs/` work dir.

## Verification

`tools/run_orfs.sh designs/asap7/lfsr` runs clean (exit 0): config extracted → bazel openroad/opensta resolved → synth skipped (make jumps straight to `2_1_floorplan`) → full floorplan→finish in upstream `make` → produces `6_final.{odb,gds,v,def,spef,sdc}`.