### PR TITLE
run_orfs.sh: --resynth mode + config-only extraction + bazel check

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,12 @@ tools/bazel_to_config_mk.sh --abs designs/asap7/lfsr /tmp/lfsr.config.mk
 make -C OpenROAD-flow-scripts/flow DESIGN_CONFIG=/tmp/lfsr.config.mk
 ```
 
-The script builds the design through `bazel-orfs` (cached after the
-first run), then unions the per-stage `*.short.mk` files Bazel writes
-and strips Bazel-internal vars.
+This costs no synthesis or place-and-route: it builds only each stage's
+`<stage>.mk` config output group (cheap bazel *analysis*, seconds), unions
+the `export VAR?=VALUE` lines, strips Bazel-internal vars, and adds the
+cquery-resolved `VERILOG_FILES`. (`run_orfs.sh`'s default reuse-synth mode
+additionally builds just the `_synth` stage to get the netlist; `--resynth`
+re-synthesizes in your ORFS install and needs no bazel flow build at all.)
 
 ### Alternative: a custom OpenROAD inside bazel-orfs (binary swap only)
 

--- a/README.md
+++ b/README.md
@@ -27,42 +27,45 @@ is the easier interface. Two tools bridge the gap.
 ### One command: `tools/run_orfs.sh`
 
 ```bash
-# Golden flow + bazel-built openroad, full place-and-route:
+# Fast, zero-setup: reuse the golden synthesized netlist + bazel openroad,
+# full place-and-route:
 tools/run_orfs.sh designs/asap7/lfsr
 
 # Your own OpenROAD build, only through placement:
 tools/run_orfs.sh --openroad ~/OpenROAD/build/src/openroad \
                   designs/asap7/lfsr floorplan place
 
-# Your modified flow scripts:
-tools/run_orfs.sh --flow-home ~/OpenROAD-flow-scripts designs/sky130hd/eyeriss
+# Re-synthesize from RTL in your own ORFS install (its yosys + slang):
+tools/run_orfs.sh --resynth --flow-home ~/OpenROAD-flow-scripts designs/asap7/lfsr
 ```
 
-It extracts the design's resolved `config.mk`, **reuses the golden
-synthesized netlist** bazel-orfs already produced
-(`results/.../1_synth.{odb,sdc}`), and runs the standard ORFS `Makefile`
-from floorplan onward against the OpenROAD binary (`--openroad`, sets
-`OPENROAD_EXE`) and flow (`--flow-home`) you choose. Reusing the netlist
-means **no yosys / yosys-slang toolchain is needed** and the P&R starting
-point is identical to HighTide's published QoR. (Synthesis is therefore
-not re-run here; use the bazel flow to re-synthesize.)
+It extracts the design's resolved `config.mk` and runs the standard ORFS
+`Makefile`. There are two synthesis modes:
 
-To **edit flow scripts**, clone ORFS and point `--flow-home` at it:
+- **Default (reuse synth):** reuses the synthesized netlist bazel-orfs
+  already produced (`results/.../1_synth.{odb,sdc}`) and runs only
+  floorplan onward. Fast and zero-setup — **no yosys/slang needed** — and
+  runs against the ORFS bazel-orfs already resolved. Best for iterating on
+  placement, routing, or the OpenROAD binary (`--openroad` sets
+  `OPENROAD_EXE`). The netlist already reflects your constraints/RTL *if*
+  you rebuild through bazel; to re-synthesize entirely in plain ORFS, use
+  `--resynth`.
+- **`--resynth` (from RTL):** runs the *whole* flow including synthesis in
+  your ORFS install, using its own yosys + yosys-slang. Honors changes to
+  constraints, RTL, or the synthesis flow itself — but slower, and requires
+  `--flow-home` pointing at a **built** OpenROAD-flow-scripts install (one
+  whose `tools/install` has yosys; ORFS's slang support is built in).
 
-```bash
-git clone https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
-# Check out the commit run_orfs.sh prints ("golden ORFS commit ...") for a
-# comparable baseline — or stay on HEAD if matching HighTide's numbers
-# doesn't matter. Then edit flow/scripts/*.tcl and:
-tools/run_orfs.sh --flow-home ./OpenROAD-flow-scripts designs/asap7/lfsr
-```
+To **edit flow scripts or steps**, point `--flow-home` at your own ORFS
+checkout and edit `flow/scripts/*.tcl` there.
 
-**QoR caveat:** HighTide's published numbers come from the bazel-orfs
-build, which pins specific tool commits (bazel-orfs, OpenROAD, and the
-ORFS commit it resolves). Pointing `--flow-home` at a *newer* ORFS shifts
-the baseline, and some extracted `config.mk` workaround variables (e.g.
-`SKIP_CTS_REPAIR_TIMING`, `SETUP_MOVE_SEQUENCE`, `write_sdc` async-reset
-edits) may be unnecessary or stale — review them against your ORFS.
+**QoR comparability:** HighTide's published numbers come from the bazel-orfs
+build, which pins specific tool commits (bazel-orfs, OpenROAD, and the ORFS
+commit `run_orfs.sh` prints). A `--resynth` run against a *different* ORFS /
+yosys shifts the baseline, and some extracted `config.mk` workaround
+variables (e.g. `SKIP_CTS_REPAIR_TIMING`, `SETUP_MOVE_SEQUENCE`, `write_sdc`
+async-reset edits) may be unnecessary or stale — review them against your
+ORFS.
 
 ### Just the config.mk: `tools/bazel_to_config_mk.sh`
 

--- a/tools/bazel_to_config_mk.sh
+++ b/tools/bazel_to_config_mk.sh
@@ -3,14 +3,15 @@
 # Extract an ORFS-compatible config.mk for a HighTide design from the
 # bazel-orfs flow's generated artifacts.
 #
-# The bazel-orfs rule writes one `<stage>.short.mk` per flow stage,
-# each containing `export VAR?=VALUE` lines for every resolved ORFS
-# env var the stage consumes. Different stages contribute different
-# vars (synth → VERILOG_FILES / SDC_FILE; floorplan → CORE_UTILIZATION;
-# final → GDS_ALLOW_EMPTY; etc.) — so this script forces a build of
-# every stage, unions the export lines across all shortmks, drops the
-# Bazel-internal ones, and emits a config.mk you can feed to upstream
-# OpenROAD-flow-scripts (`make DESIGN_CONFIG=<this-file> ...`).
+# Each flow stage exposes its resolved config as a `<stage>.mk` bazel
+# output group, written by a cheap analysis-phase action. This script
+# builds ONLY those config output groups — so it costs no synthesis or
+# place-and-route, just bazel analysis (seconds) — then unions the
+# `export VAR?=VALUE` lines across stages (different stages contribute
+# different vars: floorplan → CORE_UTILIZATION, final → GDS_ALLOW_EMPTY,
+# etc.), drops the Bazel-internal ones, adds the cquery-resolved
+# VERILOG_FILES (the one var the .mk files omit), and emits a config.mk
+# you can feed to upstream OpenROAD-flow-scripts (`make DESIGN_CONFIG=...`).
 #
 # Usage:
 #   tools/bazel_to_config_mk.sh [--abs] <design-dir-or-label> [output-file]
@@ -100,24 +101,37 @@ if [ -z "$name" ]; then
     }
 fi
 
-# --- Build every stage so all shortmks exist on disk ----------------
+# --- Extract config from the per-stage config files (NO flow build) -------
+# Each stage exposes its resolved config as the <stage>.mk output group,
+# written by a cheap analysis-phase action — so building just these groups
+# costs no synthesis or place-and-route (they complete as "internal"
+# actions in seconds). VERILOG_FILES is the one resolved variable the
+# <stage>.mk files omit; pull it from the synth target's verilog_files
+# attr via cquery (analysis only, no build).
 stages=(synth floorplan place cts grt route final)
 targets=()
 for s in "${stages[@]}"; do targets+=("//${pkg}:${name}_${s}"); done
+config_groups=1_synth.mk,2_floorplan.mk,3_place.mk,4_cts.mk,5_1_grt.mk,5_2_route.mk,6_final.mk
 
-echo "Building all stages of //${pkg}:${name} ..." >&2
-bazel build "${targets[@]}" >&2
+echo "Extracting config of //${pkg}:${name} (config only, no flow build) ..." >&2
+bazel build "${targets[@]}" --output_groups="$config_groups" >&2
 
-# --- Locate the result dir + collect every short.mk -----------------
+verilog_files=$(bazel cquery --output=files \
+    "labels(verilog_files, //${pkg}:${name}_synth)" 2>/dev/null | tr '\n' ' ')
+
+# --- Locate the result dir + collect the per-stage config .mk files -------
 results_root="bazel-bin/${pkg}/results"
 [ -d "$results_root" ] || {
     echo "ERROR: $results_root missing after build" >&2
     exit 1
 }
 
-mapfile -t shortmks < <(find "$results_root" -name '*.short.mk' -type f 2>/dev/null | sort)
-[ "${#shortmks[@]}" -gt 0 ] || {
-    echo "ERROR: no *.short.mk under $results_root" >&2
+# Stage configs are <N>_<stage>.mk; skip the *.args.mk / *.short.mk / args.mk
+# helper configs.
+mapfile -t mks < <(find "$results_root" -type f -name '*.mk' \
+    ! -name '*.args.mk' ! -name '*.short.mk' ! -name 'args.mk' 2>/dev/null | sort)
+[ "${#mks[@]}" -gt 0 ] || {
+    echo "ERROR: no per-stage *.mk under $results_root" >&2
     exit 1
 }
 
@@ -139,9 +153,13 @@ emit() {
 EOF
 
     # `export VAR?=VALUE` → keep the first occurrence of each VAR.
-    # With --abs, prefix each repo-relative token of the path-bearing
-    # vars with the repo root so the config.mk runs from any CWD.
-    grep -h '^export ' "${shortmks[@]}" \
+    # The per-stage .mk files omit VERILOG_FILES; inject the cquery-resolved
+    # list so the union is complete. With --abs, prefix each repo-relative
+    # token of the path-bearing vars with the repo root (runs from any CWD).
+    {
+        grep -h '^export ' "${mks[@]}"
+        [ -n "$verilog_files" ] && printf 'export VERILOG_FILES?=%s\n' "${verilog_files% }"
+    } \
         | awk -v skip="$SKIP_VARS" -v abs="$abs" -v root="$repo_root" '
             # Vars whose value is one or more file/dir paths.
             function is_pathvar(k) {

--- a/tools/bazel_to_config_mk.sh
+++ b/tools/bazel_to_config_mk.sh
@@ -46,6 +46,23 @@ usage() {
     exit 1
 }
 
+require_bazel() {
+    command -v bazel >/dev/null 2>&1 && return
+    cat >&2 <<'EOF'
+ERROR: 'bazel' is not installed or not on PATH.
+HighTide resolves each design's configuration with Bazel (via Bazelisk).
+Install Bazelisk (recommended — it auto-fetches the pinned Bazel version):
+  Linux x86_64:
+    sudo curl -fsSL -o /usr/local/bin/bazel \
+      https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+    sudo chmod +x /usr/local/bin/bazel
+  npm:  npm install -g @bazelbuild/bazelisk
+  go:   go install github.com/bazelbuild/bazelisk@latest
+More:   https://github.com/bazelbuild/bazelisk
+EOF
+    exit 1
+}
+
 abs=0
 positional=()
 while [ $# -gt 0 ]; do
@@ -113,6 +130,7 @@ targets=()
 for s in "${stages[@]}"; do targets+=("//${pkg}:${name}_${s}"); done
 config_groups=1_synth.mk,2_floorplan.mk,3_place.mk,4_cts.mk,5_1_grt.mk,5_2_route.mk,6_final.mk
 
+require_bazel
 echo "Extracting config of //${pkg}:${name} (config only, no flow build) ..." >&2
 bazel build "${targets[@]}" --output_groups="$config_groups" >&2
 

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -159,15 +159,16 @@ if [ -z "$config" ]; then
     config="$work_dir/config.mk"
     echo ">> Extracting config.mk -> $config" >&2
     tools/bazel_to_config_mk.sh --abs "$pkg" "$config"
-elif [ "$no_build" = 0 ] && [ "$resynth" = 0 ]; then
-    echo ">> Building all stages of //$pkg (for the synth netlist) ..." >&2
-    stage_targets=()
-    for s in synth floorplan place cts grt route final; do
-        stage_targets+=("//$pkg:${name}_$s")
-    done
-    bazel build "${stage_targets[@]}" >&2
 fi
 config=$(realpath "$config")
+
+# Reuse mode needs the bazel-synthesized netlist (config extraction above is
+# config-only and does NOT build it). Build just the synth stage — not the
+# whole flow. --resynth re-synthesizes in plain ORFS, so it needs nothing.
+if [ "$resynth" = 0 ] && [ "$no_build" = 0 ]; then
+    echo ">> Building synth netlist //$pkg:${name}_synth ..." >&2
+    bazel build "//$pkg:${name}_synth" >&2
+fi
 
 # --- Resolve OpenROAD (+ matching sta) ------------------------------------
 # Override OPENROAD_EXE/OPENSTA_EXE only when the tools wouldn't otherwise

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -2,49 +2,63 @@
 #
 # Run a HighTide design in upstream OpenROAD-flow-scripts (plain ORFS),
 # so OpenROAD researchers can experiment with a custom OpenROAD binary,
-# modified flow Tcl scripts, or added/changed flow steps — without
-# leaving HighTide's golden bazel-orfs configuration behind.
+# modified flow Tcl scripts, added/changed flow steps, or different
+# constraints — without leaving HighTide's golden bazel-orfs config.
 #
-# It (1) extracts the design's resolved ORFS config.mk via
-# tools/bazel_to_config_mk.sh --abs, (2) reuses the golden synthesized
-# netlist bazel-orfs already produced (results/.../1_synth.{odb,sdc}) so
-# no yosys / yosys-slang plugin is needed and the P&R starting point is
-# identical to HighTide's published QoR, and (3) runs the standard ORFS
-# Makefile from floorplan onward against the OpenROAD binary and flow
-# you choose.
+# It extracts the design's resolved ORFS config.mk (via
+# tools/bazel_to_config_mk.sh --abs) and runs the standard ORFS Makefile.
+#
+# Two synthesis modes:
+#
+#   default (reuse synth):  reuses the synthesized netlist bazel-orfs already
+#       produced (results/.../1_synth.{odb,sdc}) and runs only floorplan
+#       onward. Fast and zero-setup — no yosys/slang needed — and works
+#       against the ORFS bazel-orfs already resolved. Best for iterating on
+#       placement / routing / the OpenROAD binary. (The netlist is rebuilt by
+#       bazel whenever constraints/RTL change, but only if you go through the
+#       bazel build; to re-synthesize entirely in plain ORFS, use --resynth.)
+#
+#   --resynth (from RTL):  runs the *whole* flow including synthesis in your
+#       ORFS install, using its own yosys + yosys-slang. Honors changes to
+#       constraints, RTL, or the synthesis flow itself — but slower, and
+#       requires --flow-home pointing at a built OpenROAD-flow-scripts install
+#       (one whose tools/install has yosys; ORFS's slang support is built in).
 #
 # Usage:
 #   tools/run_orfs.sh [options] <design-dir-or-label> [make-target...]
 #
 # Options:
-#   --flow-home DIR  ORFS checkout to run (its `flow/` dir or the dir
-#                    itself). Default: the exact ORFS bazel-orfs resolved
-#                    (read-only) — i.e. HighTide's golden flow. To edit
-#                    flow scripts, clone ORFS at the commit printed below,
-#                    edit flow/scripts/*.tcl, and pass --flow-home <clone>.
-#   --openroad BIN   openroad executable (sets OPENROAD_EXE). Default: the
-#                    bazel-built @openroad//:openroad. Point this at your
-#                    own build to test a custom OpenROAD.
+#   --resynth        Run synthesis from RTL in your ORFS install (default:
+#                    reuse the bazel-synthesized netlist). Needs --flow-home.
+#   --flow-home DIR  ORFS checkout to run (its `flow/` dir or the root).
+#                    Default (reuse mode): the ORFS bazel-orfs resolved.
+#                    Required with --resynth: a built install with yosys+slang.
+#   --openroad BIN   openroad executable (sets OPENROAD_EXE). Point this at
+#                    your own build to test a custom OpenROAD. Default: the
+#                    bazel-built @openroad//:openroad (reuse mode) or your
+#                    ORFS install's own openroad (with --resynth).
 #   --work-dir DIR   Run/output directory (becomes ORFS WORK_HOME).
 #                    Default: <repo>/.run_orfs/<platform>/<design>.
 #   --config FILE    Use this config.mk instead of extracting one.
 #   --no-build       Don't (re)build in bazel; assume stages + config exist.
 #   -h, --help       Print this help and exit.
 #
-# make-target defaults to: floorplan place cts route finish
+# make-target default: "floorplan place cts route finish"
+#                      (--resynth: "synth floorplan place cts route finish")
 #
 # Examples:
-#   # Out-of-box: golden flow + bazel openroad, full P&R.
+#   # Fast, zero-setup: reuse golden synth + bazel openroad, full P&R:
 #   tools/run_orfs.sh designs/asap7/lfsr
-#   # My OpenROAD build, only through placement.
+#   # Your custom OpenROAD build, only through placement:
 #   tools/run_orfs.sh --openroad ~/OpenROAD/build/src/openroad \
 #                     designs/asap7/lfsr floorplan place
-#   # My modified ORFS flow scripts.
-#   tools/run_orfs.sh --flow-home ~/OpenROAD-flow-scripts designs/sky130hd/eyeriss
+#   # Re-synthesize from RTL in your ORFS install (its yosys+slang):
+#   tools/run_orfs.sh --resynth --flow-home ~/OpenROAD-flow-scripts designs/asap7/lfsr
 #
-# Note: synthesis is reused from the golden bazel build, not re-run here
-# (that keeps every design buildable without the yosys-slang toolchain and
-# holds the netlist fixed). To re-synthesize, use the bazel flow.
+# QoR comparability: HighTide's published numbers come from the bazel-orfs
+# build. A --resynth run reproduces them only if your ORFS install's yosys /
+# openroad match the commits bazel-orfs pins (printed below); otherwise the
+# baseline shifts and some config.mk workaround vars may be stale.
 
 set -euo pipefail
 
@@ -58,10 +72,12 @@ openroad=""
 work_dir=""
 config=""
 no_build=0
+resynth=0
 positional=()
 
 while [ $# -gt 0 ]; do
     case "$1" in
+        --resynth)   resynth=1;    shift ;;
         --flow-home) flow_home=$2; shift 2 ;;
         --openroad)  openroad=$2;  shift 2 ;;
         --work-dir)  work_dir=$2;  shift 2 ;;
@@ -77,7 +93,13 @@ done
 [ "${#positional[@]}" -ge 1 ] || usage
 input=${positional[0]}
 targets=("${positional[@]:1}")
-[ "${#targets[@]}" -gt 0 ] || targets=(floorplan place cts route finish)
+if [ "${#targets[@]}" -eq 0 ]; then
+    if [ "$resynth" = 1 ]; then
+        targets=(synth floorplan place cts route finish)
+    else
+        targets=(floorplan place cts route finish)
+    fi
+fi
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
@@ -97,9 +119,37 @@ name=$(awk -F'"' '
     in_call && /name[[:space:]]*=/  { print $2; exit }' "$pkg/BUILD.bazel")
 [ -n "$name" ] || { echo "ERROR: could not find name in $pkg/BUILD.bazel" >&2; exit 1; }
 
+# --- Resolve the ORFS flow dir (FLOW_HOME) --------------------------------
+user_flow_home=0
+if [ -n "$flow_home" ]; then
+    user_flow_home=1
+elif [ "$resynth" = 0 ]; then
+    # Default (reuse) path: the ORFS bazel-orfs already resolved (no
+    # tools/install needed — synth is skipped, openroad comes from bazel).
+    ob=$(bazel info output_base 2>/dev/null)
+    flow_home="$ob/external/orfs+"
+else
+    echo "ERROR: --resynth needs a built OpenROAD-flow-scripts install." >&2
+    echo "       Pass --flow-home <ORFS> (its tools/install must have yosys+slang)," >&2
+    echo "       or drop --resynth to reuse the bazel-synthesized netlist." >&2
+    exit 1
+fi
+if   [ -f "$flow_home/flow/Makefile" ]; then flow_dir="$flow_home/flow"
+elif [ -f "$flow_home/Makefile" ];      then flow_dir="$flow_home"
+else echo "ERROR: no ORFS Makefile under --flow-home $flow_home" >&2; exit 1
+fi
+orfs_commit=$(grep -oP 'OpenROAD-flow-scripts-\K[0-9a-f]{40}' MODULE.bazel | head -1)
+
+# Soft check: --resynth needs a yosys somewhere (install dir or PATH).
+if [ "$resynth" = 1 ] \
+   && [ ! -x "$flow_dir/../tools/install/yosys/bin/yosys" ] \
+   && ! command -v yosys >/dev/null 2>&1; then
+    echo "WARNING: no yosys found at $flow_dir/../tools/install or on PATH;" >&2
+    echo "         synthesis will fail unless your ORFS install provides one." >&2
+fi
+
 # --- Build stages + extract config.mk (cached after first run) ------------
 if [ -z "$work_dir" ]; then
-    # platform = first path component under designs/; leaf = last.
     rel=${pkg#designs/}
     work_dir="$repo_root/.run_orfs/${rel%%/*}/${rel##*/}"
 fi
@@ -109,7 +159,7 @@ if [ -z "$config" ]; then
     config="$work_dir/config.mk"
     echo ">> Extracting config.mk -> $config" >&2
     tools/bazel_to_config_mk.sh --abs "$pkg" "$config"
-elif [ "$no_build" = 0 ]; then
+elif [ "$no_build" = 0 ] && [ "$resynth" = 0 ]; then
     echo ">> Building all stages of //$pkg (for the synth netlist) ..." >&2
     stage_targets=()
     for s in synth floorplan place cts grt route final; do
@@ -119,77 +169,68 @@ elif [ "$no_build" = 0 ]; then
 fi
 config=$(realpath "$config")
 
-# --- Locate the golden synthesized netlist from the bazel build -----------
-results_root="bazel-bin/$pkg/results"
-synth_odb=$(find "$results_root" -name '1_synth.odb' -type f 2>/dev/null | head -1)
-[ -n "$synth_odb" ] || {
-    echo "ERROR: no 1_synth.odb under $results_root — did the bazel build run?" >&2
-    exit 1
-}
-synth_dir=$(dirname "$synth_odb")
-# results/<platform>/<design>/<variant>/1_synth.odb
-relres=${synth_odb#*/results/}
-IFS=/ read -r platform design variant _ <<<"$relres"
-
-# --- Resolve the ORFS flow dir (FLOW_HOME) --------------------------------
-if [ -z "$flow_home" ]; then
-    ob=$(bazel info output_base 2>/dev/null)
-    flow_home="$ob/external/orfs+"
-fi
-if   [ -f "$flow_home/flow/Makefile" ]; then flow_dir="$flow_home/flow"
-elif [ -f "$flow_home/Makefile" ];      then flow_dir="$flow_home"
-else echo "ERROR: no ORFS Makefile under --flow-home $flow_home" >&2; exit 1
-fi
-orfs_commit=$(grep -oP 'OpenROAD-flow-scripts-\K[0-9a-f]{40}' MODULE.bazel | head -1)
-
-# --- Resolve the OpenROAD (+ matching sta) binary -------------------------
-opensta=""
-if [ -z "$openroad" ]; then
+# --- Resolve OpenROAD (+ matching sta) ------------------------------------
+# Override OPENROAD_EXE/OPENSTA_EXE only when the tools wouldn't otherwise
+# resolve: a user-supplied --openroad, or the bazel-resolved ORFS default
+# (which has no tools/install). A user-supplied ORFS install uses its own.
+openroad_exe="$openroad"
+opensta_exe=""
+if [ -z "$openroad_exe" ] && [ "$user_flow_home" = 0 ]; then
     echo ">> Resolving bazel-built openroad ..." >&2
     bazel build @openroad//:openroad >&2
-    openroad=$(realpath "$(bazel cquery --output=files @openroad//:openroad 2>/dev/null | head -1)")
+    openroad_exe=$(realpath "$(bazel cquery --output=files @openroad//:openroad 2>/dev/null | head -1)")
     if bazel cquery @openroad//src/sta:opensta >/dev/null 2>&1; then
         bazel build @openroad//src/sta:opensta >&2 || true
-        opensta=$(realpath "$(bazel cquery --output=files @openroad//src/sta:opensta 2>/dev/null | head -1)" 2>/dev/null || true)
+        opensta_exe=$(realpath "$(bazel cquery --output=files @openroad//src/sta:opensta 2>/dev/null | head -1)" 2>/dev/null || true)
     fi
 fi
-[ -x "$openroad" ] || { echo "ERROR: openroad not executable: $openroad" >&2; exit 1; }
+[ -z "$openroad_exe" ] || [ -x "$openroad_exe" ] || {
+    echo "ERROR: openroad not executable: $openroad_exe" >&2; exit 1; }
 
-# --- Seed WORK_HOME with the golden synth artifacts so synth is skipped ---
-# Copy every 1_* / mem* artifact bazel produced (the whole yosys chain:
-# *.rtlil, 1_2_yosys.{v,sdc}, 1_synth.{odb,sdc}, mem*.json) so upstream
-# Make sees the synth prerequisites present, then touch them in dependency
-# order — newer than the (old, committed) RTL/LEF/LIB sources — so Make
-# treats synthesis as up-to-date and never invokes yosys.
-work_results="$work_dir/results/$platform/$design/$variant"
-mkdir -p "$work_results"
-chmod -R u+w "$work_results" 2>/dev/null || true
-cp -f --no-preserve=mode "$synth_dir"/1_* "$work_results"/ 2>/dev/null || true
-cp -f --no-preserve=mode "$synth_dir"/mem*.json "$work_results"/ 2>/dev/null || true
+# --- Reuse-synth (default): seed WORK_HOME with the golden netlist --------
+if [ "$resynth" = 0 ]; then
+    results_root="bazel-bin/$pkg/results"
+    synth_odb=$(find "$results_root" -name '1_synth.odb' -type f 2>/dev/null | head -1)
+    [ -n "$synth_odb" ] || {
+        echo "ERROR: no 1_synth.odb under $results_root — did the bazel build run?" >&2
+        exit 1
+    }
+    synth_dir=$(dirname "$synth_odb")
+    relres=${synth_odb#*/results/}      # <platform>/<design>/<variant>/1_synth.odb
+    IFS=/ read -r platform design variant _ <<<"$relres"
 
-# clock_period.txt is a yosys prerequisite Make would otherwise regenerate
-# (then rebuild the netlist). Its content is irrelevant once synth is
-# skipped — create it only if bazel didn't emit one.
-[ -f "$work_results/clock_period.txt" ] || echo 0 > "$work_results/clock_period.txt"
+    # Copy every 1_* / mem* artifact (the whole yosys chain) so upstream Make
+    # sees the synth prerequisites present, then touch them in dependency
+    # order — newer than the (old, committed) sources — so Make treats
+    # synthesis as up-to-date and never invokes yosys.
+    work_results="$work_dir/results/$platform/$design/$variant"
+    mkdir -p "$work_results"
+    chmod -R u+w "$work_results" 2>/dev/null || true
+    cp -f --no-preserve=mode "$synth_dir"/1_* "$work_results"/ 2>/dev/null || true
+    cp -f --no-preserve=mode "$synth_dir"/mem*.json "$work_results"/ 2>/dev/null || true
+    [ -f "$work_results/clock_period.txt" ] || echo 0 > "$work_results/clock_period.txt"
 
-# Anchor slightly in the past so the ordered touches stay <= now (avoids
-# Make's "modification time in the future" warning) yet newer than the
-# day-old committed sources.
-base=$(( $(date +%s) - 60 ))
-i=0
-for f in clock_period.txt 1_1_yosys_canonicalize.rtlil 1_2_yosys.sdc \
-         1_2_yosys.v 1_synth.odb 1_synth.sdc; do
-    [ -e "$work_results/$f" ] && touch -d "@$((base + i * 2))" "$work_results/$f"
-    i=$((i + 1))
-done
+    base=$(( $(date +%s) - 60 ))
+    i=0
+    for f in clock_period.txt 1_1_yosys_canonicalize.rtlil 1_2_yosys.sdc \
+             1_2_yosys.v 1_synth.odb 1_synth.sdc; do
+        [ -e "$work_results/$f" ] && touch -d "@$((base + i * 2))" "$work_results/$f"
+        i=$((i + 1))
+    done
+else
+    platform=${pkg#designs/}; platform=${platform%%/*}
+    design=$(awk -F'?=' '/^export DESIGN_NAME\?=/{print $2; exit}' "$config")
+fi
 
 # --- Run upstream ORFS ----------------------------------------------------
+mode=$([ "$resynth" = 1 ] && echo "from RTL (incl. synthesis)" || echo "reuse synth (floorplan onward)")
 cat >&2 <<EOF
 >> Running upstream ORFS
-   design     : $platform / $design
+   design     : $platform / ${design:-$name}
+   mode       : $mode
    flow_home  : $flow_dir
-   (golden ORFS commit bazel resolves: $orfs_commit — clone this to edit flow scripts)
-   openroad   : $openroad
+   (golden ORFS commit bazel resolves: $orfs_commit)
+   openroad   : ${openroad_exe:-<ORFS install default>}
    work_home  : $work_dir
    targets    : ${targets[*]}
 EOF
@@ -198,6 +239,6 @@ exec make -C "$flow_dir" \
     DESIGN_CONFIG="$config" \
     WORK_HOME="$work_dir" \
     FLOW_HOME="$flow_dir" \
-    OPENROAD_EXE="$openroad" \
-    ${opensta:+OPENSTA_EXE="$opensta"} \
+    ${openroad_exe:+OPENROAD_EXE="$openroad_exe"} \
+    ${opensta_exe:+OPENSTA_EXE="$opensta_exe"} \
     "${targets[@]}"

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -67,6 +67,23 @@ usage() {
     exit 1
 }
 
+require_bazel() {
+    command -v bazel >/dev/null 2>&1 && return
+    cat >&2 <<'EOF'
+ERROR: 'bazel' is not installed or not on PATH.
+HighTide resolves each design's configuration with Bazel (via Bazelisk).
+Install Bazelisk (recommended — it auto-fetches the pinned Bazel version):
+  Linux x86_64:
+    sudo curl -fsSL -o /usr/local/bin/bazel \
+      https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
+    sudo chmod +x /usr/local/bin/bazel
+  npm:  npm install -g @bazelbuild/bazelisk
+  go:   go install github.com/bazelbuild/bazelisk@latest
+More:   https://github.com/bazelbuild/bazelisk
+EOF
+    exit 1
+}
+
 flow_home=""
 openroad=""
 work_dir=""
@@ -166,6 +183,7 @@ config=$(realpath "$config")
 # config-only and does NOT build it). Build just the synth stage — not the
 # whole flow. --resynth re-synthesizes in plain ORFS, so it needs nothing.
 if [ "$resynth" = 0 ] && [ "$no_build" = 0 ]; then
+    require_bazel
     echo ">> Building synth netlist //$pkg:${name}_synth ..." >&2
     bazel build "//$pkg:${name}_synth" >&2
 fi
@@ -177,6 +195,7 @@ fi
 openroad_exe="$openroad"
 opensta_exe=""
 if [ -z "$openroad_exe" ] && [ "$user_flow_home" = 0 ]; then
+    require_bazel
     echo ">> Resolving bazel-built openroad ..." >&2
     bazel build @openroad//:openroad >&2
     openroad_exe=$(realpath "$(bazel cquery --output=files @openroad//:openroad 2>/dev/null | head -1)")


### PR DESCRIPTION
Follow-up to #207 (the plain-ORFS run path), addressing reviewer feedback.

## Changes

- **`--resynth` mode** — re-run synthesis from RTL in the researcher's own ORFS install (its native yosys + yosys-slang), honoring constraint/RTL/synth-flow changes. The default stays the fast **reuse-synth** path (seed the bazel `1_synth` netlist, run floorplan onward) since synthesis is slow on large designs. Verified end-to-end against a real ORFS install (`~/orfs/base`): its yosys synthesized from RTL → `6_final.gds`.
  - Driving the *bazel-built* yosys outside bazel does not work (bazel-orfs uses a custom wrapped synth path; the bazel yosys hangs in stock `synth_canonicalize`), so `--resynth` requires `--flow-home` at a built ORFS install.

- **Config extraction no longer builds the flow** — `bazel_to_config_mk.sh` used to build all 7 stage ODBs (synth + full P&R) just to read each stage's config. Each stage already exposes its resolved config as a cheap `<stage>.mk` output group (analysis-phase write), so it now builds only those + resolves `VERILOG_FILES` via `cquery labels(verilog_files, :…_synth)`. Drops extraction from a full flow run to **~1.3s ("1 internal action")**; output is byte-identical to the old `short.mk` union. reuse-synth then builds just the `_synth` stage for the netlist; `--resynth` needs no bazel flow build at all.

- **Clear error when bazel is missing** — both scripts print a Bazelisk install hint and exit if `bazel` isn't on PATH (lazy, so the `--config` bazel-free path still works).

## Verification
- reuse-synth (default): config-only extraction → `_synth` build → floorplan ✅
- `--resynth --flow-home ~/orfs/base`: native yosys synth → P&R → `6_final.gds` ✅
- config extraction byte-identical to prior output (lfsr), complete on an SRAM design (cnn) ✅