### PR TITLE
Friendly error when bazel-orfs submodule is uninitialized

### DIFF
--- a/tools/bazel_to_config_mk.sh
+++ b/tools/bazel_to_config_mk.sh
@@ -63,6 +63,20 @@ EOF
     exit 1
 }
 
+# The Bazel build (and the patches/ symlinks it references) need the
+# bazel-orfs submodule checked out — otherwise bazel fails deep in repo
+# fetch with a cryptic "Cannot find patch file" error.
+require_bazel_orfs() {
+    [ -f "$(git rev-parse --show-toplevel)/bazel-orfs/MODULE.bazel" ] && return
+    cat >&2 <<'EOF'
+ERROR: the bazel-orfs submodule is not initialized.
+HighTide's Bazel build needs it (the patches/ files are symlinks into it).
+Run, from the repo root:
+  git submodule update --init bazel-orfs
+EOF
+    exit 1
+}
+
 abs=0
 positional=()
 while [ $# -gt 0 ]; do
@@ -131,6 +145,7 @@ for s in "${stages[@]}"; do targets+=("//${pkg}:${name}_${s}"); done
 config_groups=1_synth.mk,2_floorplan.mk,3_place.mk,4_cts.mk,5_1_grt.mk,5_2_route.mk,6_final.mk
 
 require_bazel
+require_bazel_orfs
 echo "Extracting config of //${pkg}:${name} (config only, no flow build) ..." >&2
 bazel build "${targets[@]}" --output_groups="$config_groups" >&2
 

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -84,6 +84,20 @@ EOF
     exit 1
 }
 
+# The Bazel build (and the patches/ symlinks it references) need the
+# bazel-orfs submodule checked out — otherwise bazel fails deep in repo
+# fetch with a cryptic "Cannot find patch file" error.
+require_bazel_orfs() {
+    [ -f "$repo_root/bazel-orfs/MODULE.bazel" ] && return
+    cat >&2 <<'EOF'
+ERROR: the bazel-orfs submodule is not initialized.
+HighTide's Bazel build needs it (the patches/ files are symlinks into it).
+Run, from the repo root:
+  git submodule update --init bazel-orfs
+EOF
+    exit 1
+}
+
 flow_home=""
 openroad=""
 work_dir=""
@@ -183,7 +197,7 @@ config=$(realpath "$config")
 # config-only and does NOT build it). Build just the synth stage — not the
 # whole flow. --resynth re-synthesizes in plain ORFS, so it needs nothing.
 if [ "$resynth" = 0 ] && [ "$no_build" = 0 ]; then
-    require_bazel
+    require_bazel; require_bazel_orfs
     echo ">> Building synth netlist //$pkg:${name}_synth ..." >&2
     bazel build "//$pkg:${name}_synth" >&2
 fi
@@ -195,7 +209,7 @@ fi
 openroad_exe="$openroad"
 opensta_exe=""
 if [ -z "$openroad_exe" ] && [ "$user_flow_home" = 0 ]; then
-    require_bazel
+    require_bazel; require_bazel_orfs
     echo ">> Resolving bazel-built openroad ..." >&2
     bazel build @openroad//:openroad >&2
     openroad_exe=$(realpath "$(bazel cquery --output=files @openroad//:openroad 2>/dev/null | head -1)")


### PR DESCRIPTION
Stacked on #209.

If the `bazel-orfs` submodule isn't checked out, the `patches/` files (symlinks into the submodule) dangle and bazel fails deep in repo fetch with a cryptic `Error in patch: ... Cannot find patch file: .../patches/0036-...patch`. Hit in practice running `run_orfs.sh` on a worktree where the submodule wasn't initialized.

Add `require_bazel_orfs` (checks `bazel-orfs/MODULE.bazel`) to both `run_orfs.sh` and `bazel_to_config_mk.sh`, called before each bazel invocation. It prints:

```
ERROR: the bazel-orfs submodule is not initialized.
HighTide's Bazel build needs it (the patches/ files are symlinks into it).
Run, from the repo root:
  git submodule update --init bazel-orfs
```

Base is `#209`'s branch since this builds on its `require_bazel` helper; retarget to `main` once #209 merges.