### PR TITLE
run_orfs.sh: fix default flow-home on fresh checkout + submodule guard

### DIFF
--- a/tools/bazel_to_config_mk.sh
+++ b/tools/bazel_to_config_mk.sh
@@ -63,6 +63,20 @@ EOF
     exit 1
 }
 
+# The Bazel build (and the patches/ symlinks it references) need the
+# bazel-orfs submodule checked out — otherwise bazel fails deep in repo
+# fetch with a cryptic "Cannot find patch file" error.
+require_bazel_orfs() {
+    [ -f "$(git rev-parse --show-toplevel)/bazel-orfs/MODULE.bazel" ] && return
+    cat >&2 <<'EOF'
+ERROR: the bazel-orfs submodule is not initialized.
+HighTide's Bazel build needs it (the patches/ files are symlinks into it).
+Run, from the repo root:
+  git submodule update --init bazel-orfs
+EOF
+    exit 1
+}
+
 abs=0
 positional=()
 while [ $# -gt 0 ]; do
@@ -131,6 +145,7 @@ for s in "${stages[@]}"; do targets+=("//${pkg}:${name}_${s}"); done
 config_groups=1_synth.mk,2_floorplan.mk,3_place.mk,4_cts.mk,5_1_grt.mk,5_2_route.mk,6_final.mk
 
 require_bazel
+require_bazel_orfs
 echo "Extracting config of //${pkg}:${name} (config only, no flow build) ..." >&2
 bazel build "${targets[@]}" --output_groups="$config_groups" >&2
 

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -155,10 +155,15 @@ user_flow_home=0
 if [ -n "$flow_home" ]; then
     user_flow_home=1
 elif [ "$resynth" = 0 ]; then
-    # Default (reuse) path: the ORFS bazel-orfs already resolved (no
-    # tools/install needed — synth is skipped, openroad comes from bazel).
+    # Default (reuse) path: the ORFS that bazel-orfs resolved. Bazel fetches
+    # external repos lazily, so force-materialize the ORFS flow first, then
+    # derive its directory from cquery (robust to a fresh checkout and to the
+    # orfs+/orfs~ canonical-name difference across Bazel versions).
+    require_bazel; require_bazel_orfs
+    echo ">> Fetching the bazel-resolved ORFS flow ..." >&2
+    bazel build @orfs//flow:makefile >&2
     ob=$(bazel info output_base 2>/dev/null)
-    flow_home="$ob/external/orfs+"
+    flow_home="$ob/$(bazel cquery --output=files @orfs//flow:makefile 2>/dev/null | head -1 | xargs dirname)"
 else
     echo "ERROR: --resynth needs a built OpenROAD-flow-scripts install." >&2
     echo "       Pass --flow-home <ORFS> (its tools/install must have yosys+slang)," >&2

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -84,6 +84,20 @@ EOF
     exit 1
 }
 
+# The Bazel build (and the patches/ symlinks it references) need the
+# bazel-orfs submodule checked out — otherwise bazel fails deep in repo
+# fetch with a cryptic "Cannot find patch file" error.
+require_bazel_orfs() {
+    [ -f "$repo_root/bazel-orfs/MODULE.bazel" ] && return
+    cat >&2 <<'EOF'
+ERROR: the bazel-orfs submodule is not initialized.
+HighTide's Bazel build needs it (the patches/ files are symlinks into it).
+Run, from the repo root:
+  git submodule update --init bazel-orfs
+EOF
+    exit 1
+}
+
 flow_home=""
 openroad=""
 work_dir=""
@@ -183,7 +197,7 @@ config=$(realpath "$config")
 # config-only and does NOT build it). Build just the synth stage — not the
 # whole flow. --resynth re-synthesizes in plain ORFS, so it needs nothing.
 if [ "$resynth" = 0 ] && [ "$no_build" = 0 ]; then
-    require_bazel
+    require_bazel; require_bazel_orfs
     echo ">> Building synth netlist //$pkg:${name}_synth ..." >&2
     bazel build "//$pkg:${name}_synth" >&2
 fi
@@ -195,7 +209,7 @@ fi
 openroad_exe="$openroad"
 opensta_exe=""
 if [ -z "$openroad_exe" ] && [ "$user_flow_home" = 0 ]; then
-    require_bazel
+    require_bazel; require_bazel_orfs
     echo ">> Resolving bazel-built openroad ..." >&2
     bazel build @openroad//:openroad >&2
     openroad_exe=$(realpath "$(bazel cquery --output=files @openroad//:openroad 2>/dev/null | head -1)")


### PR DESCRIPTION
Two `run_orfs.sh` reliability fixes hit while running on other machines (donut/diode):

1. **Default flow-home failed on a fresh checkout** — the reuse-mode default pointed at `$(bazel info output_base)/external/orfs+` and checked for its Makefile, but bazel fetches external repos lazily, so on a machine that hadn't materialized ORFS it errored: `no ORFS Makefile under --flow-home .../external/orfs+`. Now force-materialize with `bazel build @orfs//flow:makefile` and derive the dir from `cquery --output=files` (also robust to the `orfs+`/`orfs~` canonical-name difference).

2. **Submodule guard** (was stranded in #211, never reached main) — if the `bazel-orfs` submodule isn't checked out, the `patches/` symlinks dangle and bazel fails with a cryptic `Cannot find patch file`. `require_bazel_orfs` now catches this and points at `git submodule update --init bazel-orfs`.