### PR TITLE
ci: skip Claude workflows on forks

### DIFF
--- a/.github/workflows/audit-updates.yml
+++ b/.github/workflows/audit-updates.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   audit-updates:
+    # Only run on the canonical repo — forks don't have the ANTHROPIC_API_KEY
+    # secret, so this Claude job would just fail on them.
+    if: ${{ github.repository == 'VLSIDA/HighTide' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/find-designs.yml
+++ b/.github/workflows/find-designs.yml
@@ -12,6 +12,9 @@ permissions:
 
 jobs:
   find-designs:
+    # Only run on the canonical repo — forks don't have the ANTHROPIC_API_KEY
+    # secret, so this Claude job would just fail on them.
+    if: ${{ github.repository == 'VLSIDA/HighTide' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
`find-designs.yml` and `audit-updates.yml` are scheduled weekly (`cron`) and invoke `anthropics/claude-code-action@v1` with `secrets.ANTHROPIC_API_KEY`. On **forks** of HighTide, that secret doesn't exist, so the scheduled runs just fail (and spend the fork's Actions minutes).

## Fix
Gate both jobs on the canonical repo:

```yaml
if: ${{ github.repository == 'VLSIDA/HighTide' }}
```

The whole job is skipped on any fork, for both the `schedule` and `workflow_dispatch` triggers.

## Not touched
- `claude.yml` — already fully disabled (`if: false`), workflow_dispatch-only.
- `benchmark-status.yml` — scheduled but uses no secrets / no Claude, so it's harmless on forks.