### PR TITLE
run_orfs.sh: grouped designs, --prepare-only, and batch patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,25 @@ tools/run_orfs.sh --openroad ~/OpenROAD/build/src/openroad \
 # Re-synthesize from RTL in your own ORFS install (its yosys + slang):
 tools/run_orfs.sh --resynth --flow-home ~/OpenROAD-flow-scripts designs/asap7/lfsr
 
-# Stage many designs without running (writes each work dir + a run.sh),
-# then run them later or on another machine — no bazel needed at run time:
-for d in designs/asap7/lfsr designs/asap7/NVDLA/partition_a; do
-    tools/run_orfs.sh --prepare-only "$d"
-done
+# Batch: run (or prepare) many designs with a bazel-style pattern. Stage
+# every asap7 design without running, then run one later / on another
+# machine — no bazel needed at run time:
+tools/run_orfs.sh --prepare-only //designs/asap7/...
 OPENROAD_EXE=~/OpenROAD/build/src/openroad .run_orfs/asap7/lfsr/run.sh
 ```
+
+**Design patterns.** The target can be one design or a bazel-style pattern
+that expands to many (the flow runs once per design, continuing past
+failures and printing a summary):
+
+| Pattern | Matches |
+|---|---|
+| `designs/asap7/lfsr` | one design |
+| `//designs/asap7/...` | all asap7 designs |
+| `//designs/asap7/NVDLA/...` | every NVDLA partition |
+| `//designs/...` or `all` | every design, every platform |
+| `asap7` \| `nangate45` \| `sky130hd` | all designs on that platform |
+| `designs/asap7/NVDLA` | a container → its sub-designs |
 
 **Grouped designs (NVDLA, bp_processor):** these are *containers* — the top
 directory holds only shared SRAM filegroups, and each runnable design is a

--- a/README.md
+++ b/README.md
@@ -37,7 +37,27 @@ tools/run_orfs.sh --openroad ~/OpenROAD/build/src/openroad \
 
 # Re-synthesize from RTL in your own ORFS install (its yosys + slang):
 tools/run_orfs.sh --resynth --flow-home ~/OpenROAD-flow-scripts designs/asap7/lfsr
+
+# Stage many designs without running (writes each work dir + a run.sh),
+# then run them later or on another machine — no bazel needed at run time:
+for d in designs/asap7/lfsr designs/asap7/NVDLA/partition_a; do
+    tools/run_orfs.sh --prepare-only "$d"
+done
+OPENROAD_EXE=~/OpenROAD/build/src/openroad .run_orfs/asap7/lfsr/run.sh
 ```
+
+**Grouped designs (NVDLA, bp_processor):** these are *containers* — the top
+directory holds only shared SRAM filegroups, and each runnable design is a
+sub-package. Pass the sub-design path, not the container:
+`designs/asap7/NVDLA/partition_a`, `designs/asap7/bp_processor/bp_uno`, etc.
+(Pass the container and the script lists the available sub-designs.)
+
+**Prepare vs. run (`--prepare-only`):** by default `run_orfs.sh` prepares
+*and* runs. With `--prepare-only` it stops after staging the work dir
+(`config.mk` + the seeded golden netlist) and writes a self-contained
+`run.sh` there — so you can prep a batch of designs in one loop, then run
+each `run.sh` whenever/wherever you like. `run.sh` needs no bazel and lets
+you override `OPENROAD_EXE`, `FLOW_HOME`, or the make targets at run time.
 
 It extracts the design's resolved `config.mk` and runs the standard ORFS
 `Makefile`. There are two synthesis modes:

--- a/tools/bazel_to_config_mk.sh
+++ b/tools/bazel_to_config_mk.sh
@@ -119,6 +119,15 @@ build_file="${pkg}/BUILD.bazel"
     exit 1
 }
 
+# Container packages (NVDLA, bp_processor) hold only shared filegroups; the
+# real hightide_design() calls live in subpackages. List them so the user
+# picks a concrete sub-design instead of getting a cryptic "no name" error.
+list_subdesigns() {
+    find "$1" -mindepth 2 -name BUILD.bazel 2>/dev/null | sort | while read -r bf; do
+        grep -q 'hightide_design\|orfs_flow' "$bf" && dirname "$bf"
+    done
+}
+
 # If no target was supplied, read the name from the hightide_design()
 # (or orfs_flow()) call in BUILD.bazel — first quoted value after `name =`.
 if [ -z "$name" ]; then
@@ -126,10 +135,19 @@ if [ -z "$name" ]; then
         /hightide_design\(|orfs_flow\(/   { in_call = 1 }
         in_call && /name[[:space:]]*=/    { print $2; exit }
     ' "$build_file")
-    [ -n "$name" ] || {
-        echo "ERROR: could not find name = \"...\" in $build_file" >&2
+    if [ -z "$name" ]; then
+        subs=$(list_subdesigns "$pkg")
+        if [ -n "$subs" ]; then
+            {
+                echo "ERROR: $pkg groups sub-designs; it has no design of its own."
+                echo "Pick one:"
+                echo "$subs" | sed 's|^|  tools/bazel_to_config_mk.sh |'
+            } >&2
+        else
+            echo "ERROR: could not find name = \"...\" in $build_file" >&2
+        fi
         exit 1
-    }
+    fi
 fi
 
 # --- Extract config from the per-stage config files (NO flow build) -------

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -41,6 +41,11 @@
 #                    Default: <repo>/.run_orfs/<platform>/<design>.
 #   --config FILE    Use this config.mk instead of extracting one.
 #   --no-build       Don't (re)build in bazel; assume stages + config exist.
+#   --prepare-only   Stage the work dir (config.mk + seeded netlist) and write
+#     (--no-run)     a self-contained run.sh, but do NOT run the flow. Loop it
+#                    over many designs to stage a batch, then run each
+#                    <work-dir>/run.sh later or on another machine (no bazel;
+#                    OPENROAD_EXE / FLOW_HOME / targets overridable at run time).
 #   -h, --help       Print this help and exit.
 #
 # make-target default: "floorplan place cts route finish"
@@ -54,6 +59,11 @@
 #                     designs/asap7/lfsr floorplan place
 #   # Re-synthesize from RTL in your ORFS install (its yosys+slang):
 #   tools/run_orfs.sh --resynth --flow-home ~/OpenROAD-flow-scripts designs/asap7/lfsr
+#   # Stage several designs without running, then run each elsewhere:
+#   for d in designs/asap7/lfsr designs/asap7/NVDLA/partition_a; do
+#     tools/run_orfs.sh --prepare-only "$d"
+#   done
+#   OPENROAD_EXE=~/OpenROAD/build/src/openroad .run_orfs/asap7/lfsr/run.sh
 #
 # QoR comparability: HighTide's published numbers come from the bazel-orfs
 # build. A --resynth run reproduces them only if your ORFS install's yosys /
@@ -104,6 +114,7 @@ work_dir=""
 config=""
 no_build=0
 resynth=0
+prepare_only=0
 positional=()
 
 while [ $# -gt 0 ]; do
@@ -114,6 +125,7 @@ while [ $# -gt 0 ]; do
         --work-dir)  work_dir=$2;  shift 2 ;;
         --config)    config=$2;    shift 2 ;;
         --no-build)  no_build=1;   shift ;;
+        --prepare-only|--no-run) prepare_only=1; shift ;;
         -h|--help)   usage ;;
         --)          shift; while [ $# -gt 0 ]; do positional+=("$1"); shift; done ;;
         -*)          echo "ERROR: unknown option: $1" >&2; usage ;;
@@ -143,12 +155,34 @@ case "$input" in
 esac
 [ -f "$pkg/BUILD.bazel" ] || { echo "ERROR: no $pkg/BUILD.bazel" >&2; exit 1; }
 
+# Some designs are grouped: a container package (NVDLA, bp_processor) holds
+# only shared filegroups, and the real hightide_design() calls live in
+# subpackages (partition_a…partition_p; bp_uno, bp_quad). List those so the
+# user can pick one instead of getting a cryptic "no name" error.
+list_subdesigns() {
+    find "$1" -mindepth 2 -name BUILD.bazel 2>/dev/null | sort | while read -r bf; do
+        grep -q 'hightide_design\|orfs_flow' "$bf" && dirname "$bf"
+    done
+}
+
 # Design target base name (first quoted value after `name =` in the
 # hightide_design()/orfs_flow() call).
 name=$(awk -F'"' '
     /hightide_design\(|orfs_flow\(/ { in_call = 1 }
     in_call && /name[[:space:]]*=/  { print $2; exit }' "$pkg/BUILD.bazel")
-[ -n "$name" ] || { echo "ERROR: could not find name in $pkg/BUILD.bazel" >&2; exit 1; }
+if [ -z "$name" ]; then
+    subs=$(list_subdesigns "$pkg")
+    if [ -n "$subs" ]; then
+        {
+            echo "ERROR: $pkg groups sub-designs; it has no design of its own."
+            echo "Pick one:"
+            echo "$subs" | sed 's|^|  tools/run_orfs.sh |'
+        } >&2
+    else
+        echo "ERROR: could not find name in $pkg/BUILD.bazel" >&2
+    fi
+    exit 1
+fi
 
 # --- Resolve the ORFS flow dir (FLOW_HOME) --------------------------------
 user_flow_home=0
@@ -213,7 +247,11 @@ fi
 # (which has no tools/install). A user-supplied ORFS install uses its own.
 openroad_exe="$openroad"
 opensta_exe=""
-if [ -z "$openroad_exe" ] && [ "$user_flow_home" = 0 ]; then
+# In --prepare-only mode, don't resolve (and thus build/download) the bazel
+# openroad: the whole point is to stage configs to run elsewhere, where the
+# researcher supplies their own binary via OPENROAD_EXE. Skip unless the
+# user explicitly named one with --openroad.
+if [ -z "$openroad_exe" ] && [ "$user_flow_home" = 0 ] && [ "$prepare_only" = 0 ]; then
     require_bazel; require_bazel_orfs
     echo ">> Resolving bazel-built openroad ..." >&2
     bazel build @openroad//:openroad >&2
@@ -259,6 +297,54 @@ if [ "$resynth" = 0 ]; then
 else
     platform=${pkg#designs/}; platform=${platform%%/*}
     design=$(awk -F'?=' '/^export DESIGN_NAME\?=/{print $2; exit}' "$config")
+fi
+
+# --- Prepare-only: write a self-contained run.sh and stop ----------------
+# Everything above (config.mk, seeded netlist, resolved paths) has staged
+# the work dir. Emit a run.sh that re-invokes the standard ORFS Makefile so
+# the design can be run later, or on another machine, with no bazel — while
+# still letting the researcher swap in their own OpenROAD (OPENROAD_EXE),
+# ORFS clone (FLOW_HOME), or targets at run time.
+if [ "$prepare_only" = 1 ]; then
+    run_script="$work_dir/run.sh"
+    def_or=""; [ -n "$openroad_exe" ] && def_or=$(printf '%q' "$openroad_exe")
+    def_sta=""; [ -n "$opensta_exe" ] && def_sta=$(printf '%q' "$opensta_exe")
+    tq=""; for t in "${targets[@]}"; do tq+=" $(printf '%q' "$t")"; done
+    {
+        echo '#!/usr/bin/env bash'
+        echo '# Auto-generated by tools/run_orfs.sh --prepare-only.'
+        echo '# Runs this prepared HighTide design in upstream ORFS — no bazel.'
+        echo '# Override at run time:'
+        echo '#   OPENROAD_EXE=/path/to/openroad ./run.sh   # your own build'
+        echo '#   FLOW_HOME=/path/to/OpenROAD-flow-scripts ./run.sh'
+        echo '#   ./run.sh floorplan place                  # pick targets'
+        echo 'set -euo pipefail'
+        echo 'cd "$(dirname "$0")"'
+        printf 'flow_home=${FLOW_HOME:-%q}\n' "$flow_dir"
+        printf 'openroad_exe=${OPENROAD_EXE:-%s}\n' "${def_or:-\"\"}"
+        printf 'opensta_exe=${OPENSTA_EXE:-%s}\n' "${def_sta:-\"\"}"
+        printf 'default_targets=(%s )\n' "$tq"
+        echo 'if [ "$#" -gt 0 ]; then targets=("$@"); else targets=("${default_targets[@]}"); fi'
+        echo 'exec make -C "$flow_home" \'
+        printf '    DESIGN_CONFIG=%q \\\n' "$config"
+        printf '    WORK_HOME=%q \\\n' "$work_dir"
+        echo '    FLOW_HOME="$flow_home" \'
+        echo '    ${openroad_exe:+OPENROAD_EXE="$openroad_exe"} \'
+        echo '    ${opensta_exe:+OPENSTA_EXE="$opensta_exe"} \'
+        echo '    "${targets[@]}"'
+    } > "$run_script"
+    chmod +x "$run_script"
+
+    mode=$([ "$resynth" = 1 ] && echo "from RTL (incl. synthesis)" || echo "reuse synth (floorplan onward)")
+    cat >&2 <<EOF
+>> Prepared (not run) — $platform / ${design:-$name}
+   mode       : $mode
+   work_home  : $work_dir
+   config.mk  : $config
+   run it     : $run_script ${targets[*]}
+   custom OR  : OPENROAD_EXE=/path/to/openroad $run_script
+EOF
+    exit 0
 fi
 
 # --- Run upstream ORFS ----------------------------------------------------

--- a/tools/run_orfs.sh
+++ b/tools/run_orfs.sh
@@ -25,7 +25,16 @@
 #       (one whose tools/install has yosys; ORFS's slang support is built in).
 #
 # Usage:
-#   tools/run_orfs.sh [options] <design-dir-or-label> [make-target...]
+#   tools/run_orfs.sh [options] <target> [make-target...]
+#
+# <target> is one design, or a bazel-style pattern for many:
+#   designs/asap7/lfsr          one design
+#   designs/asap7/NVDLA         a container -> all its sub-designs
+#   //designs/asap7/...         all asap7 designs (recursive wildcard)
+#   //designs/...  |  all       every design, every platform
+#   asap7 | nangate45 | sky130hd  all designs on that platform
+# With a multi-design target the flow runs once per design (continues past
+# failures, prints a summary); combine with --prepare-only to stage a batch.
 #
 # Options:
 #   --resynth        Run synthesis from RTL in your ORFS install (default:
@@ -59,11 +68,11 @@
 #                     designs/asap7/lfsr floorplan place
 #   # Re-synthesize from RTL in your ORFS install (its yosys+slang):
 #   tools/run_orfs.sh --resynth --flow-home ~/OpenROAD-flow-scripts designs/asap7/lfsr
-#   # Stage several designs without running, then run each elsewhere:
-#   for d in designs/asap7/lfsr designs/asap7/NVDLA/partition_a; do
-#     tools/run_orfs.sh --prepare-only "$d"
-#   done
+#   # Stage every asap7 design without running, then run one elsewhere:
+#   tools/run_orfs.sh --prepare-only //designs/asap7/...
 #   OPENROAD_EXE=~/OpenROAD/build/src/openroad .run_orfs/asap7/lfsr/run.sh
+#   # Prepare all NVDLA partitions:
+#   tools/run_orfs.sh --prepare-only //designs/asap7/NVDLA/...
 #
 # QoR comparability: HighTide's published numbers come from the bazel-orfs
 # build. A --resynth run reproduces them only if your ORFS install's yosys /
@@ -116,16 +125,17 @@ no_build=0
 resynth=0
 prepare_only=0
 positional=()
+flags=()   # design-independent flags, replayed to per-design child invocations
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        --resynth)   resynth=1;    shift ;;
-        --flow-home) flow_home=$2; shift 2 ;;
-        --openroad)  openroad=$2;  shift 2 ;;
-        --work-dir)  work_dir=$2;  shift 2 ;;
-        --config)    config=$2;    shift 2 ;;
-        --no-build)  no_build=1;   shift ;;
-        --prepare-only|--no-run) prepare_only=1; shift ;;
+        --resynth)   resynth=1;    flags+=("$1");      shift ;;
+        --flow-home) flow_home=$2; flags+=("$1" "$2"); shift 2 ;;
+        --openroad)  openroad=$2;  flags+=("$1" "$2"); shift 2 ;;
+        --work-dir)  work_dir=$2;  shift 2 ;;   # per-design; not replayed
+        --config)    config=$2;    shift 2 ;;   # per-design; not replayed
+        --no-build)  no_build=1;   flags+=("$1");      shift ;;
+        --prepare-only|--no-run) prepare_only=1; flags+=("$1"); shift ;;
         -h|--help)   usage ;;
         --)          shift; while [ $# -gt 0 ]; do positional+=("$1"); shift; done ;;
         -*)          echo "ERROR: unknown option: $1" >&2; usage ;;
@@ -147,23 +157,77 @@ fi
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
-# --- Normalize the design input to a bazel package (designs/<plat>/<d>) ---
-case "$input" in
-    //*:*) pkg=${input#//}; pkg=${pkg%:*} ;;
-    //*)   pkg=${input#//} ;;
-    *)     pkg=${input%/} ;;
-esac
-[ -f "$pkg/BUILD.bazel" ] || { echo "ERROR: no $pkg/BUILD.bazel" >&2; exit 1; }
-
-# Some designs are grouped: a container package (NVDLA, bp_processor) holds
-# only shared filegroups, and the real hightide_design() calls live in
-# subpackages (partition_a…partition_p; bp_uno, bp_quad). List those so the
-# user can pick one instead of getting a cryptic "no name" error.
-list_subdesigns() {
-    find "$1" -mindepth 2 -name BUILD.bazel 2>/dev/null | sort | while read -r bf; do
+# Every runnable design is a leaf package whose BUILD.bazel calls
+# hightide_design()/orfs_flow(). Container packages (NVDLA, bp_processor) and
+# platform dirs (designs/asap7) don't — they just hold subpackages.
+enumerate_designs() {   # <dir> -> prints each design package under it
+    find "$1" -name BUILD.bazel 2>/dev/null | sort | while read -r bf; do
         grep -q 'hightide_design\|orfs_flow' "$bf" && dirname "$bf"
     done
 }
+
+# --- Expand the input into a design list ----------------------------------
+# Bazel-style recursive wildcard is the primary syntax:
+#   //designs/...            all designs, every platform
+#   designs/asap7/...        all asap7 designs
+#   //designs/asap7/NVDLA/...  every NVDLA partition
+# Also accepted: the "all" alias and a bare platform (asap7|nangate45|
+# sky130hd); a bare container/platform dir (designs/asap7/NVDLA) expands to
+# its sub-designs; anything else is a single design package/label.
+design_list=()
+sel=${input#//}                 # tolerate the leading // of a bazel label
+case "$sel" in
+    all|ALL|designs|designs/) root="designs" ;;
+    asap7|nangate45|sky130hd) root="designs/$sel" ;;
+    *...) root=${sel%...}; root=${root%/}; [ -n "$root" ] || root="designs" ;;
+    *)    root="" ;;
+esac
+
+if [ -n "$root" ]; then
+    [ -d "$root" ] || { echo "ERROR: no such directory: $root" >&2; exit 1; }
+    mapfile -t design_list < <(enumerate_designs "$root")
+else
+    p=${sel%:*}; p=${p%/}       # drop any :target and trailing slash
+    if [ -f "$p/BUILD.bazel" ] && grep -q 'hightide_design\|orfs_flow' "$p/BUILD.bazel"; then
+        design_list=("$p")                              # a single design
+    elif [ -d "$p" ]; then
+        mapfile -t design_list < <(enumerate_designs "$p")  # container/platform dir
+    fi
+fi
+
+if [ "${#design_list[@]}" -eq 0 ]; then
+    echo "ERROR: no HighTide designs match '$input'." >&2
+    echo "       Give a design dir (designs/asap7/lfsr), a container" >&2
+    echo "       (designs/asap7/NVDLA), a platform (asap7|nangate45|sky130hd)," >&2
+    echo "       or 'all'." >&2
+    exit 1
+fi
+
+# --- Batch: >1 design → run each in its own child invocation --------------
+# Replays the design-independent flags + targets to a fresh run_orfs.sh per
+# design (keeps all the single-design logic in one place). Continues past a
+# failure and reports a summary. Per-design --work-dir/--config make no sense
+# across a batch.
+if [ "${#design_list[@]}" -gt 1 ]; then
+    [ -z "$config" ]   || { echo "ERROR: --config can't be used with multiple designs." >&2; exit 1; }
+    [ -z "$work_dir" ] || { echo "ERROR: --work-dir can't be used with multiple designs." >&2; exit 1; }
+    echo ">> ${#design_list[@]} designs matched:" >&2
+    printf '   %s\n' "${design_list[@]}" >&2
+    failed=()
+    for d in "${design_list[@]}"; do
+        printf '\n======== %s ========\n' "$d" >&2
+        "$0" "${flags[@]}" "$d" "${targets[@]}" || failed+=("$d")
+    done
+    if [ "${#failed[@]}" -gt 0 ]; then
+        printf '\nFAILED (%d/%d):\n' "${#failed[@]}" "${#design_list[@]}" >&2
+        printf '   %s\n' "${failed[@]}" >&2
+        exit 1
+    fi
+    printf '\n>> all %d designs OK\n' "${#design_list[@]}" >&2
+    exit 0
+fi
+
+pkg=${design_list[0]}
 
 # Design target base name (first quoted value after `name =` in the
 # hightide_design()/orfs_flow() call).
@@ -171,16 +235,7 @@ name=$(awk -F'"' '
     /hightide_design\(|orfs_flow\(/ { in_call = 1 }
     in_call && /name[[:space:]]*=/  { print $2; exit }' "$pkg/BUILD.bazel")
 if [ -z "$name" ]; then
-    subs=$(list_subdesigns "$pkg")
-    if [ -n "$subs" ]; then
-        {
-            echo "ERROR: $pkg groups sub-designs; it has no design of its own."
-            echo "Pick one:"
-            echo "$subs" | sed 's|^|  tools/run_orfs.sh |'
-        } >&2
-    else
-        echo "ERROR: could not find name in $pkg/BUILD.bazel" >&2
-    fi
+    echo "ERROR: could not find name in $pkg/BUILD.bazel" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Improvements to the plain-ORFS bridge (`tools/run_orfs.sh`, `tools/bazel_to_config_mk.sh`) for OpenROAD researchers running HighTide designs in upstream ORFS.

## What's new

**1. Grouped/container designs (NVDLA, bp_processor).** The top package holds only shared SRAM filegroups; the runnable `hightide_design()` calls live in sub-packages (`partition_a`…`partition_p`; `bp_uno`, `bp_quad`). Passing the container path used to die with a cryptic "could not find name". Both scripts now detect a container and either list the sub-designs (config extractor) or expand to them (runner).

**2. `--prepare-only` (alias `--no-run`).** Stages the work dir (`config.mk` + seeded golden netlist) and writes a self-contained `run.sh`, then stops — no `make`. Run each `run.sh` later or on another machine with no bazel; `OPENROAD_EXE` / `FLOW_HOME` / make targets are overridable at run time. The slow bazel OpenROAD resolve is skipped in this mode (you supply your own binary).

**3. Batch over many designs with a Bazel-style pattern.**

| Pattern | Matches |
|---|---|
| `designs/asap7/lfsr` | one design |
| `//designs/asap7/...` | all asap7 designs |
| `//designs/asap7/NVDLA/...` | every NVDLA partition |
| `//designs/...` or `all` | every design, every platform |
| `asap7` \| `nangate45` \| `sky130hd` | all designs on that platform |
| `designs/asap7/NVDLA` | a container → its sub-designs |

Enumeration is filesystem-only (leaf `BUILD.bazel` with a design call), so it needs no bazel. Each match runs in its own child invocation with flags + make targets replayed; the batch continues past failures and prints a summary. Pairs naturally with `--prepare-only` to stage a whole platform in one command.

## Verification
- Container error/expansion lists the right sub-designs for NVDLA and bp_processor.
- Input→pattern mapping checked for every form (recursive `...`, `all`, platform, single, container, bogus).
- Batch loop exercised end-to-end: non-design packages excluded, all designs dispatched, a failing one didn't abort the rest, correct `FAILED (n/N)` summary.
- `--prepare-only` staged the work dir and generated `run.sh`; the generated `run.sh` drove floorplan to completion reusing the seeded netlist with a swapped-in `OPENROAD_EXE` (no yosys).

Docs updated in `README.md`; the companion webpage change is on the `webpage` branch.