### PR TITLE
fix(run_orfs): resolve hermetic http_archive RTL paths to the output base

### DIFF
--- a/tools/bazel_to_config_mk.sh
+++ b/tools/bazel_to_config_mk.sh
@@ -170,6 +170,16 @@ bazel build "${targets[@]}" --output_groups="$config_groups" >&2
 verilog_files=$(bazel cquery --output=files \
     "labels(verilog_files, //${pkg}:${name}_synth)" 2>/dev/null | tr '\n' ' ')
 
+# Bazel output base: hermetic designs source RTL from http_archives, whose
+# files live at $output_base/external/+_repo_rules+<repo>/... — NOT under the
+# repo root (there is no repo-root external/ symlink). This location is always
+# present once the repo is fetched, unlike execroot/external/, which Bazel only
+# materializes per-action and prunes on cache hits. --abs routes external/
+# tokens here; bazel-out/ genrule outputs resolve via the repo-root bazel-out
+# convenience symlink, and repo-relative source tokens (SDC/LEF/...) via the
+# repo root.
+output_base=$(bazel info output_base 2>/dev/null)
+
 # --- Locate the result dir + collect the per-stage config .mk files -------
 results_root="bazel-bin/${pkg}/results"
 [ -d "$results_root" ] || {
@@ -211,7 +221,7 @@ EOF
         grep -h '^export ' "${mks[@]}"
         [ -n "$verilog_files" ] && printf 'export VERILOG_FILES?=%s\n' "${verilog_files% }"
     } \
-        | awk -v skip="$SKIP_VARS" -v abs="$abs" -v root="$repo_root" '
+        | awk -v skip="$SKIP_VARS" -v abs="$abs" -v root="$repo_root" -v outbase="$output_base" '
             # Vars whose value is one or more file/dir paths.
             function is_pathvar(k) {
                 return (k ~ /^(VERILOG_FILES|SDC_FILE|ADDITIONAL_LEFS|ADDITIONAL_LIBS|ADDITIONAL_GDS|IO_CONSTRAINTS|FOOTPRINT_TCL|MACRO_PLACEMENT_TCL|VERILOG_INCLUDE_DIRS|PDN_TCL)$/) || (k ~ /_TCL$/)
@@ -235,9 +245,17 @@ EOF
                         t = toks[i]
                         if (t == "") continue
                         # Absolutize relative paths; leave abs paths and
-                        # make/flag tokens (-, $) untouched.
-                        if (t !~ /^\// && t !~ /^-/ && t !~ /^\$/)
-                            t = root "/" t
+                        # make/flag tokens (-, $) untouched.  external/ tokens
+                        # (hermetic http_archive RTL + include dirs) live under
+                        # the output base; everything else — repo source and
+                        # bazel-out/ genrule outputs (via the repo-root
+                        # bazel-out symlink) — under the repo root.
+                        if (t !~ /^\// && t !~ /^-/ && t !~ /^\$/) {
+                            if ((t ~ /^external\//) && outbase != "")
+                                t = outbase "/" t
+                            else
+                                t = root "/" t
+                        }
                         out = (out == "" ? t : out " " t)
                     }
                     val = out


### PR DESCRIPTION
`tools/bazel_to_config_mk.sh --abs` prefixed every relative path token with the repo root. That's correct for repo-relative source vars (SDC_FILE, ADDITIONAL_LEFS/LIBS) and bazel-out/ genrule outputs (repo-root has a `bazel-out` symlink), but the newly-hermetic designs source RTL from http_archives whose files live at `$output_base/external/+_repo_rules+<repo>/...` — and the repo root has **no** `external/` symlink. So `VERILOG_FILES`/`VERILOG_INCLUDE_DIRS` pointed at `$repo_root/external/...` (nonexistent), and upstream ORFS Make died with `No rule to make target .../external/+_repo_rules+<repo>/....sv` — breaking both `run_orfs.sh` reuse-synth mode and `--resynth`.

**Fix:** route `external/` tokens to `bazel info output_base` (where repo rules extract archives — always present once fetched, unlike `execroot/external/` which Bazel materializes per-action and prunes on cache hits; a reuse run is a cache hit). `bazel-out/` and repo-relative tokens are unchanged, so non-hermetic designs are unaffected.

**Verified:** `tools/run_orfs.sh designs/asap7/lfsr floorplan` now reuses the bazel-synthesized netlist and completes floorplan in upstream ORFS against the hermetic RTL (previously errored at Make prerequisite resolution).